### PR TITLE
feat: expose reading residual posture

### DIFF
--- a/crates/echo-wasm-abi/src/kernel_port.rs
+++ b/crates/echo-wasm-abi/src/kernel_port.rs
@@ -10,7 +10,7 @@
 //!
 //! # ABI Version
 //!
-//! The current ABI version is [`ABI_VERSION`] (7). All response types are
+//! The current ABI version is [`ABI_VERSION`] (8). All response types are
 //! CBOR-encoded using the canonical rules defined in `docs/spec/js-cbor-mapping.md`.
 //! Breaking changes to response shapes or error codes require a bump to the
 //! ABI version.
@@ -38,7 +38,7 @@ use serde::{
 ///
 /// Increment when response types, error codes, or method signatures change
 /// in a backward-incompatible way.
-pub const ABI_VERSION: u32 = 7;
+pub const ABI_VERSION: u32 = 8;
 
 fn deserialize_opaque_id<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
 where
@@ -656,8 +656,14 @@ pub enum ReadingRightsPosture {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadingResidualPosture {
-    /// The built-in observer emitted a complete reading for the requested projection.
+    /// The observer emitted a clean, complete reading for the requested projection.
     Complete,
+    /// The observer emitted a bounded reading with explicit residual outside the payload.
+    Residual,
+    /// The observer preserved lawful plurality instead of collapsing to one reading.
+    PluralityPreserved,
+    /// The observer surfaced a lawful obstruction instead of a derived reading.
+    Obstructed,
 }
 
 /// Reading-envelope metadata carried by every observation artifact.

--- a/crates/echo-wasm-abi/src/lib.rs
+++ b/crates/echo-wasm-abi/src/lib.rs
@@ -609,6 +609,32 @@ mod tests {
     }
 
     #[test]
+    fn test_reading_residual_posture_wire_names_are_distinct() {
+        use crate::kernel_port::ReadingResidualPosture;
+        use ciborium::value::Value;
+
+        let cases = [
+            (ReadingResidualPosture::Complete, "complete"),
+            (ReadingResidualPosture::Residual, "residual"),
+            (
+                ReadingResidualPosture::PluralityPreserved,
+                "plurality_preserved",
+            ),
+            (ReadingResidualPosture::Obstructed, "obstructed"),
+        ];
+
+        for (posture, expected_text) in cases {
+            let bytes = encode_cbor(&posture).unwrap();
+            assert_eq!(
+                decode_value(&bytes).unwrap(),
+                Value::Text(expected_text.into())
+            );
+            let decoded: ReadingResidualPosture = decode_cbor(&bytes).unwrap();
+            assert_eq!(decoded, posture);
+        }
+    }
+
+    #[test]
     fn test_unpack_control_intent_rejects_wrong_op_id() {
         use crate::kernel_port::{ControlIntentV1, SchedulerMode};
 

--- a/crates/warp-core/src/observation.rs
+++ b/crates/warp-core/src/observation.rs
@@ -438,14 +438,23 @@ impl ReadingRightsPosture {
 /// Residual posture for a reading artifact.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReadingResidualPosture {
-    /// The built-in observer emitted a complete reading for the requested projection.
+    /// The observer emitted a clean, complete reading for the requested projection.
     Complete,
+    /// The observer emitted a bounded reading with explicit residual outside the payload.
+    Residual,
+    /// The observer preserved lawful plurality instead of collapsing to one reading.
+    PluralityPreserved,
+    /// The observer surfaced a lawful obstruction instead of a derived reading.
+    Obstructed,
 }
 
 impl ReadingResidualPosture {
     fn to_abi(self) -> abi::ReadingResidualPosture {
         match self {
             Self::Complete => abi::ReadingResidualPosture::Complete,
+            Self::Residual => abi::ReadingResidualPosture::Residual,
+            Self::PluralityPreserved => abi::ReadingResidualPosture::PluralityPreserved,
+            Self::Obstructed => abi::ReadingResidualPosture::Obstructed,
         }
     }
 }
@@ -1714,6 +1723,36 @@ mod tests {
             artifact.to_abi().reading.parent_basis_posture,
             abi::ObservationBasisPosture::Worldline
         );
+        assert_eq!(
+            artifact.to_abi().reading.residual_posture,
+            abi::ReadingResidualPosture::Complete
+        );
+    }
+
+    #[test]
+    fn reading_residual_postures_convert_to_abi() {
+        let cases = [
+            (
+                ReadingResidualPosture::Complete,
+                abi::ReadingResidualPosture::Complete,
+            ),
+            (
+                ReadingResidualPosture::Residual,
+                abi::ReadingResidualPosture::Residual,
+            ),
+            (
+                ReadingResidualPosture::PluralityPreserved,
+                abi::ReadingResidualPosture::PluralityPreserved,
+            ),
+            (
+                ReadingResidualPosture::Obstructed,
+                abi::ReadingResidualPosture::Obstructed,
+            ),
+        ];
+
+        for (posture, expected) in cases {
+            assert_eq!(posture.to_abi(), expected);
+        }
     }
 
     #[test]

--- a/crates/warp-wasm/src/warp_kernel.rs
+++ b/crates/warp-wasm/src/warp_kernel.rs
@@ -628,12 +628,16 @@ mod tests {
     use super::*;
     use echo_wasm_abi::{
         kernel_port::{
-            ControlIntentV1, GlobalTick as AbiGlobalTick, HeadEligibility as AbiHeadEligibility,
+            BuiltinObserverPlan as AbiBuiltinObserverPlan, ControlIntentV1,
+            GlobalTick as AbiGlobalTick, HeadEligibility as AbiHeadEligibility,
             HeadId as AbiHeadId, ObservationAt as AbiObservationAt,
+            ObservationBasisPosture as AbiObservationBasisPosture,
             ObservationCoordinate as AbiObservationCoordinate,
             ObservationFrame as AbiObservationFrame, ObservationPayload as AbiObservationPayload,
             ObservationProjection as AbiObservationProjection,
-            ObservationRequest as AbiObservationRequest, RunCompletion, SchedulerMode,
+            ObservationRequest as AbiObservationRequest,
+            ReadingObserverPlan as AbiReadingObserverPlan,
+            ReadingResidualPosture as AbiReadingResidualPosture, RunCompletion, SchedulerMode,
             SchedulerState, SettlementDecision as AbiSettlementDecision,
             SettlementOverlapRevalidation as AbiSettlementOverlapRevalidation,
             SettlementParentRevalidation as AbiSettlementParentRevalidation,
@@ -1275,6 +1279,21 @@ mod tests {
             })
             .unwrap();
         let head = kernel.current_head().unwrap();
+
+        assert_eq!(
+            artifact.reading.observer_plan,
+            AbiReadingObserverPlan::Builtin {
+                plan: AbiBuiltinObserverPlan::CommitBoundaryHead,
+            }
+        );
+        assert_eq!(
+            artifact.reading.parent_basis_posture,
+            AbiObservationBasisPosture::Worldline
+        );
+        assert_eq!(
+            artifact.reading.residual_posture,
+            AbiReadingResidualPosture::Complete
+        );
 
         let AbiObservationPayload::Head { head: observed } = artifact.payload else {
             panic!("expected head observation payload");

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -32,7 +32,7 @@ The runtime-doctrine cutover is no longer just design text:
   `SettlementService`.
 - `crates/warp-wasm/src/warp_kernel.rs` exposes neighborhood and settlement
   surfaces through the WASM kernel boundary.
-- `crates/echo-wasm-abi/src/kernel_port.rs` is currently ABI version 6 and
+- `crates/echo-wasm-abi/src/kernel_port.rs` is currently ABI version 8 and
   carries `ReadingEnvelope` inside observation artifacts.
 - `docs/spec/SPEC-0009-wasm-abi.md` now documents the current ABI contract
   instead of pretending to preserve ABI v1-v5.

--- a/docs/spec/SPEC-0004-worldlines-playback-truthbus.md
+++ b/docs/spec/SPEC-0004-worldlines-playback-truthbus.md
@@ -44,6 +44,8 @@ A playback cursor materializes a worldline at a coordinate without mutating the 
 
 Public reads are expressed through observation artifacts: coordinate resolution, reading-envelope metadata, declared frame, declared projection, artifact hash, and payload. Observation is a reading emitted from an observer basis, not raw access to the causal carrier.
 
+The reading envelope is part of the contract, not decoration: it carries the observer plan, native basis, witness refs, parent/basis posture, budget posture, rights posture, and residual posture that bound the emitted reading.
+
 ## Decision 4: Session output is replace-only
 
 Client-facing frames are authoritative values for a coordinate and channel. A client replaces rendered state from the received reading; it does not infer rollback, replay, or hidden diffs.

--- a/docs/spec/SPEC-0009-wasm-abi.md
+++ b/docs/spec/SPEC-0009-wasm-abi.md
@@ -7,7 +7,7 @@ _Define the current deterministic browser boundary for intent ingress, scheduler
 
 Legend: PLATFORM
 
-Current ABI version: 6
+Current ABI version: 8
 
 Depends on:
 
@@ -19,7 +19,7 @@ Depends on:
 
 The WASM boundary is where browser and host code meet the Echo runtime. It must be small, deterministic, and explicit about what kind of operation is crossing: intent admission, scheduler inspection, or observation.
 
-ABI version 6 keeps the current export shape and carries reading-envelope metadata for observation artifacts.
+ABI version 8 keeps the current export shape and carries richer reading-envelope metadata for observation artifacts.
 
 ## Human users / jobs / hills
 
@@ -46,6 +46,8 @@ Removed exports stay removed: `step`, `snapshot_at`, `render_snapshot`, `execute
 ## Decision 3: Observation is the only public world-state read
 
 `observe(request)` returns an observation artifact with resolved coordinate, reading envelope, declared frame, declared projection, artifact hash, and payload.
+
+The reading envelope names the observer plan, native observer basis, witness refs, parent/basis posture, budget posture, rights posture, and residual posture. Built-in observations currently emit `complete` residual posture for clean derived readings. The ABI also names `residual`, `plurality_preserved`, and `obstructed` so external consumers can recognize bounded non-clean readings without treating the payload as a generic state read.
 
 ## Decision 4: The ABI uses logical clocks only
 


### PR DESCRIPTION
## Summary
Exposes richer reading residual posture through the WASM ABI and observation artifact path.

This adds explicit ABI-shaped residual posture variants:
- `complete`
- `residual`
- `plurality_preserved`
- `obstructed`

It also bumps the ABI epoch to 8 because ABI v7 was already published before these additional serialized variants were added.

## What changed
- Expands `ReadingResidualPosture` in `echo-wasm-abi`
- Adds CBOR wire-name round-trip coverage for all residual posture variants
- Wires internal `warp-core` observation residual posture through ABI conversion
- Strengthens `warp-wasm` observation artifact assertions for:
  - observer plan metadata
  - parent basis posture
  - residual posture
- Updates ABI/read-side docs to ABI v8

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p echo-wasm-abi --lib`
- `cargo test -p warp-core --lib observation`
- `cargo test -p warp-wasm --lib --features engine`
- `cargo clippy -p warp-core --all-targets -- -D warnings -D missing_docs`
- `pnpm docs:build`

Push hook also passed the repository full local critical gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new observation reading residual posture variants, enabling more granular distinction between different bounded outcome states.

* **Documentation**
  * Bumped ABI wire-level contract to version 8.
  * Expanded reading envelope specification with explicit enumeration of components and new residual posture semantics.
  * Documented additional posture labels to help external consumers better distinguish outcome types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->