### PR TITLE
feat(core): add capability presentation obstruction boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   posture carrying the invocation handle, operation id, canonical variables
   digest, basis request, aperture request, and structured obstruction reason.
   This is not a success ticket and does not authorize execution.
+- Optic invocation admission now classifies capability presentation obstruction
+  without validating grants: missing, malformed, unbound, and placeholder
+  presentations all remain obstructed until real bounded grant validation
+  exists.
 - Echo-owned WASM package boundary tooling: `scripts/build-warp-wasm-package.sh`
   now builds `crates/warp-wasm/pkg` with the bundler target and the package
   export smoke test imports `crates/warp-wasm/pkg/rmg_wasm.js` to verify the

--- a/crates/warp-core/src/optic_artifact.rs
+++ b/crates/warp-core/src/optic_artifact.rs
@@ -6,7 +6,9 @@
 //! invocation gate. [`OpticArtifactRegistry::admit_optic_invocation`] resolves
 //! handles internally, checks operation identity, and reports obstruction in a
 //! ticket-shaped pre-admission posture without validating grants, issuing
-//! success tickets, emitting law witnesses, or executing runtime work.
+//! success tickets, emitting law witnesses, or executing runtime work. A
+//! capability presentation slot is not authority; every presentation posture
+//! obstructs until Echo can validate a real bounded grant.
 
 use std::collections::BTreeMap;
 
@@ -124,12 +126,18 @@ pub struct OpticApertureRequest {
 /// Placeholder capability presentation supplied at optic invocation time.
 ///
 /// This v0 shape is intentionally not sufficient to authorize invocation. It
-/// exists only so the admission skeleton can name the future presentation slot
+/// exists only so the admission skeleton can classify presentation posture
 /// without inventing grant validation semantics.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OpticCapabilityPresentation {
     /// Presentation identity supplied by the caller.
     pub presentation_id: String,
+    /// Grant id the presentation claims to bind to.
+    ///
+    /// Echo does not validate this grant in this slice. A non-empty value only
+    /// moves the presentation from unbound to validation-unavailable
+    /// obstruction; it never authorizes invocation.
+    pub bound_grant_id: Option<String>,
 }
 
 /// Runtime invocation request against a registered optic artifact.
@@ -158,6 +166,10 @@ pub enum OpticInvocationObstruction {
     OperationMismatch,
     /// The invocation does not carry authority to use the registered artifact.
     MissingCapability,
+    /// The invocation carries a presentation that is structurally unusable.
+    MalformedCapabilityPresentation,
+    /// The invocation carries a presentation that is not bound to any grant.
+    UnboundCapabilityPresentation,
     /// A placeholder presentation was supplied, but real grant validation does
     /// not exist in this slice.
     CapabilityValidationUnavailable,
@@ -303,17 +315,33 @@ impl OpticArtifactRegistry {
             );
         }
 
-        if invocation.capability_presentation.is_none() {
-            return Self::obstructed_invocation(
-                invocation,
-                OpticInvocationObstruction::MissingCapability,
-            );
-        }
-
         Self::obstructed_invocation(
             invocation,
-            OpticInvocationObstruction::CapabilityValidationUnavailable,
+            Self::classify_capability_presentation(invocation.capability_presentation.as_ref()),
         )
+    }
+
+    fn classify_capability_presentation(
+        presentation: Option<&OpticCapabilityPresentation>,
+    ) -> OpticInvocationObstruction {
+        let Some(presentation) = presentation else {
+            return OpticInvocationObstruction::MissingCapability;
+        };
+
+        if presentation.presentation_id.is_empty()
+            || presentation
+                .bound_grant_id
+                .as_ref()
+                .is_some_and(String::is_empty)
+        {
+            return OpticInvocationObstruction::MalformedCapabilityPresentation;
+        }
+
+        if presentation.bound_grant_id.is_none() {
+            return OpticInvocationObstruction::UnboundCapabilityPresentation;
+        }
+
+        OpticInvocationObstruction::CapabilityValidationUnavailable
     }
 
     fn obstructed_invocation(

--- a/crates/warp-core/tests/optic_invocation_admission_tests.rs
+++ b/crates/warp-core/tests/optic_invocation_admission_tests.rs
@@ -72,6 +72,12 @@ fn expected_obstructed_posture(
     })
 }
 
+fn obstruction_for(outcome: &OpticInvocationAdmissionOutcome) -> OpticInvocationObstruction {
+    match outcome {
+        OpticInvocationAdmissionOutcome::Obstructed(posture) => posture.obstruction,
+    }
+}
+
 #[test]
 fn optic_invocation_obstructs_unknown_handle() {
     let registry = OpticArtifactRegistry::new();
@@ -118,12 +124,55 @@ fn optic_invocation_obstructs_missing_capability_for_registered_handle() -> Resu
 }
 
 #[test]
