### PR TITLE
feat(core): add basis-bound optic admission shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ### Added
 
+- `warp-core` optic invocation admission now has a basis-bound obstruction
+  shell. Empty basis request bytes obstruct as `MissingBasisRequest`; identity
+  covered capability presentations still obstruct as `UnsupportedBasisResolution`
+  because Echo has not wired basis resolution, admission tickets, law witnesses,
+  scheduler work, or execution into invocation admission.
+- `docs/design/basis-bound-optic-admission.md` defines the current basis
+  boundary: basis selection is explicit admission context, and covered authority
+  material still cannot authorize execution without basis resolution.
 - `warp-core` optic invocation admission can now route bound capability
   presentations through a narrow `CapabilityPresentationValidator` to publish
   sharper grant-validation obstruction facts while preserving conservative

--- a/crates/warp-core/src/causal_facts.rs
+++ b/crates/warp-core/src/causal_facts.rs
@@ -43,6 +43,11 @@ pub enum InvocationObstructionKind {
     UnknownHandle,
     /// Invocation operation id did not match the registered artifact operation.
     OperationMismatch,
+    /// Invocation supplied no basis request bytes.
+    MissingBasisRequest,
+    /// Invocation reached the basis boundary before Echo had a resolver that
+    /// can bind the request to a causal basis.
+    UnsupportedBasisResolution,
     /// Invocation supplied no capability presentation.
     MissingCapability,
     /// Invocation supplied a malformed capability presentation.
@@ -81,6 +86,8 @@ impl InvocationObstructionKind {
         match self {
             Self::UnknownHandle => b"unknown-handle",
             Self::OperationMismatch => b"operation-mismatch",
+            Self::MissingBasisRequest => b"missing-basis-request",
+            Self::UnsupportedBasisResolution => b"unsupported-basis-resolution",
             Self::MissingCapability => b"missing-capability",
             Self::MalformedCapabilityPresentation => b"malformed-capability-presentation",
             Self::UnboundCapabilityPresentation => b"unbound-capability-presentation",

--- a/crates/warp-core/src/optic_artifact.rs
+++ b/crates/warp-core/src/optic_artifact.rs
@@ -9,7 +9,8 @@
 //! invocation admission, issuing success tickets, emitting law witnesses, or
 //! executing runtime work. A capability presentation slot is not authority;
 //! every presentation posture obstructs until Echo can validate a real bounded
-//! grant and admit authority.
+//! grant and admit authority. Basis request bytes are explicit admission
+//! context; they are not resolved into authority or execution in this slice.
 
 use std::collections::BTreeMap;
 
@@ -591,6 +592,11 @@ pub enum OpticInvocationObstruction {
     UnknownHandle,
     /// The invocation operation id does not match the registered artifact.
     OperationMismatch,
+    /// The invocation does not name any basis request bytes.
+    MissingBasisRequest,
+    /// The invocation reached basis resolution, but Echo has no basis resolver
+    /// wired into admission in this slice.
+    UnsupportedBasisResolution,
     /// The invocation does not carry authority to use the registered artifact.
     MissingCapability,
     /// The invocation carries a presentation that is structurally unusable.
@@ -1081,6 +1087,10 @@ impl OpticArtifactRegistry {
                 .obstructed_invocation(invocation, OpticInvocationObstruction::OperationMismatch);
         }
 
+        if let Some(obstruction) = Self::classify_basis_request(&invocation.basis_request) {
+            return self.obstructed_invocation(invocation, obstruction);
+        }
+
         self.obstructed_invocation(
             invocation,
             Self::classify_capability_presentation(invocation.capability_presentation.as_ref()),
@@ -1113,21 +1123,39 @@ impl OpticArtifactRegistry {
                 .obstructed_invocation(invocation, OpticInvocationObstruction::OperationMismatch);
         }
 
+        if let Some(obstruction) = Self::classify_basis_request(&invocation.basis_request) {
+            return self.obstructed_invocation(invocation, obstruction);
+        }
+
         let obstruction =
             Self::classify_capability_presentation(invocation.capability_presentation.as_ref());
         if obstruction != OpticInvocationObstruction::CapabilityValidationUnavailable {
             return self.obstructed_invocation(invocation, obstruction);
         }
 
+        let mut final_obstruction = OpticInvocationObstruction::CapabilityValidationUnavailable;
         if let Some(presentation) = invocation.capability_presentation.as_ref() {
-            let _ =
+            let validation =
                 validator.validate_capability_presentation(registered, invocation, presentation);
+            if matches!(
+                validation,
+                CapabilityGrantValidationOutcome::IdentityCovered(_)
+            ) {
+                final_obstruction = OpticInvocationObstruction::UnsupportedBasisResolution;
+            }
         }
 
-        self.obstructed_invocation(
-            invocation,
-            OpticInvocationObstruction::CapabilityValidationUnavailable,
-        )
+        self.obstructed_invocation(invocation, final_obstruction)
+    }
+
+    fn classify_basis_request(
+        basis_request: &OpticBasisRequest,
+    ) -> Option<OpticInvocationObstruction> {
+        if basis_request.bytes.is_empty() {
+            return Some(OpticInvocationObstruction::MissingBasisRequest);
+        }
+
+        None
     }
 
     fn classify_capability_presentation(
@@ -1323,6 +1351,12 @@ fn invocation_obstruction_kind(
         OpticInvocationObstruction::UnknownHandle => InvocationObstructionKind::UnknownHandle,
         OpticInvocationObstruction::OperationMismatch => {
             InvocationObstructionKind::OperationMismatch
+        }
+        OpticInvocationObstruction::MissingBasisRequest => {
+            InvocationObstructionKind::MissingBasisRequest
+        }
+        OpticInvocationObstruction::UnsupportedBasisResolution => {
+            InvocationObstructionKind::UnsupportedBasisResolution
         }
         OpticInvocationObstruction::MissingCapability => {
             InvocationObstructionKind::MissingCapability

--- a/crates/warp-core/tests/optic_invocation_admission_tests.rs
+++ b/crates/warp-core/tests/optic_invocation_admission_tests.rs
@@ -164,6 +164,21 @@ fn optic_invocation_obstructs_missing_capability_for_registered_handle() -> Resu
 }
 
 #[test]
+fn optic_invocation_obstructs_missing_basis_request() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.basis_request = OpticBasisRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        outcome,
+        expected_obstructed_posture(&invocation, OpticInvocationObstruction::MissingBasisRequest)
+    );
+    Ok(())
+}
+
+#[test]
 fn optic_invocation_obstructs_malformed_capability_presentation() -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let mut invocation = fixture_invocation(handle);
@@ -441,7 +456,7 @@ fn invocation_with_requirements_digest_mismatch_publishes_grant_validation_obstr
 }
 
 #[test]
-fn identity_covered_grant_still_does_not_admit_invocation() -> Result<(), String> {
+fn identity_covered_grant_obstructs_unsupported_basis_resolution() -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let invocation = fixture_invocation_with_presentation(handle, "grant:covered");
     let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
@@ -450,7 +465,7 @@ fn identity_covered_grant_still_does_not_admit_invocation() -> Result<(), String
 
     assert_eq!(
         obstruction_for(&outcome),
-        OpticInvocationObstruction::CapabilityValidationUnavailable
+        OpticInvocationObstruction::UnsupportedBasisResolution
     );
     assert!(gate.published_graph_facts().is_empty());
     assert!(matches!(
@@ -458,7 +473,7 @@ fn identity_covered_grant_still_does_not_admit_invocation() -> Result<(), String
         GraphFact::OpticInvocationObstructed {
             obstruction,
             ..
-        } if *obstruction == InvocationObstructionKind::CapabilityValidationUnavailable
+        } if *obstruction == InvocationObstructionKind::UnsupportedBasisResolution
     ));
     Ok(())
 }
@@ -519,6 +534,33 @@ fn missing_capability_publishes_invocation_obstruction_fact() -> Result<(), Stri
 }
 
 #[test]
+fn missing_basis_request_publishes_invocation_obstruction_fact() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.basis_request = OpticBasisRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::MissingBasisRequest
+    );
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed {
+            basis_request_digest,
+            obstruction,
+            ..
+        } if *basis_request_digest == digest_invocation_request_bytes(
+                b"echo.optic-invocation.basis-request.v0",
+                b""
+            )
+            && *obstruction == InvocationObstructionKind::MissingBasisRequest
+    ));
+    Ok(())
+}
+
+#[test]
 fn invocation_obstruction_fact_digest_is_deterministic() {
     let first = GraphFact::OpticInvocationObstructed {
         artifact_handle_id: "handle:1".to_owned(),
@@ -540,6 +582,27 @@ fn invocation_obstruction_fact_digest_is_deterministic() {
 }
 
 #[test]
+fn basis_obstruction_fact_digest_is_deterministic() {
+    let first = GraphFact::OpticInvocationObstructed {
+        artifact_handle_id: "handle:1".to_owned(),
+        operation_id: "operation:textWindow:v0".to_owned(),
+        canonical_variables_digest: b"vars".to_vec(),
+        basis_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.basis-request.v0",
+            b"basis",
+        ),
+        aperture_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.aperture-request.v0",
+            b"aperture",
+        ),
+        obstruction: InvocationObstructionKind::UnsupportedBasisResolution,
+    };
+    let repeated = first.clone();
+
+    assert_eq!(first.digest(), repeated.digest());
+}
+
+#[test]
 fn invocation_obstruction_fact_is_not_counterfactual_candidate() -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let invocation = fixture_invocation(handle);
