### PR TITLE
feat(wesley): import runtime optic artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
   hashes, schema ids, operation ids, requirements digests, and registration
   descriptors while keeping `warp-core` free of a Wesley dependency. Echo still
   owns opaque runtime-local `OpticArtifactHandle` issuance, and the imported
-  requirements bytes are stored for registration proof only, not enforcement.
+  requirements bytes are staged through an explicit adapter-local v0
+  canonicalization helper for registration proof only, not enforcement.
+  `warp-core` stores those requirements as opaque bytes and must not interpret
+  them for admission until Wesley exposes canonical requirements bytes and a
+  durable codec.
 - `docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md` records the 2026-05-14
   docs-only direct-main exception for the Echo graph model checkpoint, including
   authorization context, exact commits, validation, changed files, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ### Added
 
+- `echo-wesley-gen` now imports real `wesley-core` 0.0.3 runtime optic
+  artifacts into `warp-core` registration structs, preserving Wesley artifact
+  hashes, schema ids, operation ids, requirements digests, and registration
+  descriptors while keeping `warp-core` free of a Wesley dependency. Echo still
+  owns opaque runtime-local `OpticArtifactHandle` issuance, and the imported
+  requirements bytes are stored for registration proof only, not enforcement.
 - `docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md` records the 2026-05-14
   docs-only direct-main exception for the Echo graph model checkpoint, including
   authorization context, exact commits, validation, changed files, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "warp-core",
  "wesley-core",
 ]
 
@@ -2161,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "wesley-core"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365972ab1d1d8ece193aa3de936223e33abe3844f3fba0e7049efc50f64b3ea"
+checksum = "185e806cc7e9d4263023562a00832d777ab146b902f5ee1531940dc39e6d6515"
 dependencies = [
  "apollo-parser",
  "async-trait",

--- a/crates/echo-wesley-gen/Cargo.toml
+++ b/crates/echo-wesley-gen/Cargo.toml
@@ -22,7 +22,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 prettyplease = "0.2"
-wesley-core = "0.0.2"
+warp-core = { workspace = true }
+wesley-core = "0.0.3"
 
 
 [lints]

--- a/crates/echo-wesley-gen/src/lib.rs
+++ b/crates/echo-wesley-gen/src/lib.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Adapter from Wesley-compiled runtime optic artifacts into Echo runtime types.
+//!
+//! Wesley owns compiled artifact truth: artifact hashes, schema ids, operation
+//! ids, requirements digests, and registration descriptors. `warp-core` owns
+//! runtime registration and opaque handles. This crate is the dependency seam
+//! that may see both sides.
+//!
+//! The v0 adapter stores Wesley admission requirements as deterministic
+//! `serde_json` bytes in `warp-core`. Those bytes are registry payload only;
+//! enforcement, grant validation, admission tickets, witnesses, and execution
+//! are intentionally out of scope for this adapter.
+
+/// Imported Wesley runtime optic artifact ready for Echo registration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportedRuntimeOpticArtifact {
+    /// Echo runtime artifact shape.
+    pub artifact: warp_core::OpticArtifact,
+    /// Wesley registration descriptor mirrored into Echo's registration shape.
+    pub descriptor: warp_core::OpticRegistrationDescriptor,
+}
+
+/// Imports a Wesley-compiled runtime optic artifact into Echo runtime structs.
+///
+/// This does not register the artifact and does not issue authority. Echo still
+/// verifies the descriptor through [`warp_core::OpticArtifactRegistry`] and
+/// returns the opaque runtime-local handle only after registration succeeds.
+pub fn import_runtime_optic_artifact(
+    artifact: &wesley_core::OpticArtifact,
+) -> anyhow::Result<ImportedRuntimeOpticArtifact> {
+    let requirements_bytes = serde_json::to_vec(&artifact.requirements)?;
+
+    Ok(ImportedRuntimeOpticArtifact {
+        artifact: warp_core::OpticArtifact {
+            artifact_id: artifact.artifact_id.clone(),
+            artifact_hash: artifact.artifact_hash.clone(),
+            schema_id: artifact.schema_id.clone(),
+            requirements_digest: artifact.requirements_digest.clone(),
+            operation: warp_core::OpticArtifactOperation {
+                operation_id: artifact.operation.operation_id.clone(),
+            },
+            requirements: warp_core::OpticAdmissionRequirements {
+                bytes: requirements_bytes,
+            },
+        },
+        descriptor: import_registration_descriptor(&artifact.registration),
+    })
+}
+
+/// Imports a Wesley registration descriptor into Echo's registration shape.
+pub fn import_registration_descriptor(
+    descriptor: &wesley_core::OpticRegistrationDescriptor,
+) -> warp_core::OpticRegistrationDescriptor {
+    warp_core::OpticRegistrationDescriptor {
+        artifact_id: descriptor.artifact_id.clone(),
+        artifact_hash: descriptor.artifact_hash.clone(),
+        schema_id: descriptor.schema_id.clone(),
+        operation_id: descriptor.operation_id.clone(),
+        requirements_digest: descriptor.requirements_digest.clone(),
+    }
+}

