### PR TITLE
feat: add witnessed suffix admission shell skeleton

### DIFF
--- a/crates/echo-wasm-abi/src/kernel_port.rs
+++ b/crates/echo-wasm-abi/src/kernel_port.rs
@@ -1061,6 +1061,103 @@ pub struct SettlementResult {
     pub appended_conflicts: Vec<ProvenanceRef>,
 }
 
+/// Compact shell for judging a witnessed suffix without transport or sync.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WitnessedSuffixShell {
+    /// Worldline carrying the proposed suffix.
+    pub source_worldline_id: WorldlineId,
+    /// First source tick included in the proposed suffix.
+    pub source_suffix_start_tick: WorldlineTick,
+    /// Last source tick included in the proposed suffix, if any.
+    pub source_suffix_end_tick: Option<WorldlineTick>,
+    /// Ordered source provenance coordinates covered by the shell.
+    pub source_entries: Vec<ProvenanceRef>,
+    /// Boundary witness used when the shell has no importable entries yet.
+    pub boundary_witness: Option<ProvenanceRef>,
+    /// Deterministic digest identifying the compact shell evidence.
+    pub witness_digest: Vec<u8>,
+    /// Optional basis-relative settlement evidence reused by the shell.
+    pub basis_report: Option<SettlementBasisReport>,
+}
+
+/// Request to judge a witnessed suffix against a target basis.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WitnessedSuffixAdmissionRequest {
+    /// Source suffix and compact witness material.
+    pub source_suffix: WitnessedSuffixShell,
+    /// Worldline receiving the proposed admission.
+    pub target_worldline_id: WorldlineId,
+    /// Target basis used while judging admission.
+    pub target_basis: ProvenanceRef,
+    /// Optional target-basis evidence for strand/parent realization cases.
+    pub basis_report: Option<SettlementBasisReport>,
+}
+
+/// Response to one witnessed suffix admission request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WitnessedSuffixAdmissionResponse {
+    /// Deterministic digest of the source shell being judged.
+    pub source_shell_digest: Vec<u8>,
+    /// Resolved target basis used for the response.
+    pub target_basis: ProvenanceRef,
+    /// Exactly one top-level admission outcome.
+    pub outcome: WitnessedSuffixAdmissionOutcome,
+}
+
+/// Top-level witnessed suffix admission posture.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum WitnessedSuffixAdmissionOutcome {
+    /// The suffix is admissible on the named target basis.
+    Admitted {
+        /// Target worldline receiving the admissible suffix.
+        target_worldline_id: WorldlineId,
+        /// Target-local provenance coordinates produced or expected by admission.
+        admitted_refs: Vec<ProvenanceRef>,
+        /// Basis evidence used to classify the suffix as admitted.
+        basis_report: Option<SettlementBasisReport>,
+    },
+    /// The suffix is well-formed but retained for later judgment.
+    Staged {
+        /// Source or target coordinates retained while staged.
+        staged_refs: Vec<ProvenanceRef>,
+        /// Basis evidence used to classify the suffix as staged.
+        basis_report: Option<SettlementBasisReport>,
+    },
+    /// The suffix preserves lawful plurality instead of one admitted result.
+    Plural {
+        /// Candidate coordinates that remain lawful plural outcomes.
+        candidate_refs: Vec<ProvenanceRef>,
+        /// Read-side residual posture associated with preserved plurality.
+        residual_posture: ReadingResidualPosture,
+        /// Basis evidence used to classify the suffix as plural.
+        basis_report: Option<SettlementBasisReport>,
+    },
+    /// The suffix conflicts with the target basis under current admission law.
+    Conflict {
+        /// Deterministic reason the suffix conflicts.
+        reason: ConflictReason,
+        /// Source coordinate implicated in the conflict.
+        source_ref: ProvenanceRef,
+        /// Deterministic digest of compact conflict evidence.
+        evidence_digest: Vec<u8>,
+        /// Optional overlap revalidation evidence when footprint overlap caused the conflict.
+        overlap_revalidation: Option<SettlementOverlapRevalidation>,
+    },
+    /// The suffix cannot currently be judged or admitted.
+    Obstructed {
+        /// Source coordinate implicated in the obstruction.
+        source_ref: ProvenanceRef,
+        /// Read-side residual posture associated with the obstruction.
+        residual_posture: ReadingResidualPosture,
+        /// Deterministic digest of compact obstruction evidence.
+        evidence_digest: Vec<u8>,
+    },
+}
+
 /// Registry and handshake metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegistryInfo {

--- a/crates/echo-wasm-abi/src/lib.rs
+++ b/crates/echo-wasm-abi/src/lib.rs
@@ -38,6 +38,9 @@ pub use eintlog::*;
 
 pub mod kernel_port;
 
+#[cfg(test)]
+mod witnessed_suffix_tests;
+
 pub mod ttd;
 pub use ttd::*;
 

