### PR TITLE
feat(core): publish artifact registration graph facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 ### Added
 
+- `warp-core` now publishes in-memory causal graph facts from optic artifact
+  registration. Successful registration emits `GraphFact::ArtifactRegistered`,
+  computes a deterministic `FactDigest`, and links that digest from an
+  `ArtifactRegistrationReceipt`; obstructed registration emits
+  `GraphFact::ArtifactRegistrationObstructed` without issuing a handle or
+  success receipt. Fact digests use explicit domain tags, field tags,
+  present/absent markers, and length-prefixed bytes, not JSON.
+- `docs/design/graph-fact-publication-skeleton.md` defines the first substrate
+  publication boundary: facts are world statements, receipts explain
+  publication/refusal boundaries, and registration facts are the first
+  in-memory proof that Echo can describe its own runtime decisions.
 - `echo-wesley-gen` now imports real `wesley-core` 0.0.3 runtime optic
   artifacts into `warp-core` registration structs, preserving Wesley artifact
   hashes, schema ids, operation ids, requirements digests, and registration

--- a/crates/warp-core/src/causal_facts.rs
+++ b/crates/warp-core/src/causal_facts.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Native causal graph fact publication primitives.
+//!
+//! Facts are world statements. Receipts explain publication or refusal
+//! boundaries and reference fact digests; they do not replace facts.
+
+const FACT_DIGEST_DOMAIN: &[u8] = b"echo.causal-fact.v0";
+
+/// Stable digest for one canonical graph fact.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FactDigest([u8; 32]);
+
+impl FactDigest {
+    /// Returns the raw digest bytes.
+    #[must_use]
+    pub const fn bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Obstruction kind recorded when artifact registration fails before a handle
+/// is issued.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArtifactRegistrationObstructionKind {
+    /// Descriptor artifact id did not match artifact identity.
+    ArtifactIdMismatch,
+    /// Descriptor artifact hash did not match artifact identity.
+    ArtifactHashMismatch,
+    /// Descriptor schema id did not match artifact schema id.
+    SchemaIdMismatch,
+    /// Descriptor operation id did not match artifact operation id.
+    OperationIdMismatch,
+    /// Descriptor requirements digest did not match artifact requirements.
+    RequirementsDigestMismatch,
+}
+
+impl ArtifactRegistrationObstructionKind {
+    fn digest_label(self) -> &'static [u8] {
+        match self {
+            Self::ArtifactIdMismatch => b"artifact-id-mismatch",
+            Self::ArtifactHashMismatch => b"artifact-hash-mismatch",
+            Self::SchemaIdMismatch => b"schema-id-mismatch",
+            Self::OperationIdMismatch => b"operation-id-mismatch",
+            Self::RequirementsDigestMismatch => b"requirements-digest-mismatch",
+        }
+    }
+}
+
+/// Native Echo graph fact.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GraphFact {
+    /// Echo registered a Wesley-compiled optic artifact and issued a
+    /// runtime-local handle.
+    ArtifactRegistered {
+        /// Echo-owned runtime-local handle id.
+        handle_id: String,
+        /// Wesley artifact hash.
+        artifact_hash: String,
+        /// Wesley schema id.
+        schema_id: String,
+        /// Wesley operation id.
+        operation_id: String,
+        /// Wesley requirements digest.
+        requirements_digest: String,
+    },
+    /// Echo refused artifact registration before issuing a handle.
+    ArtifactRegistrationObstructed {
+        /// Artifact hash named by the attempted registration, if available.
+        artifact_hash: Option<String>,
+        /// Structured obstruction kind.
+        obstruction: ArtifactRegistrationObstructionKind,
+    },
+}
+
+impl GraphFact {
+    /// Computes the deterministic fact digest.
+    #[must_use]
+    pub fn digest(&self) -> FactDigest {
+        let mut bytes = Vec::new();
+        push_digest_field(&mut bytes, b"domain", FACT_DIGEST_DOMAIN);
+
+        match self {
+            Self::ArtifactRegistered {
+                handle_id,
+                artifact_hash,
+                schema_id,
+                operation_id,
+                requirements_digest,
+            } => {
+                push_digest_field(&mut bytes, b"variant", b"artifact-registered");
+                push_digest_field(&mut bytes, b"handle-id", handle_id.as_bytes());
+                push_digest_field(&mut bytes, b"artifact-hash", artifact_hash.as_bytes());
+                push_digest_field(&mut bytes, b"schema-id", schema_id.as_bytes());
+                push_digest_field(&mut bytes, b"operation-id", operation_id.as_bytes());
+                push_digest_field(
+                    &mut bytes,
+                    b"requirements-digest",
+                    requirements_digest.as_bytes(),
+                );
+            }
+            Self::ArtifactRegistrationObstructed {
+                artifact_hash,
+                obstruction,
+            } => {
+                push_digest_field(&mut bytes, b"variant", b"artifact-registration-obstructed");
+                push_optional_digest_field(
+                    &mut bytes,
+                    b"artifact-hash",
+                    artifact_hash.as_deref().map(str::as_bytes),
+                );
+                push_digest_field(&mut bytes, b"obstruction", obstruction.digest_label());
+            }
+        }
+
+        FactDigest(*blake3::hash(&bytes).as_bytes())
+    }
+}
+
+/// Graph fact plus its deterministic digest.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublishedGraphFact {
+    /// Published fact.
+    pub fact: GraphFact,
+    /// Digest computed from the fact.
+    pub digest: FactDigest,
+}
+
+impl PublishedGraphFact {
+    /// Publishes a fact by computing its digest.
+    #[must_use]
+    pub fn new(fact: GraphFact) -> Self {
+        let digest = fact.digest();
+        Self { fact, digest }
+    }
+}
+
+/// Receipt kind for artifact registration publication.
+pub const ARTIFACT_REGISTRATION_RECEIPT_KIND: &str = "artifact-registration-receipt";
+
+/// Receipt linking artifact registration to the graph fact it published.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArtifactRegistrationReceipt {
+    /// Stable discriminator for callers and wire adapters.
+    pub kind: String,
+    /// Echo-owned runtime-local handle id issued by registration.
+    pub handle_id: String,
+    /// Wesley artifact hash registered by Echo.
+    pub artifact_hash: String,
+    /// Wesley operation id registered by Echo.
+    pub operation_id: String,
+    /// Digest of the `ArtifactRegistered` graph fact.
+    pub fact_digest: FactDigest,
+}
+
+fn push_digest_field(bytes: &mut Vec<u8>, tag: &[u8], value: &[u8]) {
+    push_len_prefixed(bytes, tag);
+    push_len_prefixed(bytes, value);
+}
+
+fn push_optional_digest_field(bytes: &mut Vec<u8>, tag: &[u8], value: Option<&[u8]>) {
+    push_len_prefixed(bytes, tag);
+    match value {
+        Some(value) => {
+            bytes.push(1);
+            push_len_prefixed(bytes, value);
+        }
+        None => bytes.push(0),
+    }
+}
+
+fn push_len_prefixed(bytes: &mut Vec<u8>, value: &[u8]) {
+    bytes.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    bytes.extend_from_slice(value);
+}

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod wsc;
 
 mod admission;
 mod attachment;