@@ -549,6 +612,30 @@ fn invocation_obstruction_fact_is_not_counterfactual_candidate() -> Result<(), S
     assert_eq!(
         obstruction_for(&outcome),
         OpticInvocationObstruction::MissingCapability
+    );
+    let disposition = RewriteDisposition::Obstructed;
+    assert_ne!(
+        disposition,
+        RewriteDisposition::LegalUnselectedCounterfactual
+    );
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn basis_obstruction_is_not_counterfactual_candidate() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.basis_request = OpticBasisRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::MissingBasisRequest
     );
     let disposition = RewriteDisposition::Obstructed;
     assert_ne!(

--- a/docs/design/basis-bound-optic-admission.md
+++ b/docs/design/basis-bound-optic-admission.md
@@ -1,0 +1,165 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Basis-Bound Optic Admission
+
+Status: implementation slice.
+Scope: obstruction-only basis boundary for optic invocation admission.
+
+## Doctrine
+
+Admission decisions are evaluated against an explicit basis.
+
+Basis selection is causal context, not caller folklore. A valid
+`OpticArtifactHandle`, a matching operation id, and capability material that
+covers registered artifact identity still do not authorize execution unless Echo
+can resolve the requested basis.
+
+This slice does not resolve basis requests successfully. It only makes basis
+participation explicit:
+
+```text
+empty basis request -> MissingBasisRequest
+identity covered but no basis resolver -> UnsupportedBasisResolution
+```
+
+Both outcomes remain obstructions. They are not admission tickets, not law
+witnesses, not scheduler work, and not execution.
+
+## Flow
+
+```mermaid
+flowchart TD
+  Invocation[OpticInvocation]
+  Registry[OpticArtifactRegistry]
+  Handle[handle resolution]
+  Operation[operation id check]
+  Basis[basis request check]
+  Presentation[presentation classification]
+  Validator[CapabilityPresentationValidator]
+  BasisResolution[basis resolution unavailable]
+  Fact[GraphFact::OpticInvocationObstructed]
+  Posture[OpticAdmissionTicketPosture]
+
+  Invocation --> Registry
+  Registry --> Handle
+  Handle --> Operation
+  Operation --> Basis
+  Basis -->|empty| Fact
+  Basis -->|non-empty| Presentation
+  Presentation -->|structurally unavailable| Fact
+  Presentation -->|structurally available| Validator
+  Validator -->|identity covered| BasisResolution
+  Validator -->|validation obstructed| Fact
+  BasisResolution --> Fact
+  Fact --> Posture
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+  participant Caller as caller
+  participant Registry as OpticArtifactRegistry
+  participant Validator as CapabilityPresentationValidator
+  participant Facts as graph fact log
+
+  Caller->>Registry: admit_optic_invocation_with_capability_validator(invocation, validator)
+  Registry->>Registry: resolve artifact handle
+  Registry->>Registry: check operation id
+  Registry->>Registry: reject empty basis request
+  Registry->>Registry: classify presentation shape
+  alt presentation structurally available
+    Registry->>Validator: validate_capability_presentation(artifact, invocation, presentation)
+    Validator->>Facts: publish grant validation obstruction when validation fails
+    Registry->>Registry: obstruct identity-covered material at basis boundary
+  else missing, malformed, or unbound presentation
+    Registry->>Registry: skip validator
+  end
+  Registry->>Facts: publish OpticInvocationObstructed
+  Registry-->>Caller: Obstructed(...)
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class OpticInvocation {
+    +artifact_handle
+    +operation_id
+    +canonical_variables_digest
+    +basis_request
+    +aperture_request
+    +capability_presentation
+  }
+
+  class OpticBasisRequest {
+    +bytes
+  }
+
+  class OpticInvocationObstruction {
+    MissingBasisRequest
+    UnsupportedBasisResolution
+    MissingCapability
+    CapabilityValidationUnavailable
+  }
+
+  class OpticAdmissionTicketPosture {
+    +basis_request
+    +aperture_request
+    +obstruction
+  }
+
+  OpticInvocation --> OpticBasisRequest
+  OpticAdmissionTicketPosture --> OpticBasisRequest
+  OpticAdmissionTicketPosture --> OpticInvocationObstruction
+```
+
+## Entity relationship
+
+```mermaid
+erDiagram
+  OPTIC_INVOCATION ||--|| BASIS_REQUEST : names
+  OPTIC_INVOCATION ||--|| APERTURE_REQUEST : names
+  OPTIC_INVOCATION ||--|| INVOCATION_OBSTRUCTION_FACT : produces_when_refused
+  INVOCATION_OBSTRUCTION_FACT ||--|| BASIS_REQUEST_DIGEST : records
+  INVOCATION_OBSTRUCTION_FACT ||--|| APERTURE_REQUEST_DIGEST : records
+
+  OPTIC_INVOCATION {
+    string artifact_handle_id
+    string operation_id
+    bytes canonical_variables_digest
+  }
+
+  BASIS_REQUEST {
+    bytes opaque_request
+  }
+
+  APERTURE_REQUEST {
+    bytes opaque_request
+  }
+
+  INVOCATION_OBSTRUCTION_FACT {
+    bytes basis_request_digest
+    bytes aperture_request_digest
+    string obstruction
+  }
+```
+
+## Operating rule
+
+Basis resolution is not ambient. If Echo cannot bind an invocation to an
+explicit causal basis, the invocation remains refused even when artifact
+identity and capability material line up.
+
+## Non-goals
+
+- no successful basis resolution;
+- no successful invocation admission;
+- no successful `AdmissionTicket`;
+- no `LawWitness`;
+- no scheduler work;
+- no execution;
+- no storage engine;
+- no WASM ABI;
+- no Continuum schema.


### PR DESCRIPTION
Adds the next obstruction-only optic admission vertebra: invocation admission now treats basis request bytes as explicit admission context.

Doctrine:
- Admission decisions are evaluated against an explicit basis.
- Basis selection is causal context, not caller folklore.
- Covered capability identity still does not authorize execution without basis resolution.

Behavior:
- Empty basis request bytes obstruct as MissingBasisRequest.
- Identity-covered capability presentations still obstruct as UnsupportedBasisResolution because no basis resolver exists yet.
- Invocation obstruction facts remain deterministic and are not counterfactual candidates.

Scope:
- docs/design/basis-bound-optic-admission.md
- no successful basis resolution
- no successful invocation admission
- no AdmissionTicket
- no LawWitness
- no scheduler work
- no execution
- no storage engine
- no WASM ABI
- no Continuum schema

Verification:
- cargo test -p warp-core --test optic_invocation_admission_tests
- cargo check -p warp-core
- cargo fmt --all -- --check
- npx markdownlint-cli2 docs/design/basis-bound-optic-admission.md CHANGELOG.md
- git diff --check
- scripts/ban-nondeterminism.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optic invocations now enforce explicit basis context requirements; invocations missing required basis request bytes are blocked.
  * Unsupported basis resolution scenarios are now properly detected and obstructed during admission.

* **Documentation**
  * Added design documentation outlining basis-bound optic invocation admission behavior, obstruction outcomes, and admission workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/echo/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->