--- a/crates/echo-wesley-gen/src/lib.rs
+++ b/crates/echo-wesley-gen/src/lib.rs
@@ -12,6 +12,14 @@
 //! enforcement, grant validation, admission tickets, witnesses, and execution
 //! are intentionally out of scope for this adapter.
 
+/// Adapter-local staging codec for imported Wesley admission requirements.
+///
+/// This is not runtime admission truth. It is a v0 canonical staging format so
+/// Echo can store opaque requirements bytes while Wesley grows a durable
+/// canonical requirements byte/codec surface.
+pub const WESLEY_REQUIREMENTS_STAGING_CODEC_V0: &str =
+    "echo-wesley-gen/wesley-requirements-canonical-json-staging/v0";
+
 /// Imported Wesley runtime optic artifact ready for Echo registration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportedRuntimeOpticArtifact {
@@ -29,7 +37,7 @@ pub struct ImportedRuntimeOpticArtifact {
 pub fn import_runtime_optic_artifact(
     artifact: &wesley_core::OpticArtifact,
 ) -> anyhow::Result<ImportedRuntimeOpticArtifact> {
-    let requirements_bytes = serde_json::to_vec(&artifact.requirements)?;
+    let requirements_bytes = canonicalize_wesley_requirements_v0(&artifact.requirements)?;
 
     Ok(ImportedRuntimeOpticArtifact {
         artifact: warp_core::OpticArtifact {
@@ -48,6 +56,21 @@ pub fn import_runtime_optic_artifact(
     })
 }
 
+/// Canonicalizes Wesley admission requirements for adapter-local v0 staging.
+///
+/// The helper deliberately names the seam: these bytes are not permanent
+/// artifact truth and `warp-core` must not interpret them for admission.
+/// Durable admission should eventually consume Wesley-owned canonical
+/// requirements bytes plus an explicit codec id.
+pub fn canonicalize_wesley_requirements_v0(
+    requirements: &wesley_core::OpticAdmissionRequirements,
+) -> anyhow::Result<Vec<u8>> {
+    let value = serde_json::to_value(requirements)?;
+    let mut bytes = Vec::new();
+    write_canonical_json_value(&value, &mut bytes)?;
+    Ok(bytes)
+}
+
 /// Imports a Wesley registration descriptor into Echo's registration shape.
 pub fn import_registration_descriptor(
     descriptor: &wesley_core::OpticRegistrationDescriptor,
@@ -58,5 +81,79 @@ pub fn import_registration_descriptor(
         schema_id: descriptor.schema_id.clone(),
         operation_id: descriptor.operation_id.clone(),
         requirements_digest: descriptor.requirements_digest.clone(),
+    }
+}
+
+fn write_canonical_json_value(
+    value: &serde_json::Value,
+    bytes: &mut Vec<u8>,
+) -> anyhow::Result<()> {
+    match value {
+        serde_json::Value::Null => bytes.extend_from_slice(b"null"),
+        serde_json::Value::Bool(true) => bytes.extend_from_slice(b"true"),
+        serde_json::Value::Bool(false) => bytes.extend_from_slice(b"false"),
+        serde_json::Value::Number(number) => {
+            bytes.extend_from_slice(serde_json::to_string(number)?.as_bytes());
+        }
+        serde_json::Value::String(text) => {
+            bytes.extend_from_slice(serde_json::to_string(text)?.as_bytes());
+        }
+        serde_json::Value::Array(values) => {
+            bytes.push(b'[');
+            for (index, item) in values.iter().enumerate() {
+                if index > 0 {
+                    bytes.push(b',');
+                }
+                write_canonical_json_value(item, bytes)?;
+            }
+            bytes.push(b']');
+        }
+        serde_json::Value::Object(object) => {
+            let mut entries: Vec<_> = object.iter().collect();
+            entries.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+
+            bytes.push(b'{');
+            for (index, (key, item)) in entries.into_iter().enumerate() {
+                if index > 0 {
+                    bytes.push(b',');
+                }
+                bytes.extend_from_slice(serde_json::to_string(key)?.as_bytes());
+                bytes.push(b':');
+                write_canonical_json_value(item, bytes)?;
+            }
+            bytes.push(b'}');
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_canonical_json_value;
+
+    #[test]
+    fn canonical_json_writer_sorts_object_keys_recursively() -> anyhow::Result<()> {
+        let left = serde_json::json!({
+            "z": [{"b": 2, "a": 1}],
+            "a": {"d": false, "c": true}
+        });
+        let right = serde_json::json!({
+            "a": {"c": true, "d": false},
+            "z": [{"a": 1, "b": 2}]
+        });
+        let mut left_bytes = Vec::new();
+        let mut right_bytes = Vec::new();
+
+        write_canonical_json_value(&left, &mut left_bytes)?;
+        write_canonical_json_value(&right, &mut right_bytes)?;
+
+        assert_eq!(left_bytes, right_bytes);
+        assert_eq!(
+            left_bytes,
+            br#"{"a":{"c":true,"d":false},"z":[{"a":1,"b":2}]}"#
+        );
+
+        Ok(())
     }
 }

--- a/crates/echo-wesley-gen/src/main.rs
+++ b/crates/echo-wesley-gen/src/main.rs
@@ -23,7 +23,7 @@ use ir::{OpKind, TypeKind, WesleyIR};
 const ECHO_IR_VERSION: &str = "echo-ir/v1";
 const DEFAULT_CODEC_ID: &str = "cbor-canon-v1";
 const DEFAULT_REGISTRY_VERSION: u32 = 1;
-const WESLEY_CORE_VERSION: &str = "0.0.2";
+const WESLEY_CORE_VERSION: &str = "0.0.3";
 
 #[derive(Parser)]
 #[command(

--- a/crates/echo-wesley-gen/tests/runtime_optic_import.rs
+++ b/crates/echo-wesley-gen/tests/runtime_optic_import.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+#![allow(clippy::expect_used)]
+//! Proof that `echo-wesley-gen` adapts real Wesley runtime optic artifacts into Echo.
+
+use echo_wesley_gen::import_runtime_optic_artifact;
+use warp_core::{
+    OpticArtifactRegistrationError, OpticArtifactRegistry, OPTIC_ARTIFACT_HANDLE_KIND,
+};
+use wesley_core::compile_runtime_optic;
+
+const WORKSPACE_SCHEMA: &str = r"
+directive @wes_law(id: String!) on FIELD
+directive @wes_footprint(
+  reads: [String!]!
+  writes: [String!]!
+  forbids: [String!]
+) on FIELD
+
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Query {
+  basis(ref: ID!): WorkspaceBasis
+}
+
+type Mutation {
+  renameSymbol(input: RenameSymbolInput!): RenameSymbolResult!
+}
+
+input RenameSymbolInput {
+  basisRef: ID!
+  path: String!
+  symbol: String!
+  nextName: String!
+}
+
+type RenameSymbolResult {
+  receipt: RewriteReceipt!
+  changedFiles: [ChangedFile!]!
+}
+
+type RewriteReceipt {
+  basisRef: ID!
+  resultRef: ID!
+  operationId: String!
+  witnessDigest: String!
+}
+
+type ChangedFile {
+  path: String!
+  beforeDigest: String!
+  afterDigest: String!
+}
+
+type WorkspaceBasis {
+  ref: ID!
+  digest: String!
+}
+";
+
+const RENAME_SYMBOL_OPERATION: &str = r#"
+mutation RenameSymbol($input: RenameSymbolInput!) {
+  renameSymbol(input: $input)
+    @wes_law(id: "bounded.rewrite.v1")
+    @wes_footprint(
+      reads: ["workspace.files", "symbol.index"]
+      writes: ["workspace.files"]
+      forbids: ["secrets", "git.refs"]
+    ) {
+    receipt {
+      basisRef
+      resultRef
+      operationId
+      witnessDigest
+    }
+  }
+}
+"#;
+
+fn compile_fixture_artifact() -> wesley_core::OpticArtifact {
+    compile_runtime_optic(
+        WORKSPACE_SCHEMA,
+        RENAME_SYMBOL_OPERATION,
+        Some("RenameSymbol"),
+    )
+    .expect("fixture runtime optic should compile")
+}
+
+#[test]
+fn imports_real_wesley_runtime_optic_artifact() {
+    let wesley_artifact = compile_fixture_artifact();
+    let imported =
+        import_runtime_optic_artifact(&wesley_artifact).expect("artifact import should succeed");
+    let repeated =
+        import_runtime_optic_artifact(&wesley_artifact).expect("artifact import should repeat");
+
+    assert_eq!(imported, repeated);
+    assert_eq!(imported.artifact.artifact_id, wesley_artifact.artifact_id);
+    assert_eq!(
+        imported.artifact.artifact_hash,
+        wesley_artifact.artifact_hash
+    );
+    assert_eq!(imported.artifact.schema_id, wesley_artifact.schema_id);
+    assert_eq!(
+        imported.artifact.requirements_digest,
+        wesley_artifact.requirements_digest
+    );
+    assert_eq!(
+        imported.artifact.operation.operation_id,
+        wesley_artifact.operation.operation_id
+    );
+    assert_eq!(
+        imported.descriptor.artifact_id,
+        wesley_artifact.registration.artifact_id
+    );
+    assert_eq!(
+        imported.descriptor.artifact_hash,
+        wesley_artifact.registration.artifact_hash
+    );
+    assert_eq!(
+        imported.descriptor.schema_id,
+        wesley_artifact.registration.schema_id
+    );
+    assert_eq!(
+        imported.descriptor.operation_id,
+        wesley_artifact.registration.operation_id
+    );
+    assert_eq!(
+        imported.descriptor.requirements_digest,
+        wesley_artifact.registration.requirements_digest
+    );
+    assert!(
+        !imported.artifact.requirements.bytes.is_empty(),
+        "Wesley requirements must be imported into Echo registry bytes"
+    );
+}
+
+#[test]
+fn registers_imported_wesley_artifact_and_returns_opaque_handle() {
+    let imported = import_runtime_optic_artifact(&compile_fixture_artifact())
+        .expect("artifact import should succeed");
+    let mut registry = OpticArtifactRegistry::new();
+
+    let handle = registry
+        .register_optic_artifact(imported.artifact.clone(), imported.descriptor.clone())
+        .expect("imported Wesley artifact should register");
+    let registered = registry
+        .resolve_optic_artifact_handle(&handle)
+        .expect("registered handle should resolve internally");
+
+    assert_eq!(handle.kind, OPTIC_ARTIFACT_HANDLE_KIND);
+    assert!(!handle.id.is_empty());
+    assert_eq!(registered.handle, handle);
+    assert_eq!(registered.artifact_hash, imported.artifact.artifact_hash);
+    assert_eq!(
+        registered.requirements_digest,
+        imported.artifact.requirements_digest
+    );
+    assert_eq!(
+        registered.operation_id,
+        imported.artifact.operation.operation_id
+    );
+    assert_eq!(registered.requirements, imported.artifact.requirements);
+}
+
+#[test]
+fn rejects_tampered_artifact_hash() {
+    let imported = import_runtime_optic_artifact(&compile_fixture_artifact())
+        .expect("artifact import should succeed");
+    let mut registry = OpticArtifactRegistry::new();
+    let mut descriptor = imported.descriptor;
+    descriptor.artifact_hash = "tampered-artifact-hash".to_string();
+
+    assert!(matches!(
+        registry.register_optic_artifact(imported.artifact, descriptor),
+        Err(OpticArtifactRegistrationError::ArtifactHashMismatch)
+    ));
+}
+
+#[test]
+fn rejects_tampered_schema_id() {
+    let imported = import_runtime_optic_artifact(&compile_fixture_artifact())
+        .expect("artifact import should succeed");
+    let mut registry = OpticArtifactRegistry::new();
+    let mut descriptor = imported.descriptor;
+    descriptor.schema_id = "tampered-schema-id".to_string();
+
+    assert!(matches!(
+        registry.register_optic_artifact(imported.artifact, descriptor),
+        Err(OpticArtifactRegistrationError::SchemaIdMismatch)
+    ));
+}
+
+#[test]
+fn rejects_tampered_operation_id() {
+    let imported = import_runtime_optic_artifact(&compile_fixture_artifact())
+        .expect("artifact import should succeed");
+    let mut registry = OpticArtifactRegistry::new();
+    let mut descriptor = imported.descriptor;
+    descriptor.operation_id = "tampered-operation-id".to_string();
+
+    assert!(matches!(
+        registry.register_optic_artifact(imported.artifact, descriptor),
+        Err(OpticArtifactRegistrationError::OperationIdMismatch)
+    ));
+}
+
+#[test]
+fn rejects_tampered_requirements_digest() {
+    let imported = import_runtime_optic_artifact(&compile_fixture_artifact())
+        .expect("artifact import should succeed");
+    let mut registry = OpticArtifactRegistry::new();
+    let mut descriptor = imported.descriptor;
+    descriptor.requirements_digest = "tampered-requirements-digest".to_string();
+
+    assert!(matches!(
+        registry.register_optic_artifact(imported.artifact, descriptor),
+        Err(OpticArtifactRegistrationError::RequirementsDigestMismatch)
+    ));
+}
+
+#[test]
+fn warp_core_does_not_depend_on_wesley_core() {
+    let warp_core_manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root ancestor missing")
+        .join("crates/warp-core/Cargo.toml");
+    let manifest =
+        std::fs::read_to_string(warp_core_manifest).expect("warp-core manifest should be readable");
+
+    assert!(
+        !manifest.contains("wesley-core"),
+        "warp-core must not depend on wesley-core; the dependency seam belongs in echo-wesley-gen"
+    );
+}

--- a/crates/echo-wesley-gen/tests/runtime_optic_import.rs
+++ b/crates/echo-wesley-gen/tests/runtime_optic_import.rs
@@ -3,7 +3,10 @@
 #![allow(clippy::expect_used)]
 //! Proof that `echo-wesley-gen` adapts real Wesley runtime optic artifacts into Echo.
 
-use echo_wesley_gen::import_runtime_optic_artifact;
+use echo_wesley_gen::{
+    canonicalize_wesley_requirements_v0, import_runtime_optic_artifact,
+    WESLEY_REQUIREMENTS_STAGING_CODEC_V0,
+};
 use warp_core::{
     OpticArtifactRegistrationError, OpticArtifactRegistry, OPTIC_ARTIFACT_HANDLE_KIND,
 };
@@ -167,6 +170,48 @@ fn registers_imported_wesley_artifact_and_returns_opaque_handle() {
 }
 
 #[test]
+fn imported_requirements_bytes_are_deterministic() {
+    let wesley_artifact = compile_fixture_artifact();
+    let first = canonicalize_wesley_requirements_v0(&wesley_artifact.requirements)
+        .expect("requirements canonicalization should succeed");
+    let second = canonicalize_wesley_requirements_v0(&wesley_artifact.requirements)
+        .expect("requirements canonicalization should repeat");
+    let first_import =
+        import_runtime_optic_artifact(&wesley_artifact).expect("artifact import should succeed");
+    let second_import =
+        import_runtime_optic_artifact(&wesley_artifact).expect("artifact import should repeat");
+
+    assert_eq!(first, second);
+    assert_eq!(first_import.artifact.requirements.bytes, first);
+    assert_eq!(
+        first_import.artifact.requirements.bytes,
+        second_import.artifact.requirements.bytes
+    );
+}
+
+#[test]
+fn imported_requirements_bytes_are_not_empty() {
+    let wesley_artifact = compile_fixture_artifact();
+    let bytes = canonicalize_wesley_requirements_v0(&wesley_artifact.requirements)
+        .expect("requirements canonicalization should succeed");
+
+    assert!(!bytes.is_empty());
+}
+
+#[test]
+fn imported_requirements_bytes_are_adapter_canonical_staging() {
+    let wesley_artifact = compile_fixture_artifact();
+    let imported =
+        import_runtime_optic_artifact(&wesley_artifact).expect("artifact import should succeed");
+    let staged_bytes = canonicalize_wesley_requirements_v0(&wesley_artifact.requirements)
+        .expect("requirements canonicalization should succeed");
+
+    assert_eq!(imported.artifact.requirements.bytes, staged_bytes);
+    assert!(WESLEY_REQUIREMENTS_STAGING_CODEC_V0.contains("staging"));
+    assert!(WESLEY_REQUIREMENTS_STAGING_CODEC_V0.ends_with("/v0"));
+}
+
+#[test]
 fn rejects_tampered_artifact_hash() {
     let imported = import_runtime_optic_artifact(&compile_fixture_artifact())
         .expect("artifact import should succeed");
@@ -235,5 +280,28 @@ fn warp_core_does_not_depend_on_wesley_core() {
     assert!(
         !manifest.contains("wesley-core"),
         "warp-core must not depend on wesley-core; the dependency seam belongs in echo-wesley-gen"
+    );
+}
+
+#[test]
+fn warp_core_does_not_depend_on_serde_json_for_wesley_requirements() {
+    let warp_core_manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root ancestor missing")
+        .join("crates/warp-core/Cargo.toml");
+    let manifest =
+        std::fs::read_to_string(warp_core_manifest).expect("warp-core manifest should be readable");
+    let active_serde_json_lines: Vec<_> = manifest
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            !trimmed.starts_with('#') && trimmed.contains("serde_json")
+        })
+        .collect();
+
+    assert!(
+        active_serde_json_lines.is_empty(),
+        "warp-core must not depend on serde_json for Wesley requirements; JSON staging belongs in echo-wesley-gen"
     );
 }


### PR DESCRIPTION
Imports real Wesley 0.0.3 runtime optic artifacts through echo-wesley-gen into warp-core registration, preserving the dependency firewall: Wesley owns artifact truth, echo-wesley-gen adapts it, and warp-core owns runtime registration plus opaque handles.\n\n## Summary\n- Upgrade echo-wesley-gen to wesley-core 0.0.3\n- Add an echo-wesley-gen adapter that imports Wesley OpticArtifact + OpticRegistrationDescriptor into warp-core registration structs\n- Preserve the dependency firewall with warp-core free of any wesley-core dependency\n- Prove imported artifacts register through OpticArtifactRegistry and return Echo-owned opaque handles\n\n## Doctrine\nWesley owns artifact truth. echo-wesley-gen imports and adapts compiler truth. warp-core owns runtime registration and handles. Echo handles prove registration, not authority.\n\n## Non-goals\n- no grant validation\n- no successful admission ticket\n- no LawWitness\n- no execution\n- no scheduler\n- no basis/budget enforcement\n- no directive rename\n- no Continuum extraction\n\n## Verification\n- cargo test -p echo-wesley-gen --test runtime_optic_import\n- cargo test -p echo-wesley-gen\n- cargo check -p echo-wesley-gen\n- cargo check -p warp-core\n- scripts/ban-nondeterminism.sh\n- git diff --check