+fn optic_invocation_obstructs_malformed_capability_presentation() -> Result<(), String> {
+    let (registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.capability_presentation = Some(OpticCapabilityPresentation {
+        presentation_id: String::new(),
+        bound_grant_id: Some("grant:fixture".to_owned()),
+    });
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        outcome,
+        expected_obstructed_posture(
+            &invocation,
+            OpticInvocationObstruction::MalformedCapabilityPresentation
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn optic_invocation_obstructs_unbound_capability_presentation() -> Result<(), String> {
+    let (registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.capability_presentation = Some(OpticCapabilityPresentation {
+        presentation_id: "presentation:unbound".to_owned(),
+        bound_grant_id: None,
+    });
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        outcome,
+        expected_obstructed_posture(
+            &invocation,
+            OpticInvocationObstruction::UnboundCapabilityPresentation
+        )
+    );
+    Ok(())
+}
+
+#[test]
 fn optic_invocation_obstructs_placeholder_capability_presentation_until_grant_validation_exists(
 ) -> Result<(), String> {
     let (registry, handle) = fixture_registry_and_handle()?;
     let mut invocation = fixture_invocation(handle);
     invocation.capability_presentation = Some(OpticCapabilityPresentation {
         presentation_id: "presentation:placeholder".to_owned(),
+        bound_grant_id: Some("grant:placeholder".to_owned()),
     });
 
     let outcome = registry.admit_optic_invocation(&invocation);
@@ -135,5 +184,44 @@ fn optic_invocation_obstructs_placeholder_capability_presentation_until_grant_va
             OpticInvocationObstruction::CapabilityValidationUnavailable
         )
     );
+    Ok(())
+}
+
+#[test]
+fn optic_invocation_presentation_never_admits_without_real_grant_validation() -> Result<(), String>
+{
+    let presentations = [
+        (
+            OpticCapabilityPresentation {
+                presentation_id: String::new(),
+                bound_grant_id: Some("grant:fixture".to_owned()),
+            },
+            OpticInvocationObstruction::MalformedCapabilityPresentation,
+        ),
+        (
+            OpticCapabilityPresentation {
+                presentation_id: "presentation:unbound".to_owned(),
+                bound_grant_id: None,
+            },
+            OpticInvocationObstruction::UnboundCapabilityPresentation,
+        ),
+        (
+            OpticCapabilityPresentation {
+                presentation_id: "presentation:placeholder".to_owned(),
+                bound_grant_id: Some("grant:placeholder".to_owned()),
+            },
+            OpticInvocationObstruction::CapabilityValidationUnavailable,
+        ),
+    ];
+
+    for (presentation, expected_obstruction) in presentations {
+        let (registry, handle) = fixture_registry_and_handle()?;
+        let mut invocation = fixture_invocation(handle);
+        invocation.capability_presentation = Some(presentation);
+
+        let outcome = registry.admit_optic_invocation(&invocation);
+
+        assert_eq!(obstruction_for(&outcome), expected_obstruction);
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
Adds the next Echo-side optic admission boundary: capability presentation posture is classified, but never accepted as authority.

A capability presentation slot is not authority. Until Echo validates a real bounded `CapabilityGrant`, every presentation posture remains obstructed.

This PR extends optic invocation obstruction classification:
- `None` presentation -> `MissingCapability`
- malformed presentation -> `MalformedCapabilityPresentation`
- well-formed but unbound presentation -> `UnboundCapabilityPresentation`
- placeholder/future presentation -> `CapabilityValidationUnavailable`

The existing ticket-shaped pre-admission posture remains the carrier for every obstruction.

## What this is
- A narrow obstruction boundary for capability presentation posture
- Executable proof that `Some(presentation)` does not improve admission outcome
- Another step toward future grant validation without adding fake success

## What this is not
- Not real `CapabilityGrant` validation
- Not `CapabilityPresentation` authority
- Not a successful `AdmissionTicket`
- Not `LawWitness`
- Not grant issuance
- Not runtime execution
- Not scheduler integration
- Not WASM ABI
- Not app nouns
- Not Continuum schema publication

## Verification
RED:

```text
cargo test -p warp-core optic_invocation
```

Failed before implementation because `bound_grant_id`, `MalformedCapabilityPresentation`, and `UnboundCapabilityPresentation` did not exist.

GREEN / VERIFY:

```text
cargo test -p warp-core optic_invocation
cargo test -p warp-core optic_artifact_registry
cargo check -p warp-core
scripts/ban-nondeterminism.sh
git diff --check
```

Additional commit/push gates passed:

```text
cargo clippy -p warp-core --lib
fmt
guards
clippy-core
tests-warp-core
rustdoc
```
