### PR TITLE
test(wasm): own package export smoke boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,31 @@ jobs:
                   set -euo pipefail
                   bash scripts/tests/check_task_lists_test.sh
 
+    wasm-package-boundary:
+        name: WASM Package Boundary
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: false
+            - uses: dtolnay/rust-toolchain@1.90.0
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  workspaces: |
+                      .
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+            - name: Install wasm32 target
+              run: rustup target add wasm32-unknown-unknown
+            - name: Install wasm-pack
+              run: cargo install wasm-pack --version 0.14.0 --locked
+            - name: WASM package export smoke test
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  bash scripts/tests/warp_wasm_package_exports_test.sh
+
     man-pages:
         name: Man Pages Freshness
         runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ### Added
 
+- Echo-owned WASM package boundary tooling: `scripts/build-warp-wasm-package.sh`
+  now builds `crates/warp-wasm/pkg` with the bundler target and the package
+  export smoke test imports `pkg/rmg_wasm.js` to verify the JavaScript byte ABI
+  surface expected by consumers.
 - Stack Witness 0001 drift lock — `warp-wasm` now mirrors Wesley's fixture
   vectors for the jedit-through-Echo walking skeleton and verifies Echo's
   fixture op ids, buffer-inclusive fixture vars bytes, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   now builds `crates/warp-wasm/pkg` with the bundler target and the package
   export smoke test imports `pkg/rmg_wasm.js` to verify the JavaScript byte ABI
   surface expected by consumers.
+- The WASM package export smoke test now runs through
+  `scripts/tests/warp_wasm_package_exports_test.sh`, which rebuilds the package
+  before importing it so the export witness cannot pass against a stale package.
 - Stack Witness 0001 drift lock — `warp-wasm` now mirrors Wesley's fixture
   vectors for the jedit-through-Echo walking skeleton and verifies Echo's
   fixture op ids, buffer-inclusive fixture vars bytes, the

--- a/crates/warp-wasm/README.md
+++ b/crates/warp-wasm/README.md
@@ -28,6 +28,33 @@ See the repository root `README.md` for the full overview.
 - Intended to power future browser-based visualizers and inspectors built on
   top of the same core engine as native tools.
 
+## Package boundary
+
+Echo owns the WASM package build ritual for downstream consumers. Build the
+bundler package with:
+
+```sh
+scripts/build-warp-wasm-package.sh
+```
+
+The command refreshes `crates/warp-wasm/pkg` with:
+
+```sh
+wasm-pack build --target bundler --out-dir pkg --out-name rmg_wasm -- --features engine
+```
+
+The package export smoke test imports `crates/warp-wasm/pkg/rmg_wasm.js` and
+asserts the byte ABI export surface:
+
+```sh
+node --test scripts/tests/warp_wasm_package_exports_test.mjs
+```
+
+Consumer-facing app code should not depend on Echo's internal default
+worldline. Durable app integration should route through optic-owned basis
+resolution; raw worldline coordinates remain substrate/debug evidence, not a
+product contract.
+
 ## Documentation
 
 - Echo runtime model: `docs/architecture/outline.md`.

--- a/crates/warp-wasm/README.md
+++ b/crates/warp-wasm/README.md
@@ -47,7 +47,7 @@ The package export smoke test imports `crates/warp-wasm/pkg/rmg_wasm.js` and
 asserts the byte ABI export surface:
 
 ```sh
-node --test scripts/tests/warp_wasm_package_exports_test.mjs
+scripts/tests/warp_wasm_package_exports_test.sh
 ```
 
 Consumer-facing app code should not depend on Echo's internal default

--- a/scripts/build-warp-wasm-package.sh
+++ b/scripts/build-warp-wasm-package.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WARP_WASM_DIR="${WARP_WASM_DIR:-${REPO_ROOT}/crates/warp-wasm}"
+
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  echo "error: wasm-pack is required to build crates/warp-wasm/pkg" >&2
+  exit 127
+fi
+
+cd "${WARP_WASM_DIR}"
+wasm-pack build --target bundler --out-dir pkg --out-name rmg_wasm -- --features engine

--- a/scripts/tests/warp_wasm_package_exports_test.mjs
+++ b/scripts/tests/warp_wasm_package_exports_test.mjs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const WARP_WASM_MODULE_PATH = path.join(REPO_ROOT, 'crates', 'warp-wasm', 'pkg', 'rmg_wasm.js');
+
+const REQUIRED_BYTE_ABI_EXPORTS = Object.freeze([
+  'init',
+  'dispatch_intent',
+  'observe',
+  'scheduler_status',
+  'get_codec_id',
+  'get_registry_version',
+  'get_schema_sha256_hex',
+]);
+
+test('warp-wasm bundler package exports the byte ABI surface', async () => {
+  const module = await importWarpWasmPackage();
+
+  for (const exportName of REQUIRED_BYTE_ABI_EXPORTS) {
+    assert.equal(
+      typeof module[exportName],
+      'function',
+      `expected pkg/rmg_wasm.js to export ${exportName}`,
+    );
+  }
+});
+
+async function importWarpWasmPackage() {
+  try {
+    return await import(pathToFileURL(WARP_WASM_MODULE_PATH).href);
+  } catch (cause) {
+    throw new Error(
+      `${WARP_WASM_MODULE_PATH} is not importable; run scripts/build-warp-wasm-package.sh first`,
+      { cause },
+    );
+  }
+}

--- a/scripts/tests/warp_wasm_package_exports_test.sh
+++ b/scripts/tests/warp_wasm_package_exports_test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+scripts/build-warp-wasm-package.sh
+node --test scripts/tests/warp_wasm_package_exports_test.mjs


### PR DESCRIPTION
## Summary
Adds an Echo-owned WASM package boundary smoke test and build command.

This PR makes Echo own the package ritual for `crates/warp-wasm/pkg` instead of requiring downstream consumers to know the exact `wasm-pack` invocation.

## What changed
- Adds `scripts/build-warp-wasm-package.sh` as the canonical local bundler package build command.
- Adds `scripts/tests/warp_wasm_package_exports_test.mjs` to import `crates/warp-wasm/pkg/rmg_wasm.js` and assert the JS byte ABI export surface.
- Documents that raw worldline coordinates are substrate/debug evidence, not the durable app boundary.

## Export surface asserted
- `init`
- `dispatch_intent`
- `observe`
- `scheduler_status`
- `get_codec_id`
- `get_registry_version`
- `get_schema_sha256_hex`

## Not included
- No `default_worldline_id` export.
- No jedit changes.
- No Continuum changes.
- No publishing.

## Verification
```text
scripts/build-warp-wasm-package.sh
node --test scripts/tests/warp_wasm_package_exports_test.mjs
cargo test -p warp-wasm --features engine --lib
scripts/ban-nondeterminism.sh
cargo test -p warp-wasm --features engine stack_witness_ --lib
cargo test -p warp-wasm --features engine default_worldline --lib
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog and README with end-user guidance for building and validating the WASM package boundary.

* **Tests**
  * Added an automated smoke test that validates the generated WASM module’s JavaScript export surface.

* **Chores**
  * Added an automated build entrypoint for producing the WASM bundler package and a CI job to run the export smoke test.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/echo/pull/330)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->