### PR TITLE
feat(core): add optic admission ticket obstruction model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   presentations still obstruct until real grant validation exists. The
   registration and invocation regression fixtures avoid `expect(...)` so
   all-target Clippy remains clean.
+- Optic invocation obstruction now returns a ticket-shaped pre-admission
+  posture carrying the invocation handle, operation id, canonical variables
+  digest, basis request, aperture request, and structured obstruction reason.
+  This is not a success ticket and does not authorize execution.
 - Echo-owned WASM package boundary tooling: `scripts/build-warp-wasm-package.sh`
   now builds `crates/warp-wasm/pkg` with the bundler target and the package
   export smoke test imports `crates/warp-wasm/pkg/rmg_wasm.js` to verify the

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -248,11 +248,11 @@ pub use optic::{
     StagedIntent, StagedIntentReason, WitnessBasis, WorldlineHeadOptic,
 };
 pub use optic_artifact::{
-    OpticAdmissionRequirements, OpticApertureRequest, OpticArtifact, OpticArtifactHandle,
-    OpticArtifactOperation, OpticArtifactRegistrationError, OpticArtifactRegistry,
-    OpticBasisRequest, OpticCapabilityPresentation, OpticInvocation,
+    OpticAdmissionRequirements, OpticAdmissionTicketPosture, OpticApertureRequest, OpticArtifact,
+    OpticArtifactHandle, OpticArtifactOperation, OpticArtifactRegistrationError,
+    OpticArtifactRegistry, OpticBasisRequest, OpticCapabilityPresentation, OpticInvocation,
     OpticInvocationAdmissionOutcome, OpticInvocationObstruction, OpticRegistrationDescriptor,
-    RegisteredOpticArtifact, OPTIC_ARTIFACT_HANDLE_KIND,
+    RegisteredOpticArtifact, OPTIC_ADMISSION_TICKET_POSTURE_KIND, OPTIC_ARTIFACT_HANDLE_KIND,
 };
 pub use playback::{CursorReceipt, TruthFrame, TruthSink};
 pub use provenance_store::{

--- a/crates/warp-core/src/optic_artifact.rs
+++ b/crates/warp-core/src/optic_artifact.rs
@@ -4,9 +4,9 @@
 //!
 //! This module owns optic artifact registration and the first admission-only
 //! invocation gate. [`OpticArtifactRegistry::admit_optic_invocation`] resolves
-//! handles internally, checks operation identity, and obstructs missing or
-//! placeholder authority without validating grants, issuing admission tickets,
-//! emitting law witnesses, or executing runtime work.
+//! handles internally, checks operation identity, and reports obstruction in a
+//! ticket-shaped pre-admission posture without validating grants, issuing
+//! success tickets, emitting law witnesses, or executing runtime work.
 
 use std::collections::BTreeMap;
 
@@ -14,6 +14,9 @@ use thiserror::Error;
 
 /// Echo-owned handle kind for registered optic artifacts.
 pub const OPTIC_ARTIFACT_HANDLE_KIND: &str = "optic-artifact-handle";
+
+/// Echo-owned kind for a ticket-shaped pre-admission obstruction posture.
+pub const OPTIC_ADMISSION_TICKET_POSTURE_KIND: &str = "optic-admission-ticket-posture";
 
 const OPTIC_ARTIFACT_HANDLE_ID_PREFIX: &str = "optic-artifact-handle:";
 
@@ -160,12 +163,36 @@ pub enum OpticInvocationObstruction {
     CapabilityValidationUnavailable,
 }
 
+/// Ticket-shaped pre-admission posture for an obstructed optic invocation.
+///
+/// This is not a successful admission ticket and does not authorize runtime
+/// execution. It carries enough invocation context for callers and later
+/// witness code to explain why Echo obstructed before grant validation exists.
+#[must_use = "optic admission ticket postures explain obstructions that must be handled"]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OpticAdmissionTicketPosture {
+    /// Stable discriminator for callers and wire adapters.
+    pub kind: String,
+    /// Echo-owned runtime-local artifact handle used by the invocation.
+    pub artifact_handle: OpticArtifactHandle,
+    /// Operation id the caller requested.
+    pub operation_id: String,
+    /// Digest of canonical invocation variable bytes.
+    pub canonical_variables_digest: Vec<u8>,
+    /// Requested causal basis for the invocation.
+    pub basis_request: OpticBasisRequest,
+    /// Requested aperture for the invocation.
+    pub aperture_request: OpticApertureRequest,
+    /// Structured reason Echo obstructed before runtime execution.
+    pub obstruction: OpticInvocationObstruction,
+}
+
 /// Admission outcome for a v0 optic invocation skeleton.
 #[must_use = "optic invocation admission outcomes carry obstructions that must be handled"]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OpticInvocationAdmissionOutcome {