+mod causal_facts;
 mod clock;
 mod cmd;
 mod constants;
@@ -164,6 +165,10 @@ pub use admission::{
 pub use attachment::{
     AtomPayload, AttachmentKey, AttachmentOwner, AttachmentPlane, AttachmentValue, Codec,
     CodecRegistry, DecodeError, ErasedCodec, RegistryError,
+};
+pub use causal_facts::{
+    ArtifactRegistrationObstructionKind, ArtifactRegistrationReceipt, FactDigest, GraphFact,
+    PublishedGraphFact, ARTIFACT_REGISTRATION_RECEIPT_KIND,
 };
 pub use clock::{GlobalTick, RunId, WorldlineTick};
 pub use cmd::{

--- a/crates/warp-core/src/optic_artifact.rs
+++ b/crates/warp-core/src/optic_artifact.rs
@@ -12,6 +12,10 @@
 
 use std::collections::BTreeMap;
 
+use crate::{
+    ArtifactRegistrationObstructionKind, ArtifactRegistrationReceipt, GraphFact,
+    PublishedGraphFact, ARTIFACT_REGISTRATION_RECEIPT_KIND,
+};
 use thiserror::Error;
 
 /// Echo-owned handle kind for registered optic artifacts.
@@ -673,6 +677,8 @@ fn push_optional_receipt_field(bytes: &mut Vec<u8>, field: Option<&[u8]>) {
 pub struct OpticArtifactRegistry {
     next_handle_index: u64,
     artifacts_by_handle: BTreeMap<String, RegisteredOpticArtifact>,
+    published_graph_facts: Vec<PublishedGraphFact>,
+    artifact_registration_receipts: Vec<ArtifactRegistrationReceipt>,
 }
 
 impl OpticArtifactRegistry {
@@ -693,20 +699,34 @@ impl OpticArtifactRegistry {
         artifact: OpticArtifact,
         descriptor: OpticRegistrationDescriptor,
     ) -> Result<OpticArtifactHandle, OpticArtifactRegistrationError> {
-        Self::verify_descriptor(&artifact, &descriptor)?;
+        if let Err(error) = Self::verify_descriptor(&artifact, &descriptor) {
+            self.publish_artifact_registration_obstruction(&descriptor, &error);
+            return Err(error);
+        }
 
         let handle = self.next_handle();
+        let artifact_hash = artifact.artifact_hash;
+        let schema_id = artifact.schema_id;
+        let operation_id = artifact.operation.operation_id;
+        let requirements_digest = artifact.requirements_digest;
         let registered = RegisteredOpticArtifact {
             handle: handle.clone(),
             artifact_id: artifact.artifact_id,
-            artifact_hash: artifact.artifact_hash,
-            schema_id: artifact.schema_id,
-            operation_id: artifact.operation.operation_id,
-            requirements_digest: artifact.requirements_digest,
+            artifact_hash: artifact_hash.clone(),
+            schema_id: schema_id.clone(),
+            operation_id: operation_id.clone(),
+            requirements_digest: requirements_digest.clone(),
             requirements: artifact.requirements,
         };
         self.artifacts_by_handle
             .insert(handle.id.clone(), registered);
+        self.publish_artifact_registered_fact(
+            &handle,
+            artifact_hash,
+            schema_id,
+            operation_id,
+            requirements_digest,
+        );
 
         Ok(handle)
     }
@@ -809,6 +829,19 @@ impl OpticArtifactRegistry {
         self.artifacts_by_handle.is_empty()
     }
 
+    /// Returns in-memory graph facts published by this registry instance.
+    #[must_use]
+    pub fn published_graph_facts(&self) -> &[PublishedGraphFact] {
+        &self.published_graph_facts
+    }
+
+    /// Returns in-memory artifact registration receipts emitted by this
+    /// registry instance.
+    #[must_use]
+    pub fn artifact_registration_receipts(&self) -> &[ArtifactRegistrationReceipt] {
+        &self.artifact_registration_receipts
+    }
+
     fn verify_descriptor(
         artifact: &OpticArtifact,
         descriptor: &OpticRegistrationDescriptor,
@@ -840,5 +873,69 @@ impl OpticArtifactRegistry {
                 self.next_handle_index
             ),
         }
+    }
+
+    fn publish_artifact_registered_fact(
+        &mut self,
+        handle: &OpticArtifactHandle,
+        artifact_hash: String,
+        schema_id: String,
+        operation_id: String,
+        requirements_digest: String,
+    ) {
+        let published = PublishedGraphFact::new(GraphFact::ArtifactRegistered {
+            handle_id: handle.id.clone(),
+            artifact_hash: artifact_hash.clone(),
+            schema_id,
+            operation_id: operation_id.clone(),
+            requirements_digest,
+        });
+        self.artifact_registration_receipts
+            .push(ArtifactRegistrationReceipt {
+                kind: ARTIFACT_REGISTRATION_RECEIPT_KIND.to_owned(),
+                handle_id: handle.id.clone(),
+                artifact_hash,
+                operation_id,
+                fact_digest: published.digest,
+            });
+        self.published_graph_facts.push(published);
+    }
+
+    fn publish_artifact_registration_obstruction(
+        &mut self,
+        descriptor: &OpticRegistrationDescriptor,
+        error: &OpticArtifactRegistrationError,
+    ) {
+        if let Some(obstruction) = artifact_registration_obstruction_kind(error) {
+            self.published_graph_facts.push(PublishedGraphFact::new(
+                GraphFact::ArtifactRegistrationObstructed {
+                    artifact_hash: Some(descriptor.artifact_hash.clone()),
+                    obstruction,
+                },
+            ));
+        }
+    }
+}
+
+fn artifact_registration_obstruction_kind(
+    error: &OpticArtifactRegistrationError,
+) -> Option<ArtifactRegistrationObstructionKind> {
+    match error {
+        OpticArtifactRegistrationError::ArtifactIdMismatch => {
+            Some(ArtifactRegistrationObstructionKind::ArtifactIdMismatch)
+        }
+        OpticArtifactRegistrationError::ArtifactHashMismatch => {
+            Some(ArtifactRegistrationObstructionKind::ArtifactHashMismatch)
+        }
+        OpticArtifactRegistrationError::SchemaIdMismatch => {
+            Some(ArtifactRegistrationObstructionKind::SchemaIdMismatch)
+        }
+        OpticArtifactRegistrationError::OperationIdMismatch => {
+            Some(ArtifactRegistrationObstructionKind::OperationIdMismatch)
+        }
+        OpticArtifactRegistrationError::RequirementsDigestMismatch => {
+            Some(ArtifactRegistrationObstructionKind::RequirementsDigestMismatch)
+        }
+        OpticArtifactRegistrationError::UnknownHandle => None,
     }
 }

--- a/crates/warp-core/tests/causal_fact_publication_tests.rs
+++ b/crates/warp-core/tests/causal_fact_publication_tests.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Regression tests for graph fact publication from optic artifact registration.
+
+use warp_core::{
+    ArtifactRegistrationObstructionKind, GraphFact, OpticAdmissionRequirements, OpticArtifact,
+    OpticArtifactOperation, OpticArtifactRegistrationError, OpticArtifactRegistry,
+    OpticRegistrationDescriptor, ARTIFACT_REGISTRATION_RECEIPT_KIND,
+};
+
+fn fixture_artifact() -> OpticArtifact {
+    OpticArtifact {
+        artifact_id: "optic-artifact:stack-witness-0001".to_owned(),
+        artifact_hash: "artifact-hash:stack-witness-0001".to_owned(),
+        schema_id: "schema:jedit-text-buffer-optic:v0".to_owned(),
+        requirements_digest: "requirements-digest:stack-witness-0001".to_owned(),
+        operation: OpticArtifactOperation {
+            operation_id: "operation:textWindow:v0".to_owned(),
+        },
+        requirements: OpticAdmissionRequirements {
+            bytes: b"fixture admission requirements".to_vec(),
+        },
+    }
+}
+
+fn fixture_descriptor() -> OpticRegistrationDescriptor {
+    OpticRegistrationDescriptor {
+        artifact_id: "optic-artifact:stack-witness-0001".to_owned(),
+        artifact_hash: "artifact-hash:stack-witness-0001".to_owned(),
+        schema_id: "schema:jedit-text-buffer-optic:v0".to_owned(),
+        operation_id: "operation:textWindow:v0".to_owned(),
+        requirements_digest: "requirements-digest:stack-witness-0001".to_owned(),
+    }
+}
+
+fn registration_err_or_panic<T>(
+    result: Result<T, OpticArtifactRegistrationError>,
+    context: &str,
+) -> Result<OpticArtifactRegistrationError, String> {
+    match result {
+        Ok(_) => Err(format!("{context}: expected registration error")),
+        Err(err) => Ok(err),
+    }
+}
+
+#[test]
+fn artifact_registration_publishes_graph_fact_and_receipt() -> Result<(), String> {
+    let mut registry = OpticArtifactRegistry::new();
+    let handle = registry
+        .register_optic_artifact(fixture_artifact(), fixture_descriptor())
+        .map_err(|err| format!("fixture descriptor should register: {err:?}"))?;
+
+    assert_eq!(registry.published_graph_facts().len(), 1);
+    assert_eq!(registry.artifact_registration_receipts().len(), 1);
+
+    let published = &registry.published_graph_facts()[0];
+    let receipt = &registry.artifact_registration_receipts()[0];
+
+    assert_eq!(receipt.kind, ARTIFACT_REGISTRATION_RECEIPT_KIND);
+    assert_eq!(receipt.handle_id, handle.id);
+    assert_eq!(receipt.fact_digest, published.digest);
+    assert_eq!(published.digest, published.fact.digest());
+
+    assert!(matches!(
+        &published.fact,
+        GraphFact::ArtifactRegistered {
+            handle_id,
+            artifact_hash,
+            schema_id,
+            operation_id,
+            requirements_digest,
+        } if handle_id == &receipt.handle_id
+            && artifact_hash == "artifact-hash:stack-witness-0001"
+            && schema_id == "schema:jedit-text-buffer-optic:v0"
+            && operation_id == "operation:textWindow:v0"
+            && requirements_digest == "requirements-digest:stack-witness-0001"
+    ));
+    Ok(())
+}
+
+#[test]
+fn artifact_registration_obstruction_publishes_graph_fact_without_receipt() -> Result<(), String> {
+    let mut descriptor = fixture_descriptor();
+    descriptor.operation_id = "operation:tampered:v0".to_owned();
+    let mut registry = OpticArtifactRegistry::new();
+
+    let err = registration_err_or_panic(
+        registry.register_optic_artifact(fixture_artifact(), descriptor),
+        "tampered operation id should reject",
+    )?;
+
+    assert!(matches!(
+        err,
+        OpticArtifactRegistrationError::OperationIdMismatch
+    ));
+    assert_eq!(registry.len(), 0);
+    assert_eq!(registry.published_graph_facts().len(), 1);
+    assert!(registry.artifact_registration_receipts().is_empty());
+
+    let published = &registry.published_graph_facts()[0];
+    assert_eq!(published.digest, published.fact.digest());
+    assert!(matches!(
+        &published.fact,
+        GraphFact::ArtifactRegistrationObstructed {
+            artifact_hash,
+            obstruction,
+        } if artifact_hash.as_deref() == Some("artifact-hash:stack-witness-0001")
+            && *obstruction == ArtifactRegistrationObstructionKind::OperationIdMismatch
+    ));
+    Ok(())
+}
+
+#[test]
+fn graph_fact_digest_is_deterministic_and_kind_separated() {
+    let registered = GraphFact::ArtifactRegistered {
+        handle_id: "handle-1".to_owned(),
+        artifact_hash: "same-artifact".to_owned(),
+        schema_id: "schema".to_owned(),
+        operation_id: "operation".to_owned(),
+        requirements_digest: "requirements".to_owned(),
+    };
+    let repeated = registered.clone();
+    let obstructed = GraphFact::ArtifactRegistrationObstructed {
+        artifact_hash: Some("same-artifact".to_owned()),
+        obstruction: ArtifactRegistrationObstructionKind::ArtifactHashMismatch,
+    };
+
+    assert_eq!(registered.digest(), repeated.digest());
+    assert_ne!(registered.digest(), obstructed.digest());
+}
+
+#[test]
+fn graph_fact_digest_distinguishes_absent_and_empty_optional_fields() {
+    let absent = GraphFact::ArtifactRegistrationObstructed {
+        artifact_hash: None,
+        obstruction: ArtifactRegistrationObstructionKind::ArtifactHashMismatch,
+    };
+    let empty = GraphFact::ArtifactRegistrationObstructed {
+        artifact_hash: Some(String::new()),
+        obstruction: ArtifactRegistrationObstructionKind::ArtifactHashMismatch,
+    };
+
+    assert_ne!(absent.digest(), empty.digest());
+}

--- a/docs/design/graph-fact-publication-skeleton.md
+++ b/docs/design/graph-fact-publication-skeleton.md
@@ -1,0 +1,241 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Graph Fact Publication Skeleton
+
+Status: implementation slice.
+Scope: first in-memory publication of Echo-owned causal graph facts from optic
+artifact registration.
+
+## Doctrine
+
+Echo needs to explain its own runtime decisions through graph facts before
+authority, admission, transactions, receipts, witnesses, and materialized
+readings can become durable rather than decorative.
+
+Receipts explain graph outcomes. They do not replace graph facts.
+
+```text
+fact = world statement
+receipt = explanation or publication boundary that references fact digests
+```
+
+This slice proves only one loop:
+
+```text
+register optic artifact
+  -> issue Echo-owned opaque handle
+  -> publish ArtifactRegistered graph fact
+  -> compute deterministic FactDigest
+  -> publish registration receipt referencing FactDigest
+```
+
+Registration obstruction also publishes an obstruction fact, but it does not
+produce an artifact handle or a success receipt.
+
+## Naming boundary
+
+This slice uses `causal_facts` for native substrate facts. It intentionally does
+not use the existing `echo-graph` crate name. The existing crate is not the
+native causal substrate; this slice introduces the narrower substrate fact
+vocabulary that future graph, authority, and transaction work can target.
+
+## Non-goals
+
+- no scheduler;
+- no execution;
+- no witnesses;
+- no graph database;
+- no persistence layer;
+- no transactions;
+- no grants;
+- no invocation success;
+- no materialization;
+- no Continuum schema.
+
+## Deterministic digest law
+
+`FactDigest` is BLAKE3 over explicitly encoded fact input bytes.
+
+Digest input uses:
+
+- a domain tag;
+- variant tags;
+- field tags;
+- length-prefixed bytes;
+- present/absent markers for optional fields.
+
+Digest input must not use JSON.
+
+Absent fields and empty fields are distinct:
+
+```text
+artifact_hash = absent
+artifact_hash = present("")
+```
+
+must produce different fact digests.
+
+## Fact model v0
+
+```rust
+GraphFact::ArtifactRegistered {
+    handle_id,
+    artifact_hash,
+    schema_id,
+    operation_id,
+    requirements_digest,
+}
+
+GraphFact::ArtifactRegistrationObstructed {
+    artifact_hash,
+    obstruction,
+}
+```
+
+`ArtifactRegistered` is the first success world statement. It says Echo
+accepted one Wesley-compiled artifact descriptor and assigned a runtime-local
+handle.
+
+`ArtifactRegistrationObstructed` is a refusal world statement. It says Echo
+refused a registration attempt before issuing a handle.
+
+## Receipt linkage
+
+The first registration receipt is deliberately small:
+
+```rust
+ArtifactRegistrationReceipt {
+    kind,
+    handle_id,
+    artifact_hash,
+    operation_id,
+    fact_digest,
+}
+```
+
+The receipt references the fact digest. It is not itself the fact.
+
+## Flow
+
+```mermaid
+flowchart TD
+  App[Application or adapter]
+  Artifact[OpticArtifact]
+  Descriptor[OpticRegistrationDescriptor]
+  Registry[OpticArtifactRegistry]
+  Verify[Verify descriptor]
+  Handle[Opaque OpticArtifactHandle]
+  Fact[GraphFact::ArtifactRegistered]
+  Digest[FactDigest]
+  Receipt[ArtifactRegistrationReceipt]
+  ObstructFact[GraphFact::ArtifactRegistrationObstructed]
+
+  App --> Artifact
+  App --> Descriptor
+  Artifact --> Registry
+  Descriptor --> Registry
+  Registry --> Verify
+  Verify -->|valid| Handle
+  Handle --> Fact
+  Fact --> Digest
+  Digest --> Receipt
+  Verify -->|invalid| ObstructFact
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+  participant Caller as caller
+  participant Registry as OpticArtifactRegistry
+  participant Facts as in-memory fact log
+  participant Receipts as registration receipts
+
+  Caller->>Registry: register_optic_artifact(artifact, descriptor)
+  Registry->>Registry: verify descriptor identity and requirements
+  Registry->>Registry: issue runtime-local handle
+  Registry->>Facts: append ArtifactRegistered
+  Facts-->>Registry: FactDigest
+  Registry->>Receipts: append ArtifactRegistrationReceipt(fact_digest)
+  Registry-->>Caller: OpticArtifactHandle
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class OpticArtifactRegistry {
+    -artifacts_by_handle
+    -published_graph_facts
+    -artifact_registration_receipts
+    +register_optic_artifact()
+    +published_graph_facts()
+    +artifact_registration_receipts()
+  }
+
+  class GraphFact {
+    ArtifactRegistered
+    ArtifactRegistrationObstructed
+    +digest()
+  }
+
+  class PublishedGraphFact {
+    +fact
+    +digest
+  }
+
+  class FactDigest {
+    +bytes()
+  }
+
+  class ArtifactRegistrationReceipt {
+    +kind
+    +handle_id
+    +artifact_hash
+    +operation_id
+    +fact_digest
+  }
+
+  OpticArtifactRegistry --> PublishedGraphFact
+  PublishedGraphFact --> GraphFact
+  PublishedGraphFact --> FactDigest
+  OpticArtifactRegistry --> ArtifactRegistrationReceipt
+  ArtifactRegistrationReceipt --> FactDigest
+```
+
+## Entity relationship
+
+```mermaid
+erDiagram
+  OPTIC_ARTIFACT_REGISTRY ||--o{ REGISTERED_OPTIC_ARTIFACT : stores
+  OPTIC_ARTIFACT_REGISTRY ||--o{ PUBLISHED_GRAPH_FACT : publishes
+  OPTIC_ARTIFACT_REGISTRY ||--o{ ARTIFACT_REGISTRATION_RECEIPT : emits
+  PUBLISHED_GRAPH_FACT ||--|| FACT_DIGEST : has
+  ARTIFACT_REGISTRATION_RECEIPT ||--|| FACT_DIGEST : references
+  REGISTERED_OPTIC_ARTIFACT ||--|| OPTIC_ARTIFACT_HANDLE : has
+
+  PUBLISHED_GRAPH_FACT {
+    string fact_variant
+    bytes fact_digest
+  }
+
+  ARTIFACT_REGISTRATION_RECEIPT {
+    string kind
+    string handle_id
+    string artifact_hash
+    string operation_id
+    bytes fact_digest
+  }
+
+  OPTIC_ARTIFACT_HANDLE {
+    string kind
+    string id
+  }
+```
+
+## Operating rule
+
+If a runtime decision cannot point to graph facts, it is not yet substrate
+visible. More authority vocabulary should wait until the publication substrate
+can carry the decision.


### PR DESCRIPTION
Adds the first Echo substrate fact publication path: optic artifact registration now publishes deterministic graph facts and links successful registration receipts to fact digests.\n\nDoctrine:\nReceipts explain graph outcomes; they do not replace graph facts.\nRegistration success publishes ArtifactRegistered.\nRegistration refusal publishes ArtifactRegistrationObstructed.\nObstruction facts are causal refusal records, not counterfactuals, not handles, and not authority.\n\nScope:\n- in-memory only\n- no scheduler\n- no execution\n- no witnesses\n- no graph DB\n- no persistence layer\n- no transactions\n- no grants\n- no invocation success\n- no materialization\n- no Continuum schema