--- a/crates/echo-wasm-abi/src/witnessed_suffix_tests.rs
+++ b/crates/echo-wasm-abi/src/witnessed_suffix_tests.rs
@@ -248,10 +248,10 @@ fn witnessed_suffix_response_rejects_zero_outcomes() -> Result<(), serde_json::E
 #[test]
 fn witnessed_suffix_response_rejects_multiple_outcomes() -> Result<(), serde_json::Error> {
     let mut value = serde_json::to_value(response(admitted_outcome()))?;
-    if let Value::Object(fields) = &mut value {
-        if let Some(outcome) = fields.remove("outcome") {
-            fields.insert("outcomes".to_string(), json!([outcome.clone(), outcome]));
-        }
+    if let Value::Object(fields) = &mut value
+        && let Some(outcome) = fields.remove("outcome")
+    {
+        fields.insert("outcomes".to_string(), json!([outcome.clone(), outcome]));
     }
 
     assert!(serde_json::from_value::<WitnessedSuffixAdmissionResponse>(value).is_err());

--- a/crates/echo-wasm-abi/src/witnessed_suffix_tests.rs
+++ b/crates/echo-wasm-abi/src/witnessed_suffix_tests.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+
+use alloc::{string::ToString, vec, vec::Vec};
+
+use serde_json::{Value, json};
+
+use crate::{
+    decode_cbor, encode_cbor,
+    kernel_port::{
+        BaseRef, ConflictReason, ProvenanceRef, ReadingResidualPosture, SettlementBasisReport,
+        SettlementOverlapRevalidation, SettlementParentRevalidation,
+        WitnessedSuffixAdmissionOutcome, WitnessedSuffixAdmissionRequest,
+        WitnessedSuffixAdmissionResponse, WitnessedSuffixShell, WorldlineId, WorldlineTick,
+    },
+};
+
+fn worldline(seed: u8) -> WorldlineId {
+    WorldlineId::from_bytes([seed; 32])
+}
+
+fn tick(value: u64) -> WorldlineTick {
+    WorldlineTick(value)
+}
+
+fn provenance_ref(seed: u8, worldline_tick: u64) -> ProvenanceRef {
+    ProvenanceRef {
+        worldline_id: worldline(seed),
+        worldline_tick: tick(worldline_tick),
+        commit_hash: vec![seed.wrapping_add(1); 32],
+    }
+}
+
+fn base_ref(seed: u8) -> BaseRef {
+    BaseRef {
+        source_worldline_id: worldline(seed),
+        fork_tick: tick(1),
+        commit_hash: vec![seed.wrapping_add(2); 32],
+        boundary_hash: vec![seed.wrapping_add(3); 32],
+        provenance_ref: provenance_ref(seed.wrapping_add(4), 1),
+    }
+}
+
+fn basis_report() -> SettlementBasisReport {
+    SettlementBasisReport {
+        parent_anchor: base_ref(20),
+        child_worldline_id: worldline(21),
+        source_suffix_start_tick: tick(2),
+        source_suffix_end_tick: Some(tick(5)),
+        realized_parent_ref: provenance_ref(22, 9),
+        owned_closed_slot_count: 3,
+        parent_written_slot_count: 1,
+        parent_revalidation: SettlementParentRevalidation::ParentAdvancedDisjoint {
+            parent_from: provenance_ref(23, 1),
+            parent_to: provenance_ref(24, 9),
+        },
+    }
+}
+
+fn shell_with_entries(entries: Vec<ProvenanceRef>) -> WitnessedSuffixShell {
+    WitnessedSuffixShell {
+        source_worldline_id: worldline(3),
+        source_suffix_start_tick: tick(2),
+        source_suffix_end_tick: Some(tick(4)),
+        source_entries: entries,
+        boundary_witness: Some(provenance_ref(5, 1)),
+        witness_digest: vec![6; 32],
+        basis_report: Some(basis_report()),
+    }
+}
+
+fn request() -> WitnessedSuffixAdmissionRequest {
+    WitnessedSuffixAdmissionRequest {
+        source_suffix: shell_with_entries(vec![provenance_ref(4, 3)]),
+        target_worldline_id: worldline(11),
+        target_basis: provenance_ref(12, 9),
+        basis_report: Some(basis_report()),
+    }
+}
+
+fn response(outcome: WitnessedSuffixAdmissionOutcome) -> WitnessedSuffixAdmissionResponse {
+    WitnessedSuffixAdmissionResponse {
+        source_shell_digest: vec![6; 32],
+        target_basis: provenance_ref(12, 9),
+        outcome,
+    }
+}
+
+fn overlap_revalidation() -> SettlementOverlapRevalidation {
+    SettlementOverlapRevalidation::Conflict {
+        overlapping_slot_count: 2,
+        overlapping_slots_digest: vec![31; 32],
+    }
+}
+
+fn assert_response_round_trip(
+    outcome: WitnessedSuffixAdmissionOutcome,
+) -> Result<(), crate::CanonError> {
+    let original = response(outcome);
+    let bytes = encode_cbor(&original)?;
+    let decoded: WitnessedSuffixAdmissionResponse = decode_cbor(&bytes)?;
+
+    assert_eq!(decoded, original);
+    Ok(())
+}
+
+fn request_json() -> Result<Value, serde_json::Error> {
+    serde_json::to_value(request())
+}
+
+fn admitted_outcome() -> WitnessedSuffixAdmissionOutcome {
+    WitnessedSuffixAdmissionOutcome::Admitted {
+        target_worldline_id: worldline(11),
+        admitted_refs: vec![provenance_ref(30, 10)],
+        basis_report: Some(basis_report()),
+    }
+}
+
+#[test]
+fn witnessed_suffix_request_round_trips_with_source_and_target_refs()
+-> Result<(), crate::CanonError> {
+    let original = request();
+    let bytes = encode_cbor(&original)?;
+    let decoded: WitnessedSuffixAdmissionRequest = decode_cbor(&bytes)?;
+
+    assert_eq!(decoded, original);
+    assert_eq!(
+        decoded.source_suffix.source_entries,
+        vec![provenance_ref(4, 3)]
+    );
+    assert_eq!(decoded.target_basis, provenance_ref(12, 9));
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_response_round_trips_admitted() -> Result<(), crate::CanonError> {
+    assert_response_round_trip(admitted_outcome())
+}
+
+#[test]
+fn witnessed_suffix_response_round_trips_staged() -> Result<(), crate::CanonError> {
+    assert_response_round_trip(WitnessedSuffixAdmissionOutcome::Staged {
+        staged_refs: vec![provenance_ref(32, 11)],
+        basis_report: Some(basis_report()),
+    })
+}
+
+#[test]
+fn witnessed_suffix_response_round_trips_plural() -> Result<(), crate::CanonError> {
+    assert_response_round_trip(WitnessedSuffixAdmissionOutcome::Plural {
+        candidate_refs: vec![provenance_ref(33, 12), provenance_ref(34, 13)],
+        residual_posture: ReadingResidualPosture::PluralityPreserved,
+        basis_report: Some(basis_report()),
+    })
+}
+
+#[test]
+fn witnessed_suffix_response_round_trips_conflict() -> Result<(), crate::CanonError> {
+    assert_response_round_trip(WitnessedSuffixAdmissionOutcome::Conflict {
+        reason: ConflictReason::ParentFootprintOverlap,
+        source_ref: provenance_ref(35, 14),
+        evidence_digest: vec![36; 32],
+        overlap_revalidation: Some(overlap_revalidation()),
+    })
+}
+
+#[test]
+fn witnessed_suffix_response_round_trips_obstructed() -> Result<(), crate::CanonError> {
+    assert_response_round_trip(WitnessedSuffixAdmissionOutcome::Obstructed {
+        source_ref: provenance_ref(37, 15),
+        residual_posture: ReadingResidualPosture::Obstructed,
+        evidence_digest: vec![38; 32],
+    })
+}
+
+#[test]
+fn witnessed_suffix_shell_round_trips_empty_suffix() -> Result<(), crate::CanonError> {
+    let mut shell = shell_with_entries(Vec::new());
+    shell.source_suffix_end_tick = None;
+
+    let bytes = encode_cbor(&shell)?;
+    let decoded: WitnessedSuffixShell = decode_cbor(&bytes)?;
+
+    assert_eq!(decoded.source_entries, Vec::new());
+    assert_eq!(decoded.source_suffix_end_tick, None);
+    assert_eq!(decoded, shell);
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_shell_round_trips_single_entry_suffix() -> Result<(), crate::CanonError> {
+    let shell = shell_with_entries(vec![provenance_ref(41, 16)]);
+    let bytes = encode_cbor(&shell)?;
+    let decoded: WitnessedSuffixShell = decode_cbor(&bytes)?;
+
+    assert_eq!(decoded.source_entries, vec![provenance_ref(41, 16)]);
+    assert_eq!(decoded, shell);
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_shell_round_trips_boundary_witness_only() -> Result<(), crate::CanonError> {
+    let mut shell = shell_with_entries(Vec::new());
+    shell.source_suffix_end_tick = None;
+    shell.boundary_witness = Some(provenance_ref(42, 1));
+
+    let bytes = encode_cbor(&shell)?;
+    let decoded: WitnessedSuffixShell = decode_cbor(&bytes)?;
+
+    assert_eq!(decoded.boundary_witness, Some(provenance_ref(42, 1)));
+    assert_eq!(decoded, shell);
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_request_rejects_missing_source_suffix() -> Result<(), serde_json::Error> {
+    let mut value = request_json()?;
+    if let Value::Object(fields) = &mut value {
+        fields.remove("source_suffix");
+    }
+
+    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_request_rejects_missing_target_basis() -> Result<(), serde_json::Error> {
+    let mut value = request_json()?;
+    if let Value::Object(fields) = &mut value {
+        fields.remove("target_basis");
+    }
+
+    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_response_rejects_zero_outcomes() -> Result<(), serde_json::Error> {
+    let mut value = serde_json::to_value(response(admitted_outcome()))?;
+    if let Value::Object(fields) = &mut value {
+        fields.remove("outcome");
+    }
+
+    assert!(serde_json::from_value::<WitnessedSuffixAdmissionResponse>(value).is_err());
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_response_rejects_multiple_outcomes() -> Result<(), serde_json::Error> {
+    let mut value = serde_json::to_value(response(admitted_outcome()))?;
+    if let Value::Object(fields) = &mut value {
+        if let Some(outcome) = fields.remove("outcome") {
+            fields.insert("outcomes".to_string(), json!([outcome.clone(), outcome]));
+        }
+    }
+
+    assert!(serde_json::from_value::<WitnessedSuffixAdmissionResponse>(value).is_err());
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_request_rejects_raw_transport_endpoint() -> Result<(), serde_json::Error> {
+    let mut value = request_json()?;
+    if let Value::Object(fields) = &mut value {
+        fields.insert(
+            "transport_endpoint".to_string(),
+            json!("https://example.invalid/sync"),
+        );
+    }
+
+    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    Ok(())
+}
+
+#[test]
+fn witnessed_suffix_request_rejects_network_sync_api() -> Result<(), serde_json::Error> {
+    let mut value = request_json()?;
+    if let Value::Object(fields) = &mut value {
+        fields.insert("network_sync_api".to_string(), json!({"kind": "pull"}));
+    }
+
+    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    Ok(())
+}

--- a/crates/echo-wasm-abi/src/witnessed_suffix_tests.rs
+++ b/crates/echo-wasm-abi/src/witnessed_suffix_tests.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
 
-use alloc::{string::ToString, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 
-use serde_json::{Value, json};
+use ciborium::value::Value;
 
 use crate::{
-    decode_cbor, encode_cbor,
+    CanonError, decode_cbor, decode_value, encode_cbor, encode_value,
     kernel_port::{
         BaseRef, ConflictReason, ProvenanceRef, ReadingResidualPosture, SettlementBasisReport,
         SettlementOverlapRevalidation, SettlementParentRevalidation,
@@ -104,8 +104,37 @@ fn assert_response_round_trip(
     Ok(())
 }
 
-fn request_json() -> Result<Value, serde_json::Error> {
-    serde_json::to_value(request())
+fn value_from_cbor<T: serde::Serialize>(value: &T) -> Result<Value, CanonError> {
+    decode_value(&encode_cbor(value)?)
+}
+
+fn request_value() -> Result<Value, CanonError> {
+    value_from_cbor(&request())
+}
+
+fn remove_map_field(value: &mut Value, name: &str) -> Option<Value> {
+    let Value::Map(fields) = value else {
+        return None;
+    };
+    let position = fields
+        .iter()
+        .position(|(key, _)| matches!(key, Value::Text(field) if field == name))?;
+    Some(fields.remove(position).1)
+}
+
+fn insert_map_field(value: &mut Value, name: &str, field_value: Value) -> bool {
+    let Value::Map(fields) = value else {
+        return false;
+    };
+    fields.push((Value::Text(name.into()), field_value));
+    true
+}
+
+fn decode_value_as<T>(value: &Value) -> Result<T, CanonError>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    decode_cbor(&encode_value(value)?)
 }
 
 fn admitted_outcome() -> WitnessedSuffixAdmissionOutcome {
@@ -213,72 +242,73 @@ fn witnessed_suffix_shell_round_trips_boundary_witness_only() -> Result<(), crat
 }
 
 #[test]
-fn witnessed_suffix_request_rejects_missing_source_suffix() -> Result<(), serde_json::Error> {
-    let mut value = request_json()?;
-    if let Value::Object(fields) = &mut value {
-        fields.remove("source_suffix");
-    }
+fn witnessed_suffix_request_rejects_missing_source_suffix() -> Result<(), CanonError> {
+    let mut value = request_value()?;
+    assert!(remove_map_field(&mut value, "source_suffix").is_some());
 
-    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    assert!(decode_value_as::<WitnessedSuffixAdmissionRequest>(&value).is_err());
     Ok(())
 }
 
 #[test]
-fn witnessed_suffix_request_rejects_missing_target_basis() -> Result<(), serde_json::Error> {
-    let mut value = request_json()?;
-    if let Value::Object(fields) = &mut value {
-        fields.remove("target_basis");
-    }
+fn witnessed_suffix_request_rejects_missing_target_basis() -> Result<(), CanonError> {
+    let mut value = request_value()?;
+    assert!(remove_map_field(&mut value, "target_basis").is_some());
 
-    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    assert!(decode_value_as::<WitnessedSuffixAdmissionRequest>(&value).is_err());
     Ok(())
 }
 
 #[test]
-fn witnessed_suffix_response_rejects_zero_outcomes() -> Result<(), serde_json::Error> {
-    let mut value = serde_json::to_value(response(admitted_outcome()))?;
-    if let Value::Object(fields) = &mut value {
-        fields.remove("outcome");
-    }
+fn witnessed_suffix_response_rejects_zero_outcomes() -> Result<(), CanonError> {
+    let mut value = value_from_cbor(&response(admitted_outcome()))?;
+    assert!(remove_map_field(&mut value, "outcome").is_some());
 
-    assert!(serde_json::from_value::<WitnessedSuffixAdmissionResponse>(value).is_err());
+    assert!(decode_value_as::<WitnessedSuffixAdmissionResponse>(&value).is_err());
     Ok(())
 }
 
 #[test]
-fn witnessed_suffix_response_rejects_multiple_outcomes() -> Result<(), serde_json::Error> {
-    let mut value = serde_json::to_value(response(admitted_outcome()))?;
-    if let Value::Object(fields) = &mut value
-        && let Some(outcome) = fields.remove("outcome")
-    {
-        fields.insert("outcomes".to_string(), json!([outcome.clone(), outcome]));
-    }
+fn witnessed_suffix_response_rejects_multiple_outcomes() -> Result<(), CanonError> {
+    let mut value = value_from_cbor(&response(admitted_outcome()))?;
+    let Some(outcome) = remove_map_field(&mut value, "outcome") else {
+        return Err(CanonError::Decode("outcome field missing".into()));
+    };
+    assert!(insert_map_field(
+        &mut value,
+        "outcomes",
+        Value::Array(vec![outcome.clone(), outcome])
+    ));
 
-    assert!(serde_json::from_value::<WitnessedSuffixAdmissionResponse>(value).is_err());
+    assert!(decode_value_as::<WitnessedSuffixAdmissionResponse>(&value).is_err());
     Ok(())
 }
 
 #[test]
-fn witnessed_suffix_request_rejects_raw_transport_endpoint() -> Result<(), serde_json::Error> {
-    let mut value = request_json()?;
-    if let Value::Object(fields) = &mut value {
-        fields.insert(
-            "transport_endpoint".to_string(),
-            json!("https://example.invalid/sync"),
-        );
-    }
+fn witnessed_suffix_request_rejects_raw_transport_endpoint() -> Result<(), CanonError> {
+    let mut value = request_value()?;
+    assert!(insert_map_field(
+        &mut value,
+        "transport_endpoint",
+        Value::Text("https://example.invalid/sync".into())
+    ));
 
-    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    assert!(decode_value_as::<WitnessedSuffixAdmissionRequest>(&value).is_err());
     Ok(())
 }
 
 #[test]
-fn witnessed_suffix_request_rejects_network_sync_api() -> Result<(), serde_json::Error> {
-    let mut value = request_json()?;
-    if let Value::Object(fields) = &mut value {
-        fields.insert("network_sync_api".to_string(), json!({"kind": "pull"}));
-    }
+fn witnessed_suffix_request_rejects_network_sync_api() -> Result<(), CanonError> {
+    let mut value = request_value()?;
+    assert!(insert_map_field(
+        &mut value,
+        "network_sync_api",
+        Value::Map(vec![(
+            Value::Text("kind".into()),
+            Value::Text("pull".into())
+        )])
+    ));
 
-    assert!(serde_json::from_value::<WitnessedSuffixAdmissionRequest>(value).is_err());
+    assert!(decode_value_as::<WitnessedSuffixAdmissionRequest>(&value).is_err());
     Ok(())
 }

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -138,6 +138,7 @@ mod tick_delta;
 mod tick_patch;
 mod tx;
 mod warp_state;
+mod witnessed_suffix;
 #[cfg(test)]
 mod witnessed_suffix_tests;
 mod worldline;
@@ -248,6 +249,10 @@ pub use tick_patch::{
 };
 pub use tx::TxId;
 pub use warp_state::{WarpInstance, WarpState};
+pub use witnessed_suffix::{
+    WitnessedSuffixAdmissionOutcome, WitnessedSuffixAdmissionRequest,
+    WitnessedSuffixAdmissionResponse, WitnessedSuffixShell,
+};
 pub use worldline::{
     ApplyError, AtomWrite, AtomWriteSet, HashTriplet, OutputFrameSet, WorldlineId,
     WorldlineTickHeaderV1, WorldlineTickPatchV1,

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -138,6 +138,8 @@ mod tick_delta;
 mod tick_patch;
 mod tx;
 mod warp_state;
+#[cfg(test)]
+mod witnessed_suffix_tests;
 mod worldline;
 
 // ADR-0008 runtime primitives (Phases 1–3)

--- a/crates/warp-core/src/witnessed_suffix.rs
+++ b/crates/warp-core/src/witnessed_suffix.rs
@@ -395,8 +395,8 @@ fn hash_settlement_slot(hasher: &mut Hasher, slot: &SlotId) {
 }
 
 fn len_to_u64(len: usize) -> u64 {
-    match u64::try_from(len) {
-        Ok(value) => value,
-        Err(_) => u64::MAX,
+    const {
+        assert!(usize::BITS <= u64::BITS);
     }
+    len as u64
 }

--- a/crates/warp-core/src/witnessed_suffix.rs
+++ b/crates/warp-core/src/witnessed_suffix.rs
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Shape-only witnessed suffix admission vocabulary.
+//!
+//! This module names the first admission shell skeleton. It deliberately carries
+//! compact provenance and basis evidence only; it does not implement transport,
+//! remote synchronization, or import execution.
+
+use blake3::Hasher;
+use echo_wasm_abi::kernel_port as abi;
+
+use crate::attachment::{AttachmentOwner, AttachmentPlane};
+use crate::clock::WorldlineTick;
+use crate::ident::Hash;
+use crate::provenance_store::ProvenanceRef;
+use crate::settlement::ConflictReason;
+use crate::strand::{
+    BaseRef, StrandBasisReport, StrandOverlapRevalidation, StrandRevalidationState,
+};
+use crate::tick_patch::SlotId;
+use crate::worldline::WorldlineId;
+use crate::ReadingResidualPosture;
+
+/// Compact shell for judging a witnessed suffix without transport or sync.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WitnessedSuffixShell {
+    /// Worldline carrying the proposed suffix.
+    pub source_worldline_id: WorldlineId,
+    /// First source tick included in the proposed suffix.
+    pub source_suffix_start_tick: WorldlineTick,
+    /// Last source tick included in the proposed suffix, if any.
+    pub source_suffix_end_tick: Option<WorldlineTick>,
+    /// Ordered source provenance coordinates covered by the shell.
+    pub source_entries: Vec<ProvenanceRef>,
+    /// Boundary witness used when the shell has no importable entries yet.
+    pub boundary_witness: Option<ProvenanceRef>,
+    /// Deterministic digest identifying the compact shell evidence.
+    pub witness_digest: Hash,
+    /// Optional basis-relative settlement evidence reused by the shell.
+    pub basis_report: Option<StrandBasisReport>,
+}
+
+impl WitnessedSuffixShell {
+    /// Converts the shell into its ABI DTO.
+    #[must_use]
+    pub fn to_abi(&self) -> abi::WitnessedSuffixShell {
+        abi::WitnessedSuffixShell {
+            source_worldline_id: worldline_id_to_abi(self.source_worldline_id),
+            source_suffix_start_tick: worldline_tick_to_abi(self.source_suffix_start_tick),
+            source_suffix_end_tick: self.source_suffix_end_tick.map(worldline_tick_to_abi),
+            source_entries: self
+                .source_entries
+                .iter()
+                .copied()
+                .map(provenance_ref_to_abi)
+                .collect(),
+            boundary_witness: self.boundary_witness.map(provenance_ref_to_abi),
+            witness_digest: self.witness_digest.to_vec(),
+            basis_report: self
+                .basis_report
+                .as_ref()
+                .map(settlement_basis_report_to_abi),
+        }
+    }
+}
+
+/// Request to judge a witnessed suffix against a target basis.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WitnessedSuffixAdmissionRequest {
+    /// Source suffix and compact witness material.
+    pub source_suffix: WitnessedSuffixShell,
+    /// Worldline receiving the proposed admission.
+    pub target_worldline_id: WorldlineId,
+    /// Target basis used while judging admission.
+    pub target_basis: ProvenanceRef,
+    /// Optional target-basis evidence for strand/parent realization cases.
+    pub basis_report: Option<StrandBasisReport>,
+}
+
+impl WitnessedSuffixAdmissionRequest {
+    /// Converts the request into its ABI DTO.
+    #[must_use]
+    pub fn to_abi(&self) -> abi::WitnessedSuffixAdmissionRequest {
+        abi::WitnessedSuffixAdmissionRequest {
+            source_suffix: self.source_suffix.to_abi(),
+            target_worldline_id: worldline_id_to_abi(self.target_worldline_id),
+            target_basis: provenance_ref_to_abi(self.target_basis),
+            basis_report: self
+                .basis_report
+                .as_ref()
+                .map(settlement_basis_report_to_abi),
+        }
+    }
+}
+
+/// Response to one witnessed suffix admission request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WitnessedSuffixAdmissionResponse {
+    /// Deterministic digest of the source shell being judged.
+    pub source_shell_digest: Hash,
+    /// Resolved target basis used for the response.
+    pub target_basis: ProvenanceRef,
+    /// Exactly one top-level admission outcome.
+    pub outcome: WitnessedSuffixAdmissionOutcome,
+}
+
+impl WitnessedSuffixAdmissionResponse {
+    /// Converts the response into its ABI DTO.
+    #[must_use]
+    pub fn to_abi(&self) -> abi::WitnessedSuffixAdmissionResponse {
+        abi::WitnessedSuffixAdmissionResponse {
+            source_shell_digest: self.source_shell_digest.to_vec(),
+            target_basis: provenance_ref_to_abi(self.target_basis),
+            outcome: witnessed_suffix_outcome_to_abi(&self.outcome),
+        }
+    }
+}
+
+/// Top-level witnessed suffix admission posture.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WitnessedSuffixAdmissionOutcome {
+    /// The suffix is admissible on the named target basis.
+    Admitted {
+        /// Target worldline receiving the admissible suffix.
+        target_worldline_id: WorldlineId,
+        /// Target-local provenance coordinates produced or expected by admission.
+        admitted_refs: Vec<ProvenanceRef>,
+        /// Basis evidence used to classify the suffix as admitted.
+        basis_report: Option<StrandBasisReport>,
+    },
+    /// The suffix is well-formed but retained for later judgment.
+    Staged {
+        /// Source or target coordinates retained while staged.
+        staged_refs: Vec<ProvenanceRef>,
+        /// Basis evidence used to classify the suffix as staged.
+        basis_report: Option<StrandBasisReport>,
+    },
+    /// The suffix preserves lawful plurality instead of one admitted result.
+    Plural {
+        /// Candidate coordinates that remain lawful plural outcomes.
+        candidate_refs: Vec<ProvenanceRef>,
+        /// Read-side residual posture associated with preserved plurality.
+        residual_posture: ReadingResidualPosture,
+        /// Basis evidence used to classify the suffix as plural.
+        basis_report: Option<StrandBasisReport>,
+    },
+    /// The suffix conflicts with the target basis under current admission law.
+    Conflict {
+        /// Deterministic reason the suffix conflicts.
+        reason: ConflictReason,
+        /// Source coordinate implicated in the conflict.
+        source_ref: ProvenanceRef,
+        /// Deterministic digest of compact conflict evidence.
+        evidence_digest: Hash,
+        /// Optional overlap revalidation evidence when footprint overlap caused the conflict.
+        overlap_revalidation: Option<StrandOverlapRevalidation>,
+    },
+    /// The suffix cannot currently be judged or admitted.
+    Obstructed {
+        /// Source coordinate implicated in the obstruction.
+        source_ref: ProvenanceRef,
+        /// Read-side residual posture associated with the obstruction.
+        residual_posture: ReadingResidualPosture,
+        /// Deterministic digest of compact obstruction evidence.
+        evidence_digest: Hash,
+    },
+}
+
+fn witnessed_suffix_outcome_to_abi(
+    outcome: &WitnessedSuffixAdmissionOutcome,
+) -> abi::WitnessedSuffixAdmissionOutcome {
+    match outcome {
+        WitnessedSuffixAdmissionOutcome::Admitted {
+            target_worldline_id,
+            admitted_refs,
+            basis_report,
+        } => abi::WitnessedSuffixAdmissionOutcome::Admitted {
+            target_worldline_id: worldline_id_to_abi(*target_worldline_id),
+            admitted_refs: admitted_refs
+                .iter()
+                .copied()
+                .map(provenance_ref_to_abi)
+                .collect(),
+            basis_report: basis_report.as_ref().map(settlement_basis_report_to_abi),
+        },
+        WitnessedSuffixAdmissionOutcome::Staged {
+            staged_refs,
+            basis_report,
+        } => abi::WitnessedSuffixAdmissionOutcome::Staged {
+            staged_refs: staged_refs
+                .iter()
+                .copied()
+                .map(provenance_ref_to_abi)
+                .collect(),
+            basis_report: basis_report.as_ref().map(settlement_basis_report_to_abi),
+        },
+        WitnessedSuffixAdmissionOutcome::Plural {
+            candidate_refs,
+            residual_posture,
+            basis_report,
+        } => abi::WitnessedSuffixAdmissionOutcome::Plural {
+            candidate_refs: candidate_refs
+                .iter()
+                .copied()
+                .map(provenance_ref_to_abi)
+                .collect(),
+            residual_posture: reading_residual_posture_to_abi(*residual_posture),
+            basis_report: basis_report.as_ref().map(settlement_basis_report_to_abi),
+        },
+        WitnessedSuffixAdmissionOutcome::Conflict {
+            reason,
+            source_ref,
+            evidence_digest,
+            overlap_revalidation,
+        } => abi::WitnessedSuffixAdmissionOutcome::Conflict {
+            reason: conflict_reason_to_abi(*reason),
+            source_ref: provenance_ref_to_abi(*source_ref),
+            evidence_digest: evidence_digest.to_vec(),
+            overlap_revalidation: overlap_revalidation
+                .as_ref()
+                .map(overlap_revalidation_to_abi),
+        },
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            source_ref,
+            residual_posture,
+            evidence_digest,
+        } => abi::WitnessedSuffixAdmissionOutcome::Obstructed {
+            source_ref: provenance_ref_to_abi(*source_ref),
+            residual_posture: reading_residual_posture_to_abi(*residual_posture),
+            evidence_digest: evidence_digest.to_vec(),
+        },
+    }
+}
+
+fn settlement_basis_report_to_abi(report: &StrandBasisReport) -> abi::SettlementBasisReport {
+    abi::SettlementBasisReport {
+        parent_anchor: base_ref_to_abi(report.parent_anchor),
+        child_worldline_id: worldline_id_to_abi(report.child_worldline_id),
+        source_suffix_start_tick: worldline_tick_to_abi(report.source_suffix_start_tick),
+        source_suffix_end_tick: report.source_suffix_end_tick.map(worldline_tick_to_abi),
+        realized_parent_ref: provenance_ref_to_abi(report.realized_parent_ref),
+        owned_closed_slot_count: len_to_u64(report.owned_divergence.closed_len()),
+        parent_written_slot_count: len_to_u64(report.parent_movement.write_len()),
+        parent_revalidation: settlement_parent_revalidation_to_abi(&report.parent_revalidation),
+    }
+}
+
+fn settlement_parent_revalidation_to_abi(
+    revalidation: &StrandRevalidationState,
+) -> abi::SettlementParentRevalidation {
+    match revalidation {
+        StrandRevalidationState::AtAnchor => abi::SettlementParentRevalidation::AtAnchor,
+        StrandRevalidationState::ParentAdvancedDisjoint {
+            parent_from,
+            parent_to,
+        } => abi::SettlementParentRevalidation::ParentAdvancedDisjoint {
+            parent_from: provenance_ref_to_abi(*parent_from),
+            parent_to: provenance_ref_to_abi(*parent_to),
+        },
+        StrandRevalidationState::RevalidationRequired {
+            parent_from,
+            parent_to,
+            overlapping_slots,
+        } => abi::SettlementParentRevalidation::RevalidationRequired {
+            parent_from: provenance_ref_to_abi(*parent_from),
+            parent_to: provenance_ref_to_abi(*parent_to),
+            overlapping_slot_count: len_to_u64(overlapping_slots.len()),
+            overlapping_slots_digest: settlement_overlap_slots_digest(overlapping_slots).to_vec(),
+        },
+    }
+}
+
+fn overlap_revalidation_to_abi(
+    revalidation: &StrandOverlapRevalidation,
+) -> abi::SettlementOverlapRevalidation {
+    match revalidation {
+        StrandOverlapRevalidation::Clean { overlapping_slots } => {
+            abi::SettlementOverlapRevalidation::Clean {
+                overlapping_slot_count: len_to_u64(overlapping_slots.len()),
+                overlapping_slots_digest: settlement_overlap_slots_digest(overlapping_slots)
+                    .to_vec(),
+            }
+        }
+        StrandOverlapRevalidation::Obstructed { overlapping_slots } => {
+            abi::SettlementOverlapRevalidation::Obstructed {
+                overlapping_slot_count: len_to_u64(overlapping_slots.len()),
+                overlapping_slots_digest: settlement_overlap_slots_digest(overlapping_slots)
+                    .to_vec(),
+            }
+        }
+        StrandOverlapRevalidation::Conflict { overlapping_slots } => {
+            abi::SettlementOverlapRevalidation::Conflict {
+                overlapping_slot_count: len_to_u64(overlapping_slots.len()),
+                overlapping_slots_digest: settlement_overlap_slots_digest(overlapping_slots)
+                    .to_vec(),
+            }
+        }
+    }
+}
+
+fn base_ref_to_abi(base_ref: BaseRef) -> abi::BaseRef {
+    abi::BaseRef {
+        source_worldline_id: worldline_id_to_abi(base_ref.source_worldline_id),
+        fork_tick: worldline_tick_to_abi(base_ref.fork_tick),
+        commit_hash: base_ref.commit_hash.to_vec(),
+        boundary_hash: base_ref.boundary_hash.to_vec(),
+        provenance_ref: provenance_ref_to_abi(base_ref.provenance_ref),
+    }
+}
+
+fn provenance_ref_to_abi(reference: ProvenanceRef) -> abi::ProvenanceRef {
+    abi::ProvenanceRef {
+        worldline_id: worldline_id_to_abi(reference.worldline_id),
+        worldline_tick: worldline_tick_to_abi(reference.worldline_tick),
+        commit_hash: reference.commit_hash.to_vec(),
+    }
+}
+
+fn worldline_id_to_abi(worldline_id: WorldlineId) -> abi::WorldlineId {
+    abi::WorldlineId::from_bytes(*worldline_id.as_bytes())
+}
+
+fn worldline_tick_to_abi(worldline_tick: WorldlineTick) -> abi::WorldlineTick {
+    abi::WorldlineTick(worldline_tick.as_u64())
+}
+
+fn conflict_reason_to_abi(reason: ConflictReason) -> abi::ConflictReason {
+    match reason {
+        ConflictReason::ChannelPolicyConflict => abi::ConflictReason::ChannelPolicyConflict,
+        ConflictReason::UnsupportedImport => abi::ConflictReason::UnsupportedImport,
+        ConflictReason::BaseDivergence => abi::ConflictReason::BaseDivergence,
+        ConflictReason::ParentFootprintOverlap => abi::ConflictReason::ParentFootprintOverlap,
+        ConflictReason::QuantumMismatch => abi::ConflictReason::QuantumMismatch,
+    }
+}
+
+fn reading_residual_posture_to_abi(posture: ReadingResidualPosture) -> abi::ReadingResidualPosture {
+    match posture {
+        ReadingResidualPosture::Complete => abi::ReadingResidualPosture::Complete,
+        ReadingResidualPosture::Residual => abi::ReadingResidualPosture::Residual,
+        ReadingResidualPosture::PluralityPreserved => {
+            abi::ReadingResidualPosture::PluralityPreserved
+        }
+        ReadingResidualPosture::Obstructed => abi::ReadingResidualPosture::Obstructed,
+    }
+}
+
+fn settlement_overlap_slots_digest(slots: &[SlotId]) -> Hash {
+    let mut hasher = Hasher::new();
+    hasher.update(b"echo:settlement-overlap-slots:v1\0");
+    hasher.update(&len_to_u64(slots.len()).to_le_bytes());
+    for slot in slots {
+        hash_settlement_slot(&mut hasher, slot);
+    }
+    hasher.finalize().into()
+}
+
+fn hash_settlement_slot(hasher: &mut Hasher, slot: &SlotId) {
+    match slot {
+        SlotId::Node(node) => {
+            hasher.update(&[1]);
+            hasher.update(node.warp_id.as_bytes());
+            hasher.update(node.local_id.as_bytes());
+        }
+        SlotId::Edge(edge) => {
+            hasher.update(&[2]);
+            hasher.update(edge.warp_id.as_bytes());
+            hasher.update(edge.local_id.as_bytes());
+        }
+        SlotId::Attachment(attachment) => {
+            hasher.update(&[3]);
+            match attachment.owner {
+                AttachmentOwner::Node(node) => {
+                    hasher.update(&[1]);
+                    hasher.update(node.warp_id.as_bytes());
+                    hasher.update(node.local_id.as_bytes());
+                }
+                AttachmentOwner::Edge(edge) => {
+                    hasher.update(&[2]);
+                    hasher.update(edge.warp_id.as_bytes());
+                    hasher.update(edge.local_id.as_bytes());
+                }
+            }
+            match attachment.plane {
+                AttachmentPlane::Alpha => hasher.update(&[1]),
+                AttachmentPlane::Beta => hasher.update(&[2]),
+            };
+        }
+        SlotId::Port((warp_id, port_key)) => {
+            hasher.update(&[4]);
+            hasher.update(warp_id.as_bytes());
+            hasher.update(&port_key.to_le_bytes());
+        }
+    }
+}
+
+fn len_to_u64(len: usize) -> u64 {
+    match u64::try_from(len) {
+        Ok(value) => value,
+        Err(_) => u64::MAX,
+    }
+}

--- a/crates/warp-core/src/witnessed_suffix_tests.rs
+++ b/crates/warp-core/src/witnessed_suffix_tests.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+
+use echo_wasm_abi::kernel_port as abi;
+
+use crate::{
+    ConflictReason, ProvenanceRef, ReadingResidualPosture, WitnessedSuffixAdmissionOutcome,
+    WitnessedSuffixAdmissionRequest, WitnessedSuffixAdmissionResponse, WitnessedSuffixShell,
+    WorldlineId, WorldlineTick,
+};
+
+fn worldline(seed: u8) -> WorldlineId {
+    WorldlineId::from_bytes([seed; 32])
+}
+
+fn tick(value: u64) -> WorldlineTick {
+    WorldlineTick::from_raw(value)
+}
+
+fn provenance_ref(seed: u8, worldline_tick: u64) -> ProvenanceRef {
+    ProvenanceRef {
+        worldline_id: worldline(seed),
+        worldline_tick: tick(worldline_tick),
+        commit_hash: [seed.wrapping_add(1); 32],
+    }
+}
+
+fn shell_with_entries(entries: Vec<ProvenanceRef>) -> WitnessedSuffixShell {
+    WitnessedSuffixShell {
+        source_worldline_id: worldline(3),
+        source_suffix_start_tick: tick(2),
+        source_suffix_end_tick: Some(tick(4)),
+        source_entries: entries,
+        boundary_witness: Some(provenance_ref(5, 1)),
+        witness_digest: [6; 32],
+        basis_report: None,
+    }
+}
+
+fn request() -> WitnessedSuffixAdmissionRequest {
+    WitnessedSuffixAdmissionRequest {
+        source_suffix: shell_with_entries(vec![provenance_ref(4, 3)]),
+        target_worldline_id: worldline(11),
+        target_basis: provenance_ref(12, 9),
+        basis_report: None,
+    }
+}
+
+fn response(outcome: WitnessedSuffixAdmissionOutcome) -> WitnessedSuffixAdmissionResponse {
+    WitnessedSuffixAdmissionResponse {
+        source_shell_digest: [6; 32],
+        target_basis: provenance_ref(12, 9),
+        outcome,
+    }
+}
+
+#[test]
+fn witnessed_suffix_core_request_converts_to_abi_shape() {
+    let request = request();
+    let converted: abi::WitnessedSuffixAdmissionRequest = request.to_abi();
+
+    assert_eq!(
+        converted.source_suffix.source_worldline_id,
+        abi::WorldlineId::from_bytes([3; 32])
+    );
+    assert_eq!(
+        converted.source_suffix.source_entries,
+        vec![abi::ProvenanceRef {
+            worldline_id: abi::WorldlineId::from_bytes([4; 32]),
+            worldline_tick: abi::WorldlineTick(3),
+            commit_hash: vec![5; 32],
+        }]
+    );
+    assert_eq!(
+        converted.target_basis,
+        abi::ProvenanceRef {
+            worldline_id: abi::WorldlineId::from_bytes([12; 32]),
+            worldline_tick: abi::WorldlineTick(9),
+            commit_hash: vec![13; 32],
+        }
+    );
+}
+
+#[test]
+fn witnessed_suffix_core_response_converts_admitted_outcome_to_abi() {
+    let response = response(WitnessedSuffixAdmissionOutcome::Admitted {
+        target_worldline_id: worldline(11),
+        admitted_refs: vec![provenance_ref(30, 10)],
+        basis_report: None,
+    });
+
+    let converted: abi::WitnessedSuffixAdmissionResponse = response.to_abi();
+
+    assert!(matches!(
+        converted.outcome,
+        abi::WitnessedSuffixAdmissionOutcome::Admitted { .. }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_core_response_converts_staged_outcome_to_abi() {
+    let response = response(WitnessedSuffixAdmissionOutcome::Staged {
+        staged_refs: vec![provenance_ref(32, 11)],
+        basis_report: None,
+    });
+
+    let converted: abi::WitnessedSuffixAdmissionResponse = response.to_abi();
+
+    assert!(matches!(
+        converted.outcome,
+        abi::WitnessedSuffixAdmissionOutcome::Staged { .. }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_core_response_converts_plural_outcome_to_abi() {
+    let response = response(WitnessedSuffixAdmissionOutcome::Plural {
+        candidate_refs: vec![provenance_ref(33, 12), provenance_ref(34, 13)],
+        residual_posture: ReadingResidualPosture::PluralityPreserved,
+        basis_report: None,
+    });
+
+    let converted: abi::WitnessedSuffixAdmissionResponse = response.to_abi();
+
+    assert!(matches!(
+        converted.outcome,
+        abi::WitnessedSuffixAdmissionOutcome::Plural {
+            residual_posture: abi::ReadingResidualPosture::PluralityPreserved,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_core_response_converts_conflict_outcome_to_abi() {
+    let response = response(WitnessedSuffixAdmissionOutcome::Conflict {
+        reason: ConflictReason::ParentFootprintOverlap,
+        source_ref: provenance_ref(35, 14),
+        evidence_digest: [36; 32],
+        overlap_revalidation: None,
+    });
+
+    let converted: abi::WitnessedSuffixAdmissionResponse = response.to_abi();
+
+    assert!(matches!(
+        converted.outcome,
+        abi::WitnessedSuffixAdmissionOutcome::Conflict {
+            reason: abi::ConflictReason::ParentFootprintOverlap,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_core_response_converts_obstructed_outcome_to_abi() {
+    let response = response(WitnessedSuffixAdmissionOutcome::Obstructed {
+        source_ref: provenance_ref(37, 15),
+        residual_posture: ReadingResidualPosture::Obstructed,
+        evidence_digest: [38; 32],
+    });
+
+    let converted: abi::WitnessedSuffixAdmissionResponse = response.to_abi();
+
+    assert!(matches!(
+        converted.outcome,
+        abi::WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: abi::ReadingResidualPosture::Obstructed,
+            ..
+        }
+    ));
+}

--- a/docs/method/backlog/inbox/PLATFORM_abi-nested-evidence-strictness.md
+++ b/docs/method/backlog/inbox/PLATFORM_abi-nested-evidence-strictness.md
@@ -1,0 +1,63 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# ABI nested evidence strictness
+
+Status: inbox.
+
+Source: PR #322 review follow-up.
+
+## Why now
+
+PR #322 adds `#[serde(deny_unknown_fields)]` to the new witnessed suffix
+admission shell DTOs so callers cannot smuggle transport, sync, or stringly
+status fields into the shell boundary.
+
+That strictness currently stops at the new shell structs. The shell reuses
+existing settlement evidence DTOs such as `SettlementBasisReport`,
+`SettlementParentRevalidation`, `SettlementOverlapRevalidation`, `BaseRef`, and
+`ProvenanceRef`. Those reused DTOs predate the shell and do not consistently
+deny unknown fields.
+
+That means a future caller using a self-describing format could still nest
+unexpected keys inside existing evidence objects even when the outer witnessed
+suffix shell rejects unknown top-level fields. This was deliberately not fixed
+inside PR #322 because it would tighten pre-existing ABI behavior beyond the
+shape-only witnessed suffix skeleton.
+
+## What it should look like
+
+Make an explicit ABI policy decision for nested evidence DTO strictness:
+
+- decide whether reused ABI evidence DTOs should reject unknown fields
+  everywhere
+- identify all public DTOs that carry provenance, basis, settlement, overlap,
+  reading, or admission evidence
+- add `#[serde(deny_unknown_fields)]` where the public contract should be
+  closed
+- add deterministic CBOR rejection tests for nested unknown fields
+- document any ABI epoch/version impact if existing consumers may depend on
+  unknown-field tolerance
+
+## Done looks like
+
+- nested unknown-field behavior is intentional and tested, not incidental
+- settlement evidence DTOs have a clear compatibility posture
+- witnessed suffix admission tests cover unknown fields inside nested
+  `basis_report` evidence if the policy closes that boundary
+- any ABI version or epoch consequences are handled in the same focused change
+
+## Repo evidence
+
+- `crates/echo-wasm-abi/src/kernel_port.rs`
+- `crates/echo-wasm-abi/src/witnessed_suffix_tests.rs`
+- `docs/design/witnessed-suffix-admission-shell.md`
+- PR #322 discussion:
+  `https://github.com/flyingrobots/echo/pull/322#discussion_r3173541861`
+
+## Non-goals
+
+- Do not fold this into the first witnessed suffix shell skeleton.
+- Do not redesign the whole ABI surface opportunistically.
+- Do not add transport, sync, or import execution behavior.
+- Do not weaken the existing outer-shell `deny_unknown_fields` posture.


### PR DESCRIPTION
## Summary
Adds the first shape-only witnessed suffix admission shell skeleton.

This PR follows the METHOD sequence already landed on main:
- DESIGN: `7adf880 docs: design witnessed suffix admission shell`
- RED: `a6802f2 test: add red tests for witnessed suffix admission shell`
- GREEN: `9e23ed4 feat: add witnessed suffix admission shell skeleton`

## What changed
- Adds ABI DTOs for `WitnessedSuffixShell`, `WitnessedSuffixAdmissionRequest`, `WitnessedSuffixAdmissionResponse`, and `WitnessedSuffixAdmissionOutcome`.
- Adds core DTOs with the same vocabulary and core-to-ABI conversions.
- Covers admitted, staged, plural, conflict, and obstructed outcomes.
- Reuses existing `WorldlineId`, `WorldlineTick`, `ProvenanceRef`, settlement basis evidence, overlap revalidation evidence, `ConflictReason`, and reading residual posture vocabulary.
- Uses `#[serde(deny_unknown_fields)]` on the new ABI DTOs so transport/sync/status field smuggling is rejected at the boundary.

## Non-goals preserved
- No network transport.
- No remote sync.
- No import execution.
- No endpoints.
- No broad ABI redesign.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p echo-wasm-abi --lib witnessed_suffix`
- `cargo test -p warp-core --lib witnessed_suffix`
- `cargo clippy -p warp-core --all-targets -- -D warnings -D missing_docs`

Push hook also passed the full local gate: fmt, guards, clippy-core, runtime tests, warp-core tests, and rustdoc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added witnessed suffix admission flow with support for multiple outcome states: admitted, staged, plurality-preserving, conflicting, and obstructed scenarios.
  * Introduced new public API types for witnessed suffix shells, admission requests, and responses with outcome tracking.

* **Tests**
  * Added comprehensive test coverage for witnessed suffix serialization, deserialization, and ABI conversion across all admission outcome variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->