### PR TITLE
Witnessed suffix admission evaluator

### DIFF
--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -250,8 +250,9 @@ pub use tick_patch::{
 pub use tx::TxId;
 pub use warp_state::{WarpInstance, WarpState};
 pub use witnessed_suffix::{
+    evaluate_witnessed_suffix_admission, WitnessedSuffixAdmissionContext,
     WitnessedSuffixAdmissionOutcome, WitnessedSuffixAdmissionRequest,
-    WitnessedSuffixAdmissionResponse, WitnessedSuffixShell,
+    WitnessedSuffixAdmissionResponse, WitnessedSuffixLocalAdmissionPosture, WitnessedSuffixShell,
 };
 pub use worldline::{
     ApplyError, AtomWrite, AtomWriteSet, HashTriplet, OutputFrameSet, WorldlineId,

--- a/crates/warp-core/src/witnessed_suffix.rs
+++ b/crates/warp-core/src/witnessed_suffix.rs
@@ -7,7 +7,7 @@
 //! remote synchronization, or import execution.
 
 use blake3::Hasher;
-use echo_wasm_abi::kernel_port as abi;
+use echo_wasm_abi::{encode_cbor, kernel_port as abi};
 
 use crate::attachment::{AttachmentOwner, AttachmentPlane};
 use crate::clock::WorldlineTick;
@@ -124,6 +124,11 @@ pub trait WitnessedSuffixAdmissionContext {
     /// Returns the locally computed digest for a source shell, when available.
     fn source_shell_digest(&self, shell: &WitnessedSuffixShell) -> Option<Hash>;
 
+    /// Returns deterministic local obstruction evidence when shell identity is unavailable.
+    fn source_shell_obstruction_digest(&self, shell: &WitnessedSuffixShell) -> Hash {
+        source_shell_obstruction_digest(shell)
+    }
+
     /// Resolves a target basis against local evidence, when available.
     fn resolve_target_basis(&self, target_basis: ProvenanceRef) -> Option<ProvenanceRef>;
 
@@ -174,12 +179,13 @@ pub fn evaluate_witnessed_suffix_admission(
 ) -> WitnessedSuffixAdmissionResponse {
     let source_shell_digest = context.source_shell_digest(&request.source_suffix);
     let target_basis = context.resolve_target_basis(request.target_basis);
-    let response_source_shell_digest =
-        source_shell_digest.unwrap_or(request.source_suffix.witness_digest);
+    let response_source_shell_digest = source_shell_digest
+        .unwrap_or_else(|| context.source_shell_obstruction_digest(&request.source_suffix));
     let response_target_basis = target_basis.unwrap_or(request.target_basis);
 
     if source_shell_digest != Some(request.source_suffix.witness_digest)
         || target_basis.is_none()
+        || !source_entries_are_canonical(&request.source_suffix)
         || suffix_bounds_are_inconsistent(&request.source_suffix)
         || suffix_entries_are_outside_bounds(&request.source_suffix)
         || suffix_witness_material_is_missing(&request.source_suffix)
@@ -187,11 +193,16 @@ pub fn evaluate_witnessed_suffix_admission(
         return obstructed_response(request, response_source_shell_digest, response_target_basis);
     }
 
-    let outcome = match context.local_admission_posture(request) {
+    let normalized_request = WitnessedSuffixAdmissionRequest {
+        target_basis: response_target_basis,
+        ..request.clone()
+    };
+
+    let outcome = match context.local_admission_posture(&normalized_request) {
         WitnessedSuffixLocalAdmissionPosture::Admissible { admitted_refs } => {
             WitnessedSuffixAdmissionOutcome::Admitted {
                 target_worldline_id: request.target_worldline_id,
-                admitted_refs,
+                admitted_refs: canonical_provenance_refs(admitted_refs),
                 basis_report: request
                     .basis_report
                     .clone()
@@ -200,7 +211,7 @@ pub fn evaluate_witnessed_suffix_admission(
         }
         WitnessedSuffixLocalAdmissionPosture::Staged { staged_refs } => {
             WitnessedSuffixAdmissionOutcome::Staged {
-                staged_refs,
+                staged_refs: canonical_provenance_refs(staged_refs),
                 basis_report: request
                     .basis_report
                     .clone()
@@ -209,7 +220,7 @@ pub fn evaluate_witnessed_suffix_admission(
         }
         WitnessedSuffixLocalAdmissionPosture::Plural { candidate_refs } => {
             WitnessedSuffixAdmissionOutcome::Plural {
-                candidate_refs,
+                candidate_refs: canonical_provenance_refs(candidate_refs),
                 residual_posture: ReadingResidualPosture::PluralityPreserved,
                 basis_report: request
                     .basis_report
@@ -310,8 +321,24 @@ fn suffix_entries_are_outside_bounds(shell: &WitnessedSuffixShell) -> bool {
     })
 }
 
+fn source_entries_are_canonical(shell: &WitnessedSuffixShell) -> bool {
+    shell
+        .source_entries
+        .iter()
+        .all(|source_entry| source_entry.worldline_id == shell.source_worldline_id)
+        && shell
+            .source_entries
+            .windows(2)
+            .all(|pair| pair[0] <= pair[1])
+}
+
 fn suffix_witness_material_is_missing(shell: &WitnessedSuffixShell) -> bool {
     shell.source_entries.is_empty() && shell.boundary_witness.is_none()
+}
+
+fn canonical_provenance_refs(mut refs: Vec<ProvenanceRef>) -> Vec<ProvenanceRef> {
+    refs.sort_unstable();
+    refs
 }
 
 fn obstructed_response(
@@ -328,6 +355,55 @@ fn obstructed_response(
             evidence_digest: source_shell_digest,
         },
     }
+}
+
+fn source_shell_obstruction_digest(shell: &WitnessedSuffixShell) -> Hash {
+    let mut shell_without_claim = shell.to_abi();
+    shell_without_claim.witness_digest.clear();
+
+    let mut hasher = Hasher::new();
+    hasher.update(b"echo:witnessed-suffix-obstruction:v1\0");
+    match encode_cbor(&shell_without_claim) {
+        Ok(encoded_shell) => {
+            hasher.update(&encoded_shell);
+        }
+        Err(_) => hash_source_shell_obstruction_fallback(&mut hasher, shell),
+    }
+    hasher.finalize().into()
+}
+
+fn hash_source_shell_obstruction_fallback(hasher: &mut Hasher, shell: &WitnessedSuffixShell) {
+    hasher.update(shell.source_worldline_id.as_bytes());
+    hasher.update(&shell.source_suffix_start_tick.as_u64().to_le_bytes());
+    match shell.source_suffix_end_tick {
+        Some(end_tick) => {
+            hasher.update(&[1]);
+            hasher.update(&end_tick.as_u64().to_le_bytes());
+        }
+        None => {
+            hasher.update(&[0]);
+        }
+    }
+    hasher.update(&len_to_u64(shell.source_entries.len()).to_le_bytes());
+    for source_entry in &shell.source_entries {
+        hash_provenance_ref(hasher, source_entry);
+    }
+    match shell.boundary_witness {
+        Some(boundary_witness) => {
+            hasher.update(&[1]);
+            hash_provenance_ref(hasher, &boundary_witness);
+        }
+        None => {
+            hasher.update(&[0]);
+        }
+    }
+    hasher.update(&[u8::from(shell.basis_report.is_some())]);
+}
+
+fn hash_provenance_ref(hasher: &mut Hasher, reference: &ProvenanceRef) {
+    hasher.update(reference.worldline_id.as_bytes());
+    hasher.update(&reference.worldline_tick.as_u64().to_le_bytes());
+    hasher.update(&reference.commit_hash);
 }
 
 fn witnessed_suffix_outcome_to_abi(

--- a/crates/warp-core/src/witnessed_suffix.rs
+++ b/crates/warp-core/src/witnessed_suffix.rs
@@ -165,6 +165,8 @@ pub enum WitnessedSuffixLocalAdmissionPosture {
         source_ref: ProvenanceRef,
         /// Deterministic digest of compact conflict evidence.
         evidence_digest: Hash,
+        /// Optional overlap revalidation evidence when footprint overlap caused the conflict.
+        overlap_revalidation: Option<StrandOverlapRevalidation>,
     },
 }
 
@@ -182,15 +184,21 @@ pub fn evaluate_witnessed_suffix_admission(
     let response_source_shell_digest = source_shell_digest
         .unwrap_or_else(|| context.source_shell_obstruction_digest(&request.source_suffix));
     let response_target_basis = target_basis.unwrap_or(request.target_basis);
+    let source_entry_obstruction_ref = source_entry_obstruction_ref(&request.source_suffix);
 
     if source_shell_digest != Some(request.source_suffix.witness_digest)
         || target_basis.is_none()
-        || !source_entries_are_canonical(&request.source_suffix)
         || suffix_bounds_are_inconsistent(&request.source_suffix)
-        || suffix_entries_are_outside_bounds(&request.source_suffix)
+        || source_entry_obstruction_ref.is_some()
         || suffix_witness_material_is_missing(&request.source_suffix)
+        || basis_report_is_inconsistent(request, response_target_basis)
     {
-        return obstructed_response(request, response_source_shell_digest, response_target_basis);
+        return obstructed_response(
+            request,
+            response_source_shell_digest,
+            response_target_basis,
+            source_entry_obstruction_ref,
+        );
     }
 
     let normalized_request = WitnessedSuffixAdmissionRequest {
@@ -203,40 +211,32 @@ pub fn evaluate_witnessed_suffix_admission(
             WitnessedSuffixAdmissionOutcome::Admitted {
                 target_worldline_id: request.target_worldline_id,
                 admitted_refs: canonical_provenance_refs(admitted_refs),
-                basis_report: request
-                    .basis_report
-                    .clone()
-                    .or_else(|| request.source_suffix.basis_report.clone()),
+                basis_report: response_basis_report(request),
             }
         }
         WitnessedSuffixLocalAdmissionPosture::Staged { staged_refs } => {
             WitnessedSuffixAdmissionOutcome::Staged {
                 staged_refs: canonical_provenance_refs(staged_refs),
-                basis_report: request
-                    .basis_report
-                    .clone()
-                    .or_else(|| request.source_suffix.basis_report.clone()),
+                basis_report: response_basis_report(request),
             }
         }
         WitnessedSuffixLocalAdmissionPosture::Plural { candidate_refs } => {
             WitnessedSuffixAdmissionOutcome::Plural {
                 candidate_refs: canonical_provenance_refs(candidate_refs),
                 residual_posture: ReadingResidualPosture::PluralityPreserved,
-                basis_report: request
-                    .basis_report
-                    .clone()
-                    .or_else(|| request.source_suffix.basis_report.clone()),
+                basis_report: response_basis_report(request),
             }
         }
         WitnessedSuffixLocalAdmissionPosture::Conflict {
             reason,
             source_ref,
             evidence_digest,
+            overlap_revalidation,
         } => WitnessedSuffixAdmissionOutcome::Conflict {
             reason,
             source_ref,
             evidence_digest,
-            overlap_revalidation: None,
+            overlap_revalidation,
         },
     };
 
@@ -297,7 +297,14 @@ pub enum WitnessedSuffixAdmissionOutcome {
     },
 }
 
-fn obstruction_source_ref(request: &WitnessedSuffixAdmissionRequest) -> ProvenanceRef {
+fn obstruction_source_ref(
+    request: &WitnessedSuffixAdmissionRequest,
+    source_entry_obstruction_ref: Option<ProvenanceRef>,
+) -> ProvenanceRef {
+    if let Some(source_ref) = source_entry_obstruction_ref {
+        return source_ref;
+    }
+
     request
         .source_suffix
         .boundary_witness
@@ -311,29 +318,55 @@ fn suffix_bounds_are_inconsistent(shell: &WitnessedSuffixShell) -> bool {
         .is_some_and(|end_tick| end_tick.as_u64() < shell.source_suffix_start_tick.as_u64())
 }
 
-fn suffix_entries_are_outside_bounds(shell: &WitnessedSuffixShell) -> bool {
+fn source_entry_obstruction_ref(shell: &WitnessedSuffixShell) -> Option<ProvenanceRef> {
+    suffix_entry_outside_bounds(shell)
+        .or_else(|| source_entry_from_foreign_worldline(shell))
+        .or_else(|| non_canonical_source_entry(shell))
+}
+
+fn suffix_entry_outside_bounds(shell: &WitnessedSuffixShell) -> Option<ProvenanceRef> {
     let start_tick = shell.source_suffix_start_tick.as_u64();
     let end_tick = shell.source_suffix_end_tick.map(WorldlineTick::as_u64);
 
-    shell.source_entries.iter().any(|source_entry| {
+    shell.source_entries.iter().copied().find(|source_entry| {
         let entry_tick = source_entry.worldline_tick.as_u64();
         entry_tick < start_tick || end_tick.is_some_and(|end_tick| entry_tick > end_tick)
     })
 }
 
-fn source_entries_are_canonical(shell: &WitnessedSuffixShell) -> bool {
+fn source_entry_from_foreign_worldline(shell: &WitnessedSuffixShell) -> Option<ProvenanceRef> {
     shell
         .source_entries
         .iter()
-        .all(|source_entry| source_entry.worldline_id == shell.source_worldline_id)
-        && shell
-            .source_entries
-            .windows(2)
-            .all(|pair| pair[0] <= pair[1])
+        .copied()
+        .find(|source_entry| source_entry.worldline_id != shell.source_worldline_id)
+}
+
+fn non_canonical_source_entry(shell: &WitnessedSuffixShell) -> Option<ProvenanceRef> {
+    shell
+        .source_entries
+        .windows(2)
+        .find_map(|pair| (pair[0] >= pair[1]).then_some(pair[1]))
 }
 
 fn suffix_witness_material_is_missing(shell: &WitnessedSuffixShell) -> bool {
     shell.source_entries.is_empty() && shell.boundary_witness.is_none()
+}
+
+fn basis_report_is_inconsistent(
+    request: &WitnessedSuffixAdmissionRequest,
+    target_basis: ProvenanceRef,
+) -> bool {
+    response_basis_report(request)
+        .as_ref()
+        .is_some_and(|report| report.realized_parent_ref != target_basis)
+}
+
+fn response_basis_report(request: &WitnessedSuffixAdmissionRequest) -> Option<StrandBasisReport> {
+    request
+        .basis_report
+        .clone()
+        .or_else(|| request.source_suffix.basis_report.clone())
 }
 
 fn canonical_provenance_refs(mut refs: Vec<ProvenanceRef>) -> Vec<ProvenanceRef> {
@@ -345,12 +378,13 @@ fn obstructed_response(
     request: &WitnessedSuffixAdmissionRequest,
     source_shell_digest: Hash,
     target_basis: ProvenanceRef,
+    source_entry_obstruction_ref: Option<ProvenanceRef>,
 ) -> WitnessedSuffixAdmissionResponse {
     WitnessedSuffixAdmissionResponse {
         source_shell_digest,
         target_basis,
         outcome: WitnessedSuffixAdmissionOutcome::Obstructed {
-            source_ref: obstruction_source_ref(request),
+            source_ref: obstruction_source_ref(request, source_entry_obstruction_ref),
             residual_posture: ReadingResidualPosture::Obstructed,
             evidence_digest: source_shell_digest,
         },

--- a/crates/warp-core/src/witnessed_suffix.rs
+++ b/crates/warp-core/src/witnessed_suffix.rs
@@ -116,6 +116,81 @@ impl WitnessedSuffixAdmissionResponse {
     }
 }
 
+/// Read-only local evidence source used by witnessed suffix admission evaluation.
+///
+/// This trait is intentionally narrow: it does not expose runtime mutation,
+/// transport, peer identity, sync loops, or raw patch streams.
+pub trait WitnessedSuffixAdmissionContext {
+    /// Returns the locally computed digest for a source shell, when available.
+    fn source_shell_digest(&self, shell: &WitnessedSuffixShell) -> Option<Hash>;
+
+    /// Resolves a target basis against local evidence, when available.
+    fn resolve_target_basis(&self, target_basis: ProvenanceRef) -> Option<ProvenanceRef>;
+
+    /// Reports the local admission posture for a well-formed request.
+    fn local_admission_posture(
+        &self,
+        request: &WitnessedSuffixAdmissionRequest,
+    ) -> WitnessedSuffixLocalAdmissionPosture;
+}
+
+/// Local posture reported by the read-only admission context.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WitnessedSuffixLocalAdmissionPosture {
+    /// Local evidence says the suffix is admissible.
+    Admissible {
+        /// Target-local provenance coordinates produced or expected by admission.
+        admitted_refs: Vec<ProvenanceRef>,
+    },
+    /// Local evidence says the suffix should be retained for later judgment.
+    Staged {
+        /// Source or target coordinates retained while staged.
+        staged_refs: Vec<ProvenanceRef>,
+    },
+    /// Local evidence preserves lawful plurality.
+    Plural {
+        /// Candidate coordinates that remain lawful plural outcomes.
+        candidate_refs: Vec<ProvenanceRef>,
+    },
+    /// Local evidence reports deterministic adverse admission law.
+    Conflict {
+        /// Deterministic reason the suffix conflicts.
+        reason: ConflictReason,
+        /// Source coordinate implicated in the conflict.
+        source_ref: ProvenanceRef,
+        /// Deterministic digest of compact conflict evidence.
+        evidence_digest: Hash,
+    },
+}
+
+/// Evaluates one witnessed suffix admission request against local evidence.
+///
+/// GREEN 1 adds the contract surface only. Later GREEN slices will replace the
+/// conservative obstruction fallback with the full local classification rules.
+#[must_use]
+pub fn evaluate_witnessed_suffix_admission(
+    request: &WitnessedSuffixAdmissionRequest,
+    context: &impl WitnessedSuffixAdmissionContext,
+) -> WitnessedSuffixAdmissionResponse {
+    let source_shell_digest = context
+        .source_shell_digest(&request.source_suffix)
+        .unwrap_or(request.source_suffix.witness_digest);
+    let target_basis = context
+        .resolve_target_basis(request.target_basis)
+        .unwrap_or(request.target_basis);
+    let _local_posture = context.local_admission_posture(request);
+
+    WitnessedSuffixAdmissionResponse {
+        source_shell_digest,
+        target_basis,
+        outcome: WitnessedSuffixAdmissionOutcome::Obstructed {
+            source_ref: obstruction_source_ref(request),
+            residual_posture: ReadingResidualPosture::Obstructed,
+            evidence_digest: source_shell_digest,
+        },
+    }
+}
+
 /// Top-level witnessed suffix admission posture.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WitnessedSuffixAdmissionOutcome {
@@ -164,6 +239,14 @@ pub enum WitnessedSuffixAdmissionOutcome {
         /// Deterministic digest of compact obstruction evidence.
         evidence_digest: Hash,
     },
+}
+
+fn obstruction_source_ref(request: &WitnessedSuffixAdmissionRequest) -> ProvenanceRef {
+    request
+        .source_suffix
+        .boundary_witness
+        .or_else(|| request.source_suffix.source_entries.first().copied())
+        .unwrap_or(request.target_basis)
 }
 
 fn witnessed_suffix_outcome_to_abi(

--- a/crates/warp-core/src/witnessed_suffix.rs
+++ b/crates/warp-core/src/witnessed_suffix.rs
@@ -165,29 +165,73 @@ pub enum WitnessedSuffixLocalAdmissionPosture {
 
 /// Evaluates one witnessed suffix admission request against local evidence.
 ///
-/// GREEN 1 adds the contract surface only. Later GREEN slices will replace the
-/// conservative obstruction fallback with the full local classification rules.
+/// Performs deterministic local validation before returning the classified
+/// posture reported by the read-only context.
 #[must_use]
 pub fn evaluate_witnessed_suffix_admission(
     request: &WitnessedSuffixAdmissionRequest,
     context: &impl WitnessedSuffixAdmissionContext,
 ) -> WitnessedSuffixAdmissionResponse {
-    let source_shell_digest = context
-        .source_shell_digest(&request.source_suffix)
-        .unwrap_or(request.source_suffix.witness_digest);
-    let target_basis = context
-        .resolve_target_basis(request.target_basis)
-        .unwrap_or(request.target_basis);
-    let _local_posture = context.local_admission_posture(request);
+    let source_shell_digest = context.source_shell_digest(&request.source_suffix);
+    let target_basis = context.resolve_target_basis(request.target_basis);
+    let response_source_shell_digest =
+        source_shell_digest.unwrap_or(request.source_suffix.witness_digest);
+    let response_target_basis = target_basis.unwrap_or(request.target_basis);
+
+    if source_shell_digest != Some(request.source_suffix.witness_digest)
+        || target_basis.is_none()
+        || suffix_bounds_are_inconsistent(&request.source_suffix)
+        || suffix_witness_material_is_missing(&request.source_suffix)
+    {
+        return obstructed_response(request, response_source_shell_digest, response_target_basis);
+    }
+
+    let outcome = match context.local_admission_posture(request) {
+        WitnessedSuffixLocalAdmissionPosture::Admissible { admitted_refs } => {
+            WitnessedSuffixAdmissionOutcome::Admitted {
+                target_worldline_id: request.target_worldline_id,
+                admitted_refs,
+                basis_report: request
+                    .basis_report
+                    .clone()
+                    .or_else(|| request.source_suffix.basis_report.clone()),
+            }
+        }
+        WitnessedSuffixLocalAdmissionPosture::Staged { staged_refs } => {
+            WitnessedSuffixAdmissionOutcome::Staged {
+                staged_refs,
+                basis_report: request
+                    .basis_report
+                    .clone()
+                    .or_else(|| request.source_suffix.basis_report.clone()),
+            }
+        }
+        WitnessedSuffixLocalAdmissionPosture::Plural { candidate_refs } => {
+            WitnessedSuffixAdmissionOutcome::Plural {
+                candidate_refs,
+                residual_posture: ReadingResidualPosture::PluralityPreserved,
+                basis_report: request
+                    .basis_report
+                    .clone()
+                    .or_else(|| request.source_suffix.basis_report.clone()),
+            }
+        }
+        WitnessedSuffixLocalAdmissionPosture::Conflict {
+            reason,
+            source_ref,
+            evidence_digest,
+        } => WitnessedSuffixAdmissionOutcome::Conflict {
+            reason,
+            source_ref,
+            evidence_digest,
+            overlap_revalidation: None,
+        },
+    };
 
     WitnessedSuffixAdmissionResponse {
-        source_shell_digest,
-        target_basis,
-        outcome: WitnessedSuffixAdmissionOutcome::Obstructed {
-            source_ref: obstruction_source_ref(request),
-            residual_posture: ReadingResidualPosture::Obstructed,
-            evidence_digest: source_shell_digest,
-        },
+        source_shell_digest: response_source_shell_digest,
+        target_basis: response_target_basis,
+        outcome,
     }
 }
 
@@ -247,6 +291,32 @@ fn obstruction_source_ref(request: &WitnessedSuffixAdmissionRequest) -> Provenan
         .boundary_witness
         .or_else(|| request.source_suffix.source_entries.first().copied())
         .unwrap_or(request.target_basis)
+}
+
+fn suffix_bounds_are_inconsistent(shell: &WitnessedSuffixShell) -> bool {
+    shell
+        .source_suffix_end_tick
+        .is_some_and(|end_tick| end_tick.as_u64() < shell.source_suffix_start_tick.as_u64())
+}
+
+fn suffix_witness_material_is_missing(shell: &WitnessedSuffixShell) -> bool {
+    shell.source_entries.is_empty() && shell.boundary_witness.is_none()
+}
+
+fn obstructed_response(
+    request: &WitnessedSuffixAdmissionRequest,
+    source_shell_digest: Hash,
+    target_basis: ProvenanceRef,
+) -> WitnessedSuffixAdmissionResponse {
+    WitnessedSuffixAdmissionResponse {
+        source_shell_digest,
+        target_basis,
+        outcome: WitnessedSuffixAdmissionOutcome::Obstructed {
+            source_ref: obstruction_source_ref(request),
+            residual_posture: ReadingResidualPosture::Obstructed,
+            evidence_digest: source_shell_digest,
+        },
+    }
 }
 
 fn witnessed_suffix_outcome_to_abi(

--- a/crates/warp-core/src/witnessed_suffix.rs
+++ b/crates/warp-core/src/witnessed_suffix.rs
@@ -181,6 +181,7 @@ pub fn evaluate_witnessed_suffix_admission(
     if source_shell_digest != Some(request.source_suffix.witness_digest)
         || target_basis.is_none()
         || suffix_bounds_are_inconsistent(&request.source_suffix)
+        || suffix_entries_are_outside_bounds(&request.source_suffix)
         || suffix_witness_material_is_missing(&request.source_suffix)
     {
         return obstructed_response(request, response_source_shell_digest, response_target_basis);
@@ -297,6 +298,16 @@ fn suffix_bounds_are_inconsistent(shell: &WitnessedSuffixShell) -> bool {
     shell
         .source_suffix_end_tick
         .is_some_and(|end_tick| end_tick.as_u64() < shell.source_suffix_start_tick.as_u64())
+}
+
+fn suffix_entries_are_outside_bounds(shell: &WitnessedSuffixShell) -> bool {
+    let start_tick = shell.source_suffix_start_tick.as_u64();
+    let end_tick = shell.source_suffix_end_tick.map(WorldlineTick::as_u64);
+
+    shell.source_entries.iter().any(|source_entry| {
+        let entry_tick = source_entry.worldline_tick.as_u64();
+        entry_tick < start_tick || end_tick.is_some_and(|end_tick| entry_tick > end_tick)
+    })
 }
 
 fn suffix_witness_material_is_missing(shell: &WitnessedSuffixShell) -> bool {

--- a/crates/warp-core/src/witnessed_suffix_tests.rs
+++ b/crates/warp-core/src/witnessed_suffix_tests.rs
@@ -4,9 +4,10 @@
 use echo_wasm_abi::kernel_port as abi;
 
 use crate::{
-    ConflictReason, ProvenanceRef, ReadingResidualPosture, WitnessedSuffixAdmissionOutcome,
-    WitnessedSuffixAdmissionRequest, WitnessedSuffixAdmissionResponse, WitnessedSuffixShell,
-    WorldlineId, WorldlineTick,
+    evaluate_witnessed_suffix_admission, ConflictReason, Hash, ProvenanceRef,
+    ReadingResidualPosture, WitnessedSuffixAdmissionContext, WitnessedSuffixAdmissionOutcome,
+    WitnessedSuffixAdmissionRequest, WitnessedSuffixAdmissionResponse,
+    WitnessedSuffixLocalAdmissionPosture, WitnessedSuffixShell, WorldlineId, WorldlineTick,
 };
 
 fn worldline(seed: u8) -> WorldlineId {
@@ -51,6 +52,37 @@ fn response(outcome: WitnessedSuffixAdmissionOutcome) -> WitnessedSuffixAdmissio
         source_shell_digest: [6; 32],
         target_basis: provenance_ref(12, 9),
         outcome,
+    }
+}
+
+struct FakeAdmissionContext {
+    expected_shell_digest: Option<Hash>,
+    resolved_target_basis: Option<ProvenanceRef>,
+    posture: WitnessedSuffixLocalAdmissionPosture,
+}
+
+impl WitnessedSuffixAdmissionContext for FakeAdmissionContext {
+    fn source_shell_digest(&self, _shell: &WitnessedSuffixShell) -> Option<Hash> {
+        self.expected_shell_digest
+    }
+
+    fn resolve_target_basis(&self, _target_basis: ProvenanceRef) -> Option<ProvenanceRef> {
+        self.resolved_target_basis
+    }
+
+    fn local_admission_posture(
+        &self,
+        _request: &WitnessedSuffixAdmissionRequest,
+    ) -> WitnessedSuffixLocalAdmissionPosture {
+        self.posture.clone()
+    }
+}
+
+fn clean_context(posture: WitnessedSuffixLocalAdmissionPosture) -> FakeAdmissionContext {
+    FakeAdmissionContext {
+        expected_shell_digest: Some([6; 32]),
+        resolved_target_basis: Some(provenance_ref(12, 9)),
+        posture,
     }
 }
 
@@ -168,4 +200,164 @@ fn witnessed_suffix_core_response_converts_obstructed_outcome_to_abi() {
             ..
         }
     ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_admits_clean_suffix() {
+    let request = request();
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert_eq!(response.source_shell_digest, [6; 32]);
+    assert_eq!(response.target_basis, provenance_ref(12, 9));
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Admitted {
+            target_worldline_id,
+            admitted_refs,
+            ..
+        } if target_worldline_id == worldline(11)
+            && admitted_refs == vec![provenance_ref(30, 10)]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_stages_boundary_only_suffix() {
+    let request = WitnessedSuffixAdmissionRequest {
+        source_suffix: shell_with_entries(Vec::new()),
+        target_worldline_id: worldline(11),
+        target_basis: provenance_ref(12, 9),
+        basis_report: None,
+    };
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Staged {
+        staged_refs: vec![provenance_ref(5, 1)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Staged { staged_refs, .. }
+            if staged_refs == vec![provenance_ref(5, 1)]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_preserves_plural_outcome() {
+    let request = request();
+    let candidates = vec![provenance_ref(33, 12), provenance_ref(34, 13)];
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Plural {
+        candidate_refs: candidates.clone(),
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Plural {
+            candidate_refs,
+            residual_posture: ReadingResidualPosture::PluralityPreserved,
+            ..
+        } if candidate_refs == candidates
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_conflicts_with_adverse_admission_law() {
+    let request = request();
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Conflict {
+        reason: ConflictReason::ParentFootprintOverlap,
+        source_ref: provenance_ref(35, 14),
+        evidence_digest: [36; 32],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Conflict {
+            reason: ConflictReason::ParentFootprintOverlap,
+            source_ref,
+            evidence_digest,
+            ..
+        } if source_ref == provenance_ref(35, 14) && evidence_digest == [36; 32]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_mismatched_digest() {
+    let request = request();
+    let context = FakeAdmissionContext {
+        expected_shell_digest: Some([99; 32]),
+        resolved_target_basis: Some(provenance_ref(12, 9)),
+        posture: WitnessedSuffixLocalAdmissionPosture::Admissible {
+            admitted_refs: vec![provenance_ref(30, 10)],
+        },
+    };
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_unknown_target_basis() {
+    let request = request();
+    let context = FakeAdmissionContext {
+        expected_shell_digest: Some([6; 32]),
+        resolved_target_basis: None,
+        posture: WitnessedSuffixLocalAdmissionPosture::Admissible {
+            admitted_refs: vec![provenance_ref(30, 10)],
+        },
+    };
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_inconsistent_bounds() {
+    let mut request = request();
+    request.source_suffix.source_suffix_start_tick = tick(5);
+    request.source_suffix.source_suffix_end_tick = Some(tick(4));
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_has_no_transport_or_sync_surface() {
+    let source = include_str!("witnessed_suffix.rs");
+
+    assert!(!source.contains("transport_endpoint"));
+    assert!(!source.contains("network_sync_api"));
+    assert!(!source.contains("peer_identity"));
+    assert!(!source.contains("sync_daemon"));
+    assert!(!source.contains("raw_patch_stream"));
 }

--- a/crates/warp-core/src/witnessed_suffix_tests.rs
+++ b/crates/warp-core/src/witnessed_suffix_tests.rs
@@ -246,6 +246,79 @@ fn witnessed_suffix_evaluator_stages_boundary_only_suffix() {
 }
 
 #[test]
+fn witnessed_suffix_evaluator_obstructs_empty_suffix_without_boundary_witness() {
+    let mut request = WitnessedSuffixAdmissionRequest {
+        source_suffix: shell_with_entries(Vec::new()),
+        target_worldline_id: worldline(11),
+        target_basis: provenance_ref(12, 9),
+        basis_report: None,
+    };
+    request.source_suffix.boundary_witness = None;
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Staged {
+        staged_refs: Vec::new(),
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_allows_equal_start_and_end_ticks() {
+    let mut request = request();
+    request.source_suffix.source_suffix_end_tick =
+        Some(request.source_suffix.source_suffix_start_tick);
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Admitted {
+            target_worldline_id,
+            admitted_refs,
+            ..
+        } if target_worldline_id == worldline(11)
+            && admitted_refs == vec![provenance_ref(30, 10)]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_stages_when_target_basis_is_boundary_witness() {
+    let boundary_witness = provenance_ref(5, 1);
+    let request = WitnessedSuffixAdmissionRequest {
+        source_suffix: shell_with_entries(Vec::new()),
+        target_worldline_id: worldline(11),
+        target_basis: boundary_witness,
+        basis_report: None,
+    };
+    let context = FakeAdmissionContext {
+        expected_shell_digest: Some([6; 32]),
+        resolved_target_basis: Some(boundary_witness),
+        posture: WitnessedSuffixLocalAdmissionPosture::Staged {
+            staged_refs: vec![boundary_witness],
+        },
+    };
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert_eq!(response.target_basis, boundary_witness);
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Staged { staged_refs, .. }
+            if staged_refs == vec![boundary_witness]
+    ));
+}
+
+#[test]
 fn witnessed_suffix_evaluator_preserves_plural_outcome() {
     let request = request();
     let candidates = vec![provenance_ref(33, 12), provenance_ref(34, 13)];
@@ -282,7 +355,7 @@ fn witnessed_suffix_evaluator_conflicts_with_adverse_admission_law() {
             reason: ConflictReason::ParentFootprintOverlap,
             source_ref,
             evidence_digest,
-            ..
+            overlap_revalidation: None,
         } if source_ref == provenance_ref(35, 14) && evidence_digest == [36; 32]
     ));
 }
@@ -360,4 +433,34 @@ fn witnessed_suffix_evaluator_has_no_transport_or_sync_surface() {
     assert!(!source.contains("peer_identity"));
     assert!(!source.contains("sync_daemon"));
     assert!(!source.contains("raw_patch_stream"));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_has_no_status_or_execution_surface() {
+    let source = include_str!("witnessed_suffix.rs");
+    let forbidden = [
+        "status: String",
+        "status: &str",
+        "string_status",
+        "execute_import",
+        "import_executor",
+        "append_local_commit",
+        "append_recorded_event",
+        "append_provenance",
+        "apply_to_worldline_state",
+        "worldline_state_mut",
+        "WorldlineRuntime",
+        "tokio::runtime",
+        "async_runtime",
+        "TcpListener",
+        "UdpSocket",
+        "socket_listener",
+    ];
+
+    for term in forbidden {
+        assert!(
+            !source.contains(term),
+            "forbidden evaluator surface: {term}"
+        );
+    }
 }

--- a/crates/warp-core/src/witnessed_suffix_tests.rs
+++ b/crates/warp-core/src/witnessed_suffix_tests.rs
@@ -4,10 +4,13 @@
 use echo_wasm_abi::kernel_port as abi;
 
 use crate::{
-    evaluate_witnessed_suffix_admission, ConflictReason, Hash, ProvenanceRef,
-    ReadingResidualPosture, WitnessedSuffixAdmissionContext, WitnessedSuffixAdmissionOutcome,
-    WitnessedSuffixAdmissionRequest, WitnessedSuffixAdmissionResponse,
-    WitnessedSuffixLocalAdmissionPosture, WitnessedSuffixShell, WorldlineId, WorldlineTick,
+    evaluate_witnessed_suffix_admission, make_node_id, make_strand_id, BaseRef, ConflictReason,
+    Hash, NodeKey, ParentMovementFootprint, ProvenanceRef, ReadingResidualPosture, SlotId,
+    StrandBasisReport, StrandDivergenceFootprint, StrandOverlapRevalidation,
+    StrandRevalidationState, WarpId, WitnessedSuffixAdmissionContext,
+    WitnessedSuffixAdmissionOutcome, WitnessedSuffixAdmissionRequest,
+    WitnessedSuffixAdmissionResponse, WitnessedSuffixLocalAdmissionPosture, WitnessedSuffixShell,
+    WorldlineId, WorldlineTick,
 };
 
 fn worldline(seed: u8) -> WorldlineId {
@@ -23,6 +26,35 @@ fn provenance_ref(seed: u8, worldline_tick: u64) -> ProvenanceRef {
         worldline_id: worldline(seed),
         worldline_tick: tick(worldline_tick),
         commit_hash: [seed.wrapping_add(1); 32],
+    }
+}
+
+fn node_slot(label: &str) -> SlotId {
+    SlotId::Node(NodeKey {
+        warp_id: WarpId([91; 32]),
+        local_id: make_node_id(label),
+    })
+}
+
+fn basis_report(realized_parent_ref: ProvenanceRef) -> StrandBasisReport {
+    let parent_anchor = provenance_ref(20, 1);
+
+    StrandBasisReport {
+        strand_id: make_strand_id("witnessed-suffix-test"),
+        parent_anchor: BaseRef {
+            source_worldline_id: parent_anchor.worldline_id,
+            fork_tick: parent_anchor.worldline_tick,
+            commit_hash: parent_anchor.commit_hash,
+            boundary_hash: [21; 32],
+            provenance_ref: parent_anchor,
+        },
+        child_worldline_id: worldline(22),
+        source_suffix_start_tick: tick(2),
+        source_suffix_end_tick: Some(tick(4)),
+        realized_parent_ref,
+        owned_divergence: StrandDivergenceFootprint::default(),
+        parent_movement: ParentMovementFootprint::default(),
+        parent_revalidation: StrandRevalidationState::AtAnchor,
     }
 }
 
@@ -369,6 +401,7 @@ fn witnessed_suffix_evaluator_conflicts_with_adverse_admission_law() {
         reason: ConflictReason::ParentFootprintOverlap,
         source_ref: provenance_ref(35, 14),
         evidence_digest: [36; 32],
+        overlap_revalidation: None,
     });
 
     let response = evaluate_witnessed_suffix_admission(&request, &context);
@@ -381,6 +414,44 @@ fn witnessed_suffix_evaluator_conflicts_with_adverse_admission_law() {
             evidence_digest,
             overlap_revalidation: None,
         } if source_ref == provenance_ref(35, 14) && evidence_digest == [36; 32]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_preserves_conflict_overlap_revalidation() {
+    let request = request();
+    let overlap_revalidation = StrandOverlapRevalidation::Conflict {
+        overlapping_slots: vec![node_slot("overlap-a"), node_slot("overlap-b")],
+    };
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Conflict {
+        reason: ConflictReason::ParentFootprintOverlap,
+        source_ref: provenance_ref(35, 14),
+        evidence_digest: [36; 32],
+        overlap_revalidation: Some(overlap_revalidation.clone()),
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        &response.outcome,
+        WitnessedSuffixAdmissionOutcome::Conflict {
+            reason: ConflictReason::ParentFootprintOverlap,
+            overlap_revalidation: Some(actual),
+            ..
+        } if actual == &overlap_revalidation
+    ));
+
+    let converted = response.to_abi();
+
+    assert!(matches!(
+        converted.outcome,
+        abi::WitnessedSuffixAdmissionOutcome::Conflict {
+            overlap_revalidation: Some(abi::SettlementOverlapRevalidation::Conflict {
+                overlapping_slot_count: 2,
+                ..
+            }),
+            ..
+        }
     ));
 }
 
@@ -399,6 +470,66 @@ fn witnessed_suffix_evaluator_classifies_against_resolved_target_basis() {
         response.outcome,
         WitnessedSuffixAdmissionOutcome::Admitted { admitted_refs, .. }
             if admitted_refs == vec![resolved_basis]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_preserves_matching_request_basis_report() {
+    let mut request = request();
+    let report = basis_report(provenance_ref(12, 9));
+    request.basis_report = Some(report.clone());
+    request.source_suffix.basis_report = Some(basis_report(provenance_ref(12, 9)));
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Admitted {
+            basis_report: Some(actual),
+            ..
+        } if actual == report
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_falls_back_to_matching_source_basis_report() {
+    let mut request = request();
+    let report = basis_report(provenance_ref(12, 9));
+    request.source_suffix.basis_report = Some(report.clone());
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Staged {
+        staged_refs: vec![provenance_ref(5, 1)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Staged {
+            basis_report: Some(actual),
+            ..
+        } if actual == report
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_stale_basis_report() {
+    let mut request = request();
+    request.basis_report = Some(basis_report(provenance_ref(99, 99)));
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        }
     ));
 }
 
@@ -546,7 +677,8 @@ fn witnessed_suffix_evaluator_obstructs_inconsistent_bounds() {
 fn witnessed_suffix_evaluator_obstructs_source_entry_outside_suffix_bounds() {
     for outside_tick in [1, 5] {
         let mut request = request();
-        request.source_suffix.source_entries = vec![provenance_ref(3, outside_tick)];
+        let offending_ref = provenance_ref(3, outside_tick);
+        request.source_suffix.source_entries = vec![offending_ref];
         let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
             admitted_refs: vec![provenance_ref(30, 10)],
         });
@@ -556,9 +688,10 @@ fn witnessed_suffix_evaluator_obstructs_source_entry_outside_suffix_bounds() {
         assert!(matches!(
             response.outcome,
             WitnessedSuffixAdmissionOutcome::Obstructed {
+                source_ref,
                 residual_posture: ReadingResidualPosture::Obstructed,
                 ..
-            }
+            } if source_ref == offending_ref
         ));
     }
 }
@@ -566,7 +699,8 @@ fn witnessed_suffix_evaluator_obstructs_source_entry_outside_suffix_bounds() {
 #[test]
 fn witnessed_suffix_evaluator_obstructs_source_entry_from_foreign_worldline() {
     let mut request = request();
-    request.source_suffix.source_entries = vec![provenance_ref(4, 3)];
+    let offending_ref = provenance_ref(4, 3);
+    request.source_suffix.source_entries = vec![offending_ref];
     let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
         admitted_refs: vec![provenance_ref(30, 10)],
     });
@@ -576,16 +710,18 @@ fn witnessed_suffix_evaluator_obstructs_source_entry_from_foreign_worldline() {
     assert!(matches!(
         response.outcome,
         WitnessedSuffixAdmissionOutcome::Obstructed {
+            source_ref,
             residual_posture: ReadingResidualPosture::Obstructed,
             ..
-        }
+        } if source_ref == offending_ref
     ));
 }
 
 #[test]
 fn witnessed_suffix_evaluator_obstructs_out_of_order_source_entries() {
     let mut request = request();
-    request.source_suffix.source_entries = vec![provenance_ref(3, 4), provenance_ref(3, 3)];
+    let offending_ref = provenance_ref(3, 3);
+    request.source_suffix.source_entries = vec![provenance_ref(3, 4), offending_ref];
     let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
         admitted_refs: vec![provenance_ref(30, 10)],
     });
@@ -595,9 +731,31 @@ fn witnessed_suffix_evaluator_obstructs_out_of_order_source_entries() {
     assert!(matches!(
         response.outcome,
         WitnessedSuffixAdmissionOutcome::Obstructed {
+            source_ref,
             residual_posture: ReadingResidualPosture::Obstructed,
             ..
-        }
+        } if source_ref == offending_ref
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_duplicate_source_entries() {
+    let mut request = request();
+    let duplicate_ref = provenance_ref(3, 3);
+    request.source_suffix.source_entries = vec![duplicate_ref, duplicate_ref];
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            source_ref,
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        } if source_ref == duplicate_ref
     ));
 }
 

--- a/crates/warp-core/src/witnessed_suffix_tests.rs
+++ b/crates/warp-core/src/witnessed_suffix_tests.rs
@@ -40,7 +40,7 @@ fn shell_with_entries(entries: Vec<ProvenanceRef>) -> WitnessedSuffixShell {
 
 fn request() -> WitnessedSuffixAdmissionRequest {
     WitnessedSuffixAdmissionRequest {
-        source_suffix: shell_with_entries(vec![provenance_ref(4, 3)]),
+        source_suffix: shell_with_entries(vec![provenance_ref(3, 3)]),
         target_worldline_id: worldline(11),
         target_basis: provenance_ref(12, 9),
         basis_report: None,
@@ -78,6 +78,29 @@ impl WitnessedSuffixAdmissionContext for FakeAdmissionContext {
     }
 }
 
+struct TargetBasisEchoAdmissionContext {
+    resolved_target_basis: ProvenanceRef,
+}
+
+impl WitnessedSuffixAdmissionContext for TargetBasisEchoAdmissionContext {
+    fn source_shell_digest(&self, _shell: &WitnessedSuffixShell) -> Option<Hash> {
+        Some([6; 32])
+    }
+
+    fn resolve_target_basis(&self, _target_basis: ProvenanceRef) -> Option<ProvenanceRef> {
+        Some(self.resolved_target_basis)
+    }
+
+    fn local_admission_posture(
+        &self,
+        request: &WitnessedSuffixAdmissionRequest,
+    ) -> WitnessedSuffixLocalAdmissionPosture {
+        WitnessedSuffixLocalAdmissionPosture::Admissible {
+            admitted_refs: vec![request.target_basis],
+        }
+    }
+}
+
 fn clean_context(posture: WitnessedSuffixLocalAdmissionPosture) -> FakeAdmissionContext {
     FakeAdmissionContext {
         expected_shell_digest: Some([6; 32]),
@@ -98,9 +121,9 @@ fn witnessed_suffix_core_request_converts_to_abi_shape() {
     assert_eq!(
         converted.source_suffix.source_entries,
         vec![abi::ProvenanceRef {
-            worldline_id: abi::WorldlineId::from_bytes([4; 32]),
+            worldline_id: abi::WorldlineId::from_bytes([3; 32]),
             worldline_tick: abi::WorldlineTick(3),
-            commit_hash: vec![5; 32],
+            commit_hash: vec![4; 32],
         }]
     );
     assert_eq!(
@@ -274,7 +297,7 @@ fn witnessed_suffix_evaluator_allows_equal_start_and_end_ticks() {
     let mut request = request();
     request.source_suffix.source_suffix_end_tick =
         Some(request.source_suffix.source_suffix_start_tick);
-    request.source_suffix.source_entries = vec![provenance_ref(4, 2)];
+    request.source_suffix.source_entries = vec![provenance_ref(3, 2)];
     let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
         admitted_refs: vec![provenance_ref(30, 10)],
     });
@@ -362,6 +385,72 @@ fn witnessed_suffix_evaluator_conflicts_with_adverse_admission_law() {
 }
 
 #[test]
+fn witnessed_suffix_evaluator_classifies_against_resolved_target_basis() {
+    let request = request();
+    let resolved_basis = provenance_ref(44, 20);
+    let context = TargetBasisEchoAdmissionContext {
+        resolved_target_basis: resolved_basis,
+    };
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert_eq!(response.target_basis, resolved_basis);
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Admitted { admitted_refs, .. }
+            if admitted_refs == vec![resolved_basis]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_normalizes_admitted_refs() {
+    let request = request();
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 12), provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Admitted { admitted_refs, .. }
+            if admitted_refs == vec![provenance_ref(30, 10), provenance_ref(30, 12)]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_normalizes_staged_refs() {
+    let request = request();
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Staged {
+        staged_refs: vec![provenance_ref(32, 12), provenance_ref(32, 11)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Staged { staged_refs, .. }
+            if staged_refs == vec![provenance_ref(32, 11), provenance_ref(32, 12)]
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_normalizes_plural_candidate_refs() {
+    let request = request();
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Plural {
+        candidate_refs: vec![provenance_ref(34, 13), provenance_ref(33, 12)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Plural { candidate_refs, .. }
+            if candidate_refs == vec![provenance_ref(33, 12), provenance_ref(34, 13)]
+    ));
+}
+
+#[test]
 fn witnessed_suffix_evaluator_obstructs_mismatched_digest() {
     let request = request();
     let context = FakeAdmissionContext {
@@ -380,6 +469,34 @@ fn witnessed_suffix_evaluator_obstructs_mismatched_digest() {
             residual_posture: ReadingResidualPosture::Obstructed,
             ..
         }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_missing_local_source_digest_without_reusing_request_digest()
+{
+    let request = request();
+    let context = FakeAdmissionContext {
+        expected_shell_digest: None,
+        resolved_target_basis: Some(provenance_ref(12, 9)),
+        posture: WitnessedSuffixLocalAdmissionPosture::Admissible {
+            admitted_refs: vec![provenance_ref(30, 10)],
+        },
+    };
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert_ne!(
+        response.source_shell_digest,
+        request.source_suffix.witness_digest
+    );
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            evidence_digest,
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        } if evidence_digest == response.source_shell_digest
     ));
 }
 
@@ -429,7 +546,7 @@ fn witnessed_suffix_evaluator_obstructs_inconsistent_bounds() {
 fn witnessed_suffix_evaluator_obstructs_source_entry_outside_suffix_bounds() {
     for outside_tick in [1, 5] {
         let mut request = request();
-        request.source_suffix.source_entries = vec![provenance_ref(4, outside_tick)];
+        request.source_suffix.source_entries = vec![provenance_ref(3, outside_tick)];
         let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
             admitted_refs: vec![provenance_ref(30, 10)],
         });
@@ -444,6 +561,44 @@ fn witnessed_suffix_evaluator_obstructs_source_entry_outside_suffix_bounds() {
             }
         ));
     }
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_source_entry_from_foreign_worldline() {
+    let mut request = request();
+    request.source_suffix.source_entries = vec![provenance_ref(4, 3)];
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_out_of_order_source_entries() {
+    let mut request = request();
+    request.source_suffix.source_entries = vec![provenance_ref(3, 4), provenance_ref(3, 3)];
+    let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+        admitted_refs: vec![provenance_ref(30, 10)],
+    });
+
+    let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+    assert!(matches!(
+        response.outcome,
+        WitnessedSuffixAdmissionOutcome::Obstructed {
+            residual_posture: ReadingResidualPosture::Obstructed,
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/warp-core/src/witnessed_suffix_tests.rs
+++ b/crates/warp-core/src/witnessed_suffix_tests.rs
@@ -274,6 +274,7 @@ fn witnessed_suffix_evaluator_allows_equal_start_and_end_ticks() {
     let mut request = request();
     request.source_suffix.source_suffix_end_tick =
         Some(request.source_suffix.source_suffix_start_tick);
+    request.source_suffix.source_entries = vec![provenance_ref(4, 2)];
     let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
         admitted_refs: vec![provenance_ref(30, 10)],
     });
@@ -422,6 +423,27 @@ fn witnessed_suffix_evaluator_obstructs_inconsistent_bounds() {
             ..
         }
     ));
+}
+
+#[test]
+fn witnessed_suffix_evaluator_obstructs_source_entry_outside_suffix_bounds() {
+    for outside_tick in [1, 5] {
+        let mut request = request();
+        request.source_suffix.source_entries = vec![provenance_ref(4, outside_tick)];
+        let context = clean_context(WitnessedSuffixLocalAdmissionPosture::Admissible {
+            admitted_refs: vec![provenance_ref(30, 10)],
+        });
+
+        let response = evaluate_witnessed_suffix_admission(&request, &context);
+
+        assert!(matches!(
+            response.outcome,
+            WitnessedSuffixAdmissionOutcome::Obstructed {
+                residual_posture: ReadingResidualPosture::Obstructed,
+                ..
+            }
+        ));
+    }
 }
 
 #[test]

--- a/docs/design/continuum-runtime-and-cas-readings.md
+++ b/docs/design/continuum-runtime-and-cas-readings.md
@@ -536,7 +536,10 @@ store, cache, index, schedule, and observe in the way that fits its purpose.
 
 ### Step 1: Keep This As Doctrine
 
-This packet only aligns Echo's mental model. It does not edit production code.
+This packet aligns Echo's mental model first. It may accompany small,
+test-backed production slices, such as the `witnessed_suffix` evaluator and
+tests, when those slices need doctrine-level determinism, hash, and canonical
+ordering guidance.
 
 ### Step 2: Audit Stale Temperature Language
 

--- a/docs/design/continuum-runtime-and-cas-readings.md
+++ b/docs/design/continuum-runtime-and-cas-readings.md
@@ -1,0 +1,636 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Echo Continuum Runtime And CAS Readings
+
+_Align Echo with the Continuum/WARP optic doctrine without making Echo
+subordinate to `git-warp` or treating cached graph-like state as substrate
+truth._
+
+Status: Design
+
+Owner: Echo / WARP runtime
+
+Scope: doctrine and implementation runway only
+
+## Hill
+
+Echo is a peer Continuum runtime implementation.
+
+Echo stores, executes, admits, observes, exports, imports, and retains
+witnessed causal history in its own runtime style. Echo may use `echo-cas`,
+indexes, checkpoints, and cached materialized readings for performance and
+revelation. Those retained or cached objects are not substrate truth.
+
+The substrate is witnessed causal history:
+
+- worldlines
+- strands
+- braids
+- ticks
+- receipts
+- frontiers
+- payload hashes
+- witnesses
+- suffixes
+- admissions
+- readings
+- retained artifacts
+
+State-like values are observer-relative readings over that history.
+
+## Doctrine Correction
+
+Older Continuum and Echo docs sometimes describe Echo as the hot side and
+`git-warp` as the cold side of one shared runtime story. That language is now
+too narrow.
+
+The corrected doctrine is:
+
+```text
+Echo is one Continuum-speaking runtime.
+git-warp is another Continuum-speaking runtime.
+Continuum is the shared protocol, contract, admission, and witness language.
+```
+
+Hot, cold, durable, low-latency, browser-hosted, offline-first, or archival are
+runtime postures. They are not protocol ontology.
+
+Echo does not produce facts for `git-warp`. Echo and `git-warp` both produce,
+admit, retain, and observe witnessed causal history. They interoperate by
+exchanging protocol-shaped causal artifacts, not by sharing runtime internals.
+
+The browser analogy is the useful one: Continuum is the shared protocol and
+contract law; Echo and `git-warp` are independent implementations with their
+own engines, caches, storage models, and developer surfaces.
+
+## Echo As A Continuum Runtime
+
+Echo owns its local runtime truth:
+
+- scheduling and deterministic execution
+- ingress and admission policy
+- worldline, strand, and braid runtime structure
+- tick admission
+- receipt creation
+- observer execution
+- retained runtime artifacts
+- `echo-cas` storage policy
+- runtime-local indexes and caches
+
+Continuum constrains Echo at the shared boundary:
+
+- shared noun meanings
+- authored contract families
+- admission outcome families
+- witnessed suffix and import/export shells
+- observer-relative reading envelopes
+- receipt and witness layering
+
+Echo should consume and publish Continuum-compatible families where the surface
+crosses repo, language, process, WASM, network, or tool boundaries. Echo should
+not flatten its internal engine shape into Continuum terms everywhere.
+
+## Echo As Deterministic Witness Engine
+
+Echo's primary product is deterministic witnessed causal transition.
+
+In older runtime language, a tick mutates state. Under the Continuum/WARP optic
+doctrine, a tick:
+
+```text
+slices causal inputs -> applies deterministic law -> emits transition ->
+witnesses what happened -> retains enough evidence
+```
+
+Echo should therefore optimize its public semantics around:
+
+- receipts
+- observers
+- apertures
+- readings
+- admissions
+- braids
+- retained witnesses
+
+Public APIs should move toward operations such as:
+
+- tick or admit a witnessed transition
+- observe through an aperture
+- read a bounded slice
+- braid or compare witnessed claims
+- retain or reveal witness-backed artifacts
+
+Low-level materialization remains useful, but it should not define the public
+ontology.
+
+## No Canonical Materialized-State Ontology
+
+Echo may keep state-like values. Echo may cache them. Echo may materialize
+them for observation, debugging, export, or recovery. The rule is naming and
+authority:
+
+- witnessed causal history is substrate truth
+- cached materialized state is a retained reading or recovery aid
+- graph-like data is an observer-relative chart over history
+- observer payloads are readings, not the runtime itself
+- checkpoints are retained bases, not universal truth objects
+
+Echo can store graph-like readings, graph-oriented indexes, and materialized
+graph caches. Those objects are legal when they are scoped to a causal basis,
+observer law, projection, and retention purpose. They are not the canonical
+graph.
+
+No public API should imply that Echo owns one canonical graph or state object
+that all observers secretly read.
+
+## echo-cas Role
+
+`echo-cas` is Echo's content-addressed retention layer. It may store:
+
+- tick receipts
+- witnessed transition records
+- payload blobs
+- witness shells
+- suffix shells
+- reading artifacts
+- checkpoint bases
+- index shards
+- cached slice readings
+- retained observer outputs
+
+The CAS hash names bytes. The semantic key names the question those bytes
+answer.
+
+That means a cached reading needs both:
+
+- a content hash for the retained artifact
+- an honest causal or optic coordinate for lookup and invalidation
+
+Example coordinate components:
+
+- runtime or history identity
+- worldline, strand, or braid identity
+- frontier or antichain basis
+- observer or optic aperture
+- read intent
+- entity or slice key
+- witness set digest or witness refs
+- reducer or admission law version
+- projection version
+- rights and budget posture
+
+`echo-cas` may retain the answer. It must not become the semantic authority for
+the question.
+
+## Cached Reading Invalidation
+
+Cached readings are immutable answers at a named basis. Echo should not mutate
+them in place.
+
+A cache entry remains valid for the coordinate, witness set, reducer version,
+projection version, and rights/budget posture it names. It is not valid for a
+new live frontier unless the lookup can prove causal containment or an
+equivalent witness relation.
+
+Invalidation is therefore mostly selection, not deletion:
+
+- a new tick creates a new frontier
+- a new suffix admission creates a new witness basis
+- a changed observer law changes the projection version
+- a changed admission or reduction law changes the reducer version
+- changed rights or budget posture changes the revelation basis
+
+Echo may garbage collect unreferenced cache blobs. That is storage policy, not
+truth revision.
+
+## Live Tail And Identity Honesty
+
+Echo has the same live-tail honesty problem as `git-warp`.
+
+If Echo has:
+
+```text
+retained checkpoint or cached reading
++ live tail of ticks, suffixes, or admissions
+```
+
+then Echo must not return the checkpoint or cached reading hash as if it
+identified the live result.
+
+Honest options are:
+
+- reduce the live tail under a bounded witness basis
+- return a read identity that names checkpoint basis plus tail witness set
+- return a slice hash or witness-set hash whose meaning is explicit
+- fail closed with an obstruction or missing-basis posture
+
+Hash names should stay precise:
+
+- `stateHash` names a full materialized state only when that is honestly what
+  was produced
+- `readIdentity` names coordinate, aperture, intent, witness basis, and
+  law/projection versions
+- `sliceHash` names the emitted bounded slice
+- `witnessSetHash` names the witnesses used
+
+No Echo API should return a global-sounding hash for an aperture-local reading
+or a stale checkpoint basis.
+
+## TickReceipt As Holographic Witness
+
+A `TickReceipt` is not just an execution log. It is the retained witness that a
+local causal transition was admitted under a specific runtime basis and law.
+
+It should be sufficient, at its intended purpose level, to support:
+
+- replay
+- audit
+- observer explanation
+- suffix export
+- import admission
+- retained reading provenance
+- future proof lowering
+
+This does not mean v17 or the next Echo slice implements IPA, SNARKs, or other
+cryptographic proof systems. It means Echo should preserve enough witness
+structure that future proof backends can lower retained holographic artifacts
+without reinterpreting runtime logs.
+
+## Holographic Boundary Artifacts
+
+Holographic witness structure should not be tick-only.
+
+Echo needs a family of witness-bearing boundary artifacts across the same
+recurring act:
+
+```text
+slice -> lower -> witness -> retain
+```
+
+Examples:
+
+- a tick slices local causal inputs and witnesses an admitted transition
+- a merge slices compatible or competing histories and witnesses what was
+  preserved, conflicted, or left plural
+- a braid slices multiple lanes or strands and witnesses the plural weave or
+  lowered reading
+- an import slices external suffix evidence and witnesses the local admission
+  outcome
+- an observation slices history through an aperture and witnesses the emitted
+  reading
+
+Names may evolve, but the layers should stay separate:
+
+- tick receipt
+- braid shell
+- merge witness
+- import shell
+- admission response
+- reading artifact
+- property certificate
+- observer receipt
+
+This packet does not require all of those product APIs now. It requires Echo
+to avoid flattening them into one runtime log or one state snapshot.
+
+## Observer And Optic API
+
+Echo reads should move toward optics over worldlines, strands, and braids.
+
+An optic read is:
+
+```text
+choose aperture -> slice causal history -> lower under law -> witness ->
+retain if needed -> emit observer-relative reading
+```
+
+The public shape should make the distinction visible:
+
+- `ObserverPlan` names the revelation discipline
+- `ObserverInstance` owns runtime observer state
+- `ReadingEnvelope` names emitted observer-relative readings
+- witness refs and residual posture explain what supports or limits the read
+
+Worldlines, strands, and braids are all lawful optic sources. They are not
+different kinds of global state object.
+
+## Bounded Replay And Reveal
+
+Bounded residency in Echo means more than avoiding a large graph
+materialization. It also means Echo should not require full worldline or
+runtime state just to answer a lawful observation, verify a local transition,
+or reveal a retained artifact.
+
+Echo should be able to ask:
+
+- which causal slice is required for this read?
+- which receipt and retained inputs are required to verify this tick?
+- which witness material justifies this property or entity reading?
+- which residual remains outside the requested aperture?
+
+Future receipts and retained artifacts should be able to point at:
+
+- read sets
+- write sets
+- affected entity or property sets
+- basis and frontier
+- payload hashes
+- retained witness handles
+- compact index hints where useful
+
+The goal is not to make every receipt huge. The goal is to make bounded replay
+and bounded reveal possible without rediscovering witness material from a full
+state scan.
+
+## Aperture-Aware Execution Semantics
+
+Observation is aperture-aware, and execution should preserve enough structure
+to make that true later.
+
+A tick, admission, import, or braid may need to distinguish:
+
+- input aperture
+- effect aperture
+- retention aperture
+- reveal aperture
+
+Those apertures enable bounded debugging, bounded replay, partial transport,
+rights-gated revelation, and local repair. They should not be collapsed into a
+single "state changed" fact.
+
+## Attachments And Recursive Optic Boundaries
+
+WARP entities may carry attachments. Some attachments may themselves descend
+into another recursive WARP.
+
+Echo should therefore treat attachments as aperture boundaries, not as bytes
+that are always loaded with the parent reading.
+
+An attachment may be:
+
+- a content blob
+- a causal artifact
+- a nested WARP coordinate
+- a retained reading
+- a receipt or witness
+- a proof-bearing artifact in a future phase
+- a foreign suffix shell
+
+Attachment descent should be explicit:
+
+```text
+observe entity -> encounter attachment -> check rights/budget/law ->
+emit nested reading or obstruction -> retain boundary witness
+```
+
+Default entity reads should return attachment references or posture, not
+silently load recursive worlds.
+
+## Admission Algebra
+
+Echo should keep admission outcomes typed and explicit:
+
+- `Admitted`
+- `Staged`
+- `Plural`
+- `Conflict`
+- `Obstructed`
+
+`Admitted` is the local successful admission posture. Continuum publication may
+also use `Derived` where the shared family vocabulary requires that word. The
+important rule is that success, staging, preserved plurality, conflict, and
+obstruction remain separate outcomes.
+
+Echo must not collapse admission into:
+
+- `Ok` versus `Err`
+- latest-writer-wins
+- boolean sync success
+- string status fields
+- hidden host-time ordering
+
+## Witnessed Suffix Evaluator Fit
+
+The witnessed suffix evaluator is an Echo-local admission classifier.
+
+It fits this doctrine because it:
+
+- evaluates one witnessed suffix request against local read-only evidence
+- returns a typed admission outcome
+- distinguishes obstruction, conflict, plurality, staging, and admission
+- does not fetch remote state
+- does not run a sync daemon
+- does not mutate worldlines or scheduler state
+- does not depend on `git-warp`
+
+In Continuum terms, the evaluator is part of import/admission law for a
+protocol-shaped causal artifact. Transport can call it later. Transport must
+not become the place where admission law is invented.
+
+## Public Optic API Versus Plumber And Debug API
+
+Echo should separate blessed reads from operational inspection.
+
+Public optic APIs:
+
+- read witnessed causal history through an aperture
+- return reading envelopes or read identities
+- surface residual, plurality, conflict, or obstruction posture
+- never hide full materialization as a fallback
+- never claim a cached reading is substrate truth
+
+Plumber and debug APIs:
+
+- may inspect caches
+- may create or repair indexes
+- may prewarm retained readings
+- may export diagnostic materializations
+- may run expensive validation
+- must be named as operational work
+
+The rule is:
+
+```text
+Optic observes.
+Plumber maintains.
+Debug explains.
+```
+
+A Plumber or debug operation must not become a hidden fallback for a public
+optic read.
+
+## Avoid Host-Bag Abstractions
+
+Echo should not respond to this doctrine by adding a giant generic runtime bag.
+
+Avoid broad names and helper surfaces that hide the law:
+
+- `RuntimeFacade`
+- `ObservationManager`
+- `GraphLikeRuntimeAdapter`
+- `SyncHostContext`
+- `UniversalMaterializer`
+
+Prefer small typed surfaces whose names expose the layer:
+
+- admission
+- observation
+- reading
+- witness
+- retention
+- braid
+- plurality
+- obstruction
+
+The goal is not abstraction volume. The goal is making the causal law
+inspectable.
+
+## LWW Posture
+
+Last-write-wins is allowed only as a projection or admissibility law for a
+specific observer reading where that law is named.
+
+LWW is not substrate truth.
+
+In Echo terms:
+
+- witnessed facts remain retained
+- conflicting or plural facts remain inspectable
+- an observer may lower a property reading with an LWW-style projection
+- the projection must not erase the causal evidence that made plurality or
+  conflict possible
+
+One-line rule:
+
+```text
+LWW is a lens, not reality.
+```
+
+## Continuum Interoperability
+
+Echo and `git-warp` interoperate by exchanging Continuum-shaped causal
+artifacts:
+
+- suffix shells
+- receipts
+- witness refs
+- payload refs
+- frontier identities
+- admission outcomes
+- reading envelopes where appropriate
+
+They do not exchange:
+
+- runtime internals
+- scheduler state
+- `echo-cas` implementation details
+- Git implementation details
+- private graph caches
+- materialized state as canonical truth
+
+The shared law is witnessed causal admission. Each runtime remains free to
+store, cache, index, schedule, and observe in the way that fits its purpose.
+
+## Implementation Runway
+
+### Step 1: Keep This As Doctrine
+
+This packet only aligns Echo's mental model. It does not edit production code.
+
+### Step 2: Audit Stale Temperature Language
+
+Later doc work should update older Echo and Continuum wording that assigns Echo
+and `git-warp` fixed hot/cold half-roles.
+
+Replace that framing with sibling Continuum runtimes and optional runtime
+posture.
+
+### Step 3: Tie Suffix Admission To Continuum Families
+
+The witnessed suffix evaluator should stay local, but its input and output
+shape should remain mappable to Continuum suffix/import families.
+
+Do not add transport until admission law remains boring and tested.
+
+### Step 4: Define CAS Reading Keys
+
+A future RED slice should define the smallest honest cache-key structure for
+retained readings:
+
+- coordinate
+- aperture
+- intent
+- witness basis
+- reducer version
+- projection version
+- posture fields
+- content hash
+
+Do not make `echo-cas` responsible for ontology.
+
+### Step 5: Define Live-Tail Reading Identity
+
+Before returning hashes for live readings, Echo should define how a reading
+names checkpoint basis plus live tail witnesses. If that basis cannot be named
+honestly, the read must fail closed or return an obstructed posture.
+
+### Step 6: Add Optic APIs Only When Bounded Reads Are Clear
+
+Do not add a broad public optic surface until Echo can name:
+
+- the causal basis read
+- the witness basis retained
+- the projection law used
+- the invalidation rule for any cached reading
+- the failure posture when evidence is missing
+
+### Step 7: Keep Recursive Attachments Explicit
+
+Future attachment work should expose attachment refs and recursive aperture
+descent explicitly. It should not make default entity reads load attachment
+bodies or nested WARP readings.
+
+## Non-Goals
+
+This design does not include:
+
+- a `git-warp` dependency
+- a sync daemon
+- a global graph API
+- a global state API
+- a universal runtime facade
+- proof or IPA implementation
+- full Continuum wire protocol implementation
+- ABI redesign unless required by RED tests
+- storage engine replacement
+- full cache eviction policy
+- hidden materialization fallback
+- broad host-bag runtime abstraction
+- implicit recursive attachment loading
+
+## Acceptance Criteria For Future Slices
+
+Future implementation slices should prove:
+
+- Echo optic reads name their causal basis
+- cached readings name their witness basis and projection law
+- live-tail readings do not reuse stale checkpoint hashes
+- missing evidence fails closed
+- suffix admission remains typed and local
+- attachments are revealed by explicit aperture descent
+- no public read API treats cached state as substrate truth
+- no API makes Echo subordinate to `git-warp`
+- Plumber/debug operations are explicit and not hidden read fallbacks
+
+## Practical Rule
+
+When adding Echo runtime surface area, ask:
+
+- Is this witnessed causal history?
+- Is this an observer-relative reading?
+- Is this a retained shell?
+- Is this a cache or index for performance?
+- Is this a Plumber/debug operation?
+
+If the answer is unclear, split the type before shipping it.

--- a/docs/design/witnessed-suffix-admission-evaluator.md
+++ b/docs/design/witnessed-suffix-admission-evaluator.md
@@ -173,7 +173,8 @@ boundaries.
 
 The evaluator must keep failure categories separate:
 
-- impossible or invalid DTO shape fails during construction or decode
+- impossible or invalid ABI DTO shape fails during ABI decode; plain Rust
+  struct construction remains permissive and is checked by evaluator validation
 - well-formed requests with unverifiable local evidence evaluate to `Obstructed`
 - well-formed requests with deterministic adverse admission law evaluate to
   `Conflict`
@@ -188,7 +189,8 @@ Initial classification shape:
 
 - source shell identity is valid
 - target basis resolves locally
-- source suffix entries are present and ordered
+- source suffix entries are present, on the source worldline, and canonical
+  ordered
 - basis evidence is clean or absent because no basis drift is involved
 - no conflict or obstruction evidence is found
 
@@ -282,15 +284,20 @@ admission, staging, or plurality decision from local evidence.
 - request with compact conflict evidence evaluates to `Conflict`
 - request with unavailable target basis evaluates to `Obstructed`
 - every evaluator response converts to the existing ABI response shape
-- every evaluator response carries the original source shell digest and resolved
-  target basis
+- every evaluator response carries the locally verified source shell digest and
+  resolved target basis; if local digest evidence is missing, obstruction uses
+  a local obstruction digest instead of the caller-provided witness digest
 
 ### Known Failure Tests
 
-- malformed or impossible request DTO shape fails during construction or decode
+- malformed or impossible request DTO shape fails during ABI decode
 - request with mismatched source shell digest evaluates to `Obstructed`
 - request with inconsistent suffix tick bounds returns `Obstructed`
 - request with source entries outside suffix bounds returns `Obstructed`
+- request with source entries from a foreign worldline returns `Obstructed`
+- request with out-of-order source entries returns `Obstructed`
+- request with missing local source digest does not reuse the caller-provided
+  witness digest as evidence
 - request with unknown target basis returns `Obstructed`
 - response construction cannot produce zero outcomes
 - response construction cannot produce multiple top-level outcomes
@@ -389,7 +396,9 @@ Expected implementation:
 - validate digest posture
 - validate boundary witness or entry presence
 - validate target basis availability through local context
-- fail impossible DTO shapes during construction or decode
+- fail impossible DTO shapes during ABI decode
+- validate plain Rust request values inside the evaluator before local posture
+  classification
 - classify well-formed but unverifiable local evidence as obstruction
 - classify deterministic adverse admission law as conflict
 

--- a/docs/design/witnessed-suffix-admission-evaluator.md
+++ b/docs/design/witnessed-suffix-admission-evaluator.md
@@ -171,6 +171,15 @@ boundaries.
 
 ## Outcome Classification
 
+The evaluator must keep failure categories separate:
+
+- impossible or invalid DTO shape fails during construction or decode
+- well-formed requests with unverifiable local evidence evaluate to `Obstructed`
+- well-formed requests with deterministic adverse admission law evaluate to
+  `Conflict`
+
+That split keeps `Obstructed` from becoming a catch-all failure bucket.
+
 ### `Admitted`
 
 Use `Admitted` when the suffix is locally admissible on the target basis.
@@ -278,8 +287,8 @@ admission, staging, or plurality decision from local evidence.
 
 ### Known Failure Tests
 
-- request with mismatched source shell digest returns `Obstructed` or rejects
-  before classification, depending on the final error posture
+- malformed or impossible request DTO shape fails during construction or decode
+- request with mismatched source shell digest evaluates to `Obstructed`
 - request with inconsistent suffix tick bounds returns `Obstructed`
 - request with source entries outside suffix bounds returns `Obstructed`
 - request with unknown target basis returns `Obstructed`
@@ -380,8 +389,9 @@ Expected implementation:
 - validate digest posture
 - validate boundary witness or entry presence
 - validate target basis availability through local context
-- classify invalid local evidence as obstruction unless the RED tests require a
-  typed construction error
+- fail impossible DTO shapes during construction or decode
+- classify well-formed but unverifiable local evidence as obstruction
+- classify deterministic adverse admission law as conflict
 
 ### GREEN 3
 

--- a/docs/design/witnessed-suffix-admission-evaluator.md
+++ b/docs/design/witnessed-suffix-admission-evaluator.md
@@ -189,8 +189,8 @@ Initial classification shape:
 
 - source shell identity is valid
 - target basis resolves locally
-- source suffix entries are present, on the source worldline, and canonical
-  ordered
+- source suffix entries are present, on the source worldline, distinct, and
+  canonical ordered
 - basis evidence is clean or absent because no basis drift is involved
 - no conflict or obstruction evidence is found
 
@@ -296,8 +296,10 @@ admission, staging, or plurality decision from local evidence.
 - request with source entries outside suffix bounds returns `Obstructed`
 - request with source entries from a foreign worldline returns `Obstructed`
 - request with out-of-order source entries returns `Obstructed`
+- request with duplicate source entries returns `Obstructed`
 - request with missing local source digest does not reuse the caller-provided
   witness digest as evidence
+- request with stale basis evidence returns `Obstructed`
 - request with unknown target basis returns `Obstructed`
 - response construction cannot produce zero outcomes
 - response construction cannot produce multiple top-level outcomes
@@ -313,6 +315,8 @@ admission, staging, or plurality decision from local evidence.
 - suffix with target basis equal to its boundary witness
 - conflict outcome with clean overlap revalidation absent
 - conflict outcome with conflicting overlap revalidation present
+- admitted, staged, and plural outcomes with basis evidence that matches the
+  resolved target basis
 - plural outcome with `ReadingResidualPosture::PluralityPreserved`
 - obstruction outcome with `ReadingResidualPosture::Obstructed`
 

--- a/docs/method/backlog/inbox/PLATFORM_witnessed-suffix-admission-hardening.md
+++ b/docs/method/backlog/inbox/PLATFORM_witnessed-suffix-admission-hardening.md
@@ -1,0 +1,73 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Witnessed suffix admission hardening
+
+Status: inbox.
+
+Source: PR #323 retrospective follow-up.
+
+## Why now
+
+PR #323 hardened the witnessed suffix local admission evaluator around
+deterministic posture output, canonical source entries, resolved-basis
+classification, and missing local digest evidence.
+
+Those fixes should not turn into a wider PR-review workstream, but the review
+left useful backlog fuel. Future call sites may construct
+`WitnessedSuffixLocalAdmissionPosture` outside the current tests. Obstruction
+digest domains may grow beyond the local evaluator family. Other
+admission-shaped responses may still expose caller-order leakage at an ABI
+boundary. Test fixtures that look clean can also accidentally encode malformed
+causal coordinates.
+
+This card captures that follow-up work without reopening the current evaluator
+scope.
+
+## What it should look like
+
+- Add canonical constructors or validation helpers for
+  `WitnessedSuffixLocalAdmissionPosture` before additional call sites build
+  postures directly.
+- Add an explicit design paragraph for canonical source suffix invariants:
+    - every source entry belongs to the shell source worldline
+    - provenance refs are in canonical order
+    - entries sit inside the claimed suffix bounds
+    - the suffix carries either witness-backed entries or boundary witness
+      evidence sufficient for an honest obstruction
+- Document obstruction digest domains and how their domain/version strings
+  relate to future Continuum evidence hashes.
+- Audit admission and settlement response vectors for ABI-visible caller-order
+  leakage.
+- Strengthen fixture discipline so positive "clean" fixtures cannot encode
+  malformed causal coordinates by accident. Malformed coordinates should appear
+  only in negative tests that name the invariant they violate.
+
+## Done looks like
+
+- Posture construction has a named canonical path, or direct construction is
+  intentionally constrained and documented.
+- The witnessed suffix design docs name the canonical source suffix invariants
+  explicitly.
+- Obstruction digest domain/version policy is documented before more digest
+  families appear.
+- ABI-visible admission and settlement vectors are audited, with canonicalized
+  vectors fixed or caller-law ordering documented.
+- Test fixture helpers make valid causal coordinates the default.
+
+## Repo evidence
+
+- `crates/warp-core/src/witnessed_suffix.rs`
+- `crates/warp-core/src/witnessed_suffix_tests.rs`
+- `crates/echo-wasm-abi/src/witnessed_suffix_tests.rs`
+- `docs/design/witnessed-suffix-admission-evaluator.md`
+- `docs/design/continuum-runtime-and-cas-readings.md`
+- PR #323: `https://github.com/flyingrobots/echo/pull/323`
+
+## Non-goals
+
+- Do not reopen PR #323's evaluator implementation without a new RED.
+- Do not redesign the witnessed suffix ABI.
+- Do not add Continuum proof, IPA, or commitment machinery.
+- Do not change transport, sync, or import execution behavior.
+- Do not weaken the evaluator's existing obstruction posture.


### PR DESCRIPTION
## Summary

Adds a local, read-only witnessed suffix admission evaluator for `warp-core` and keeps the surface deliberately narrow.

- Introduces the `WitnessedSuffixAdmissionContext` contract and local admission posture so the evaluator can classify local evidence without transport, sync, peer identity, daemon behavior, async runtime, host bags, or ABI redesign.
- Classifies typed outcomes as `Admitted`, `Staged`, `Plural`, `Conflict`, or `Obstructed` rather than string statuses or side effects.
- Preserves obstruction for missing or unverifiable local evidence, mismatched source shell digest, unknown target basis, inconsistent suffix bounds, empty suffixes without boundary witness material, and source entries outside declared suffix bounds.
- Keeps ABI witnessed suffix request/response coverage green while adding evaluator edge and non-goal guard coverage.
- Adds `docs/design/continuum-runtime-and-cas-readings.md` to clarify Echo as a peer Continuum runtime and cached materialized readings as observer-relative artifacts over witnessed causal history.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p warp-core --lib witnessed_suffix` — 19 passed
- `cargo test -p echo-wasm-abi --lib witnessed_suffix` — 15 passed
- `cargo clippy -p warp-core --all-targets -- -D warnings -D missing_docs`
- `pnpm docs:build`
- Push hook passed its docs-only focused Prettier check for the final doctrine commit.

`pnpm docs:build` passed with the existing local engine warning: this shell is using Node `v25.9.0`, while `package.json` declares `>=18 <25`.

## Notes

Overlap revalidation remains intentionally out of scope. That is a separate API-shape decision.