-    /// Echo obstructed the invocation before runtime execution.
-    Obstructed(OpticInvocationObstruction),
+    /// Echo obstructed the invocation before issuing any success ticket.
+    Obstructed(OpticAdmissionTicketPosture),
 }
 
 /// Registration and lookup errors for Echo optic artifact handles.
@@ -255,33 +282,53 @@ impl OpticArtifactRegistry {
     /// Admits or obstructs an invocation against a registered optic artifact.
     ///
     /// This v0 skeleton intentionally has no success path. It proves that Echo
-    /// resolves handles internally and that a registered handle is not authority.
+    /// resolves handles internally, that a registered handle is not authority,
+    /// and that obstruction is reported as a structured pre-ticket posture.
     #[must_use = "optic invocation admission outcomes carry obstructions that must be handled"]
     pub fn admit_optic_invocation(
         &self,
         invocation: &OpticInvocation,
     ) -> OpticInvocationAdmissionOutcome {
         let Ok(registered) = self.resolve_optic_artifact_handle(&invocation.artifact_handle) else {
-            return OpticInvocationAdmissionOutcome::Obstructed(
+            return Self::obstructed_invocation(
+                invocation,
                 OpticInvocationObstruction::UnknownHandle,
             );
         };
 
         if invocation.operation_id != registered.operation_id {
-            return OpticInvocationAdmissionOutcome::Obstructed(
+            return Self::obstructed_invocation(
+                invocation,
                 OpticInvocationObstruction::OperationMismatch,
             );
         }
 
         if invocation.capability_presentation.is_none() {
-            return OpticInvocationAdmissionOutcome::Obstructed(
+            return Self::obstructed_invocation(
+                invocation,
                 OpticInvocationObstruction::MissingCapability,
             );
         }
 
-        OpticInvocationAdmissionOutcome::Obstructed(
+        Self::obstructed_invocation(
+            invocation,
             OpticInvocationObstruction::CapabilityValidationUnavailable,
         )
+    }
+
+    fn obstructed_invocation(
+        invocation: &OpticInvocation,
+        obstruction: OpticInvocationObstruction,
+    ) -> OpticInvocationAdmissionOutcome {
+        OpticInvocationAdmissionOutcome::Obstructed(OpticAdmissionTicketPosture {
+            kind: OPTIC_ADMISSION_TICKET_POSTURE_KIND.to_owned(),
+            artifact_handle: invocation.artifact_handle.clone(),
+            operation_id: invocation.operation_id.clone(),
+            canonical_variables_digest: invocation.canonical_variables_digest.clone(),
+            basis_request: invocation.basis_request.clone(),
+            aperture_request: invocation.aperture_request.clone(),
+            obstruction,
+        })
     }
 
     /// Returns the number of registered artifacts.

--- a/crates/warp-core/tests/optic_invocation_admission_tests.rs
+++ b/crates/warp-core/tests/optic_invocation_admission_tests.rs
@@ -3,10 +3,10 @@
 //! Regression tests for optic invocation admission obstruction.
 
 use warp_core::{
-    OpticAdmissionRequirements, OpticApertureRequest, OpticArtifact, OpticArtifactHandle,
-    OpticArtifactOperation, OpticArtifactRegistry, OpticBasisRequest, OpticCapabilityPresentation,
-    OpticInvocation, OpticInvocationAdmissionOutcome, OpticInvocationObstruction,
-    OpticRegistrationDescriptor,
+    OpticAdmissionRequirements, OpticAdmissionTicketPosture, OpticApertureRequest, OpticArtifact,
+    OpticArtifactHandle, OpticArtifactOperation, OpticArtifactRegistry, OpticBasisRequest,
+    OpticCapabilityPresentation, OpticInvocation, OpticInvocationAdmissionOutcome,
+    OpticInvocationObstruction, OpticRegistrationDescriptor, OPTIC_ADMISSION_TICKET_POSTURE_KIND,
 };
 
 fn fixture_artifact() -> OpticArtifact {
@@ -57,6 +57,21 @@ fn fixture_invocation(handle: OpticArtifactHandle) -> OpticInvocation {
     }
 }
 
+fn expected_obstructed_posture(
+    invocation: &OpticInvocation,
+    obstruction: OpticInvocationObstruction,
+) -> OpticInvocationAdmissionOutcome {
+    OpticInvocationAdmissionOutcome::Obstructed(OpticAdmissionTicketPosture {
+        kind: OPTIC_ADMISSION_TICKET_POSTURE_KIND.to_owned(),
+        artifact_handle: invocation.artifact_handle.clone(),
+        operation_id: invocation.operation_id.clone(),
+        canonical_variables_digest: invocation.canonical_variables_digest.clone(),
+        basis_request: invocation.basis_request.clone(),
+        aperture_request: invocation.aperture_request.clone(),
+        obstruction,
+    })
+}
+
 #[test]
 fn optic_invocation_obstructs_unknown_handle() {
     let registry = OpticArtifactRegistry::new();
@@ -69,7 +84,7 @@ fn optic_invocation_obstructs_unknown_handle() {
 
     assert_eq!(
         outcome,
-        OpticInvocationAdmissionOutcome::Obstructed(OpticInvocationObstruction::UnknownHandle)
+        expected_obstructed_posture(&invocation, OpticInvocationObstruction::UnknownHandle)
     );
 }
 
@@ -83,7 +98,7 @@ fn optic_invocation_obstructs_operation_mismatch() -> Result<(), String> {
 
     assert_eq!(
         outcome,
-        OpticInvocationAdmissionOutcome::Obstructed(OpticInvocationObstruction::OperationMismatch)
+        expected_obstructed_posture(&invocation, OpticInvocationObstruction::OperationMismatch)
     );
     Ok(())
 }
@@ -97,7 +112,7 @@ fn optic_invocation_obstructs_missing_capability_for_registered_handle() -> Resu
 
     assert_eq!(
         outcome,
-        OpticInvocationAdmissionOutcome::Obstructed(OpticInvocationObstruction::MissingCapability)
+        expected_obstructed_posture(&invocation, OpticInvocationObstruction::MissingCapability)
     );
     Ok(())
 }
@@ -115,7 +130,8 @@ fn optic_invocation_obstructs_placeholder_capability_presentation_until_grant_va
 
     assert_eq!(
         outcome,
-        OpticInvocationAdmissionOutcome::Obstructed(
+        expected_obstructed_posture(
+            &invocation,
             OpticInvocationObstruction::CapabilityValidationUnavailable
         )
     );


### PR DESCRIPTION
## Summary
Adds the next Echo-side lawful optic admission boundary: invocation obstruction is now reported as a ticket-shaped pre-admission posture.

This PR preserves the existing no-success-path rule. Echo still obstructs unknown handles, operation mismatches, missing capability presentation, and placeholder capability presentation. The change is that each obstruction now carries structured invocation context:
- artifact handle
- requested operation id
- canonical variables digest
- basis request
- aperture request
- obstruction reason

## What this is
- A structured pre-ticket posture for explaining admission refusal
- A narrow bridge toward future AdmissionTicket / LawWitness work
- Executable proof that refusal is explainable without granting authority

## What this is not
- Not a successful AdmissionTicket
- Not CapabilityGrant validation
- Not CapabilityPresentation validation
- Not runtime execution
- Not scheduler integration
- Not WASM ABI
- Not app nouns
- Not Continuum schema publication

## Verification
RED:

```text
cargo test -p warp-core optic_invocation
```

Failed before implementation because `OpticAdmissionTicketPosture` and `OPTIC_ADMISSION_TICKET_POSTURE_KIND` did not exist.

GREEN / VERIFY:

```text
cargo test -p warp-core optic_invocation
cargo test -p warp-core optic_artifact_registry
cargo check -p warp-core
scripts/ban-nondeterminism.sh
git diff --check
```

Push gate also passed:

```text
fmt
guards
clippy-core
tests-warp-core
rustdoc
```
