### PR TITLE
docs(process): record direct-main docs exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ### Added
 
+- `docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md` records the 2026-05-14
+  docs-only direct-main exception for the Echo graph model checkpoint, including
+  authorization context, exact commits, validation, changed files, and the
+  future rule to prefer PRs unless an emergency or docs-only fast path is
+  explicitly authorized.
 - `docs/design/built-in-echo-graph-data-model.md` defines Echo's native
   graph ontology for future optic admission, authority, transaction atomicity,
   receipts, witnessed readings, footprint addressing, transaction-local object

--- a/docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md
+++ b/docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md
@@ -1,0 +1,82 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Direct Main Exception Log
+
+Status: process scar tissue.
+Scope: exceptional direct pushes to `main` that bypass the normal PR workflow.
+
+## Doctrine
+
+Direct pushes to `main` remain forbidden by default.
+
+The normal path is branch, PR, review, green CI, then merge. A direct-main push is
+acceptable only when an explicit maintainer instruction authorizes a narrow
+exception and the change is low-risk, already locally validated, and provenance is
+recorded immediately afterward.
+
+This log does not create a standing fast path. It records exceptions so the repo
+keeps its process history honest.
+
+## 2026-05-14 — Echo graph model docs checkpoint
+
+### Why `main` was bypassed
+
+The maintainer explicitly authorized pushing the docs checkpoint directly after
+confirming the two local commits were wanted on `main`.
+
+The change was docs-only and captured a design checkpoint for Echo's built-in
+graph data model before additional optic, authority, and transaction work
+continued.
+
+### Commits pushed
+
+```text
+a3d6632 docs(core): define built-in Echo graph data model
+512a33d docs(core): expand Echo graph model coverage
+```
+
+### Files changed
+
+```text
+CHANGELOG.md
+docs/design/built-in-echo-graph-data-model.md
+```
+
+No Rust source, tests, workflows, scripts, generated artifacts, or runtime code
+were touched by the direct push.
+
+### Validation run
+
+The pre-push hook classified the change as docs-only and ran the markdown
+formatting gate:
+
+```text
+[verify-local] docs-only change set
+[verify-local] prettier --check (2 markdown files)
+Checking formatting...
+All matched files use Prettier code style!
+[verify-local] completed in 1s (fresh)
+```
+
+GitHub accepted the push through an admin bypass and reported the rule violation
+that was bypassed:
+
+```text
+remote: Bypassed rule violations for refs/heads/main:
+remote:
+remote: - Changes must be made through a pull request.
+```
+
+### Future rule
+
+Prefer PRs unless an emergency or docs-only fast path is explicitly authorized by
+a maintainer.
+
+Even for docs-only direct pushes:
+
+- state the exception before pushing;
+- run the relevant docs validation;
+- record exact commits and changed files;
+- confirm no source/runtime code was touched;
+- add a process note afterward if the exception affected repository governance.


### PR DESCRIPTION
Records the docs-only direct-main exception for the built-in Echo graph data model commits and pins the future rule: prefer PRs unless emergency or explicitly authorized docs-only fast path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog and established documentation for an exception policy governing direct pushes to the main branch.
  * Documented procedures for authorizing, validating, and tracking exceptions to the standard pull request workflow.
  * Specified requirements for low-risk, locally validated exceptions, including validation criteria, commit tracking, scope confirmation, and provenance recording.
  * Added initial exception entry documenting a docs-only authorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/echo/pull/340)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->