### PR TITLE
feat(core): add aperture-bound optic admission shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ### Added
 
+- `warp-core` optic invocation admission now has an aperture-bound obstruction
+  shell. Empty aperture request bytes obstruct as `MissingApertureRequest`;
+  `UnsupportedApertureResolution` is defined as future vocabulary but remains
+  unreachable until basis resolution exists because aperture semantics are scoped
+  inside a resolved causal basis.
+- `docs/design/aperture-bound-optic-admission.md` defines aperture as the
+  visibility/effect window over a resolved basis and pins the rule that basis
+  resolution gates aperture resolution.
 - `warp-core` optic invocation admission now has a basis-bound obstruction
   shell. Empty basis request bytes obstruct as `MissingBasisRequest`; identity
   covered capability presentations still obstruct as `UnsupportedBasisResolution`

--- a/crates/warp-core/src/causal_facts.rs
+++ b/crates/warp-core/src/causal_facts.rs
@@ -45,9 +45,15 @@ pub enum InvocationObstructionKind {
     OperationMismatch,
     /// Invocation supplied no basis request bytes.
     MissingBasisRequest,
+    /// Invocation supplied no aperture request bytes.
+    MissingApertureRequest,
     /// Invocation reached the basis boundary before Echo had a resolver that
     /// can bind the request to a causal basis.
     UnsupportedBasisResolution,
+    /// Invocation reached the aperture boundary after basis resolution, but
+    /// Echo had no aperture resolver that could bind the request to a graph
+    /// region.
+    UnsupportedApertureResolution,
     /// Invocation supplied no capability presentation.
     MissingCapability,
     /// Invocation supplied a malformed capability presentation.
@@ -87,7 +93,9 @@ impl InvocationObstructionKind {
             Self::UnknownHandle => b"unknown-handle",
             Self::OperationMismatch => b"operation-mismatch",
             Self::MissingBasisRequest => b"missing-basis-request",
+            Self::MissingApertureRequest => b"missing-aperture-request",
             Self::UnsupportedBasisResolution => b"unsupported-basis-resolution",
+            Self::UnsupportedApertureResolution => b"unsupported-aperture-resolution",
             Self::MissingCapability => b"missing-capability",
             Self::MalformedCapabilityPresentation => b"malformed-capability-presentation",
             Self::UnboundCapabilityPresentation => b"unbound-capability-presentation",

--- a/crates/warp-core/src/optic_artifact.rs
+++ b/crates/warp-core/src/optic_artifact.rs
@@ -10,7 +10,8 @@
 //! executing runtime work. A capability presentation slot is not authority;
 //! every presentation posture obstructs until Echo can validate a real bounded
 //! grant and admit authority. Basis request bytes are explicit admission
-//! context; they are not resolved into authority or execution in this slice.
+//! context; aperture request bytes are explicit visibility/effect context.
+//! Neither is resolved into authority or execution in this slice.
 
 use std::collections::BTreeMap;
 
@@ -594,9 +595,14 @@ pub enum OpticInvocationObstruction {
     OperationMismatch,
     /// The invocation does not name any basis request bytes.
     MissingBasisRequest,
+    /// The invocation does not name any aperture request bytes.
+    MissingApertureRequest,
     /// The invocation reached basis resolution, but Echo has no basis resolver
     /// wired into admission in this slice.
     UnsupportedBasisResolution,
+    /// The invocation reached aperture resolution, but Echo has no aperture
+    /// resolver wired into admission in this slice.
+    UnsupportedApertureResolution,
     /// The invocation does not carry authority to use the registered artifact.
     MissingCapability,
     /// The invocation carries a presentation that is structurally unusable.
@@ -1091,6 +1097,10 @@ impl OpticArtifactRegistry {
             return self.obstructed_invocation(invocation, obstruction);
         }
 
+        if let Some(obstruction) = Self::classify_aperture_request(&invocation.aperture_request) {
+            return self.obstructed_invocation(invocation, obstruction);
+        }
+
         self.obstructed_invocation(
             invocation,
             Self::classify_capability_presentation(invocation.capability_presentation.as_ref()),
@@ -1127,6 +1137,10 @@ impl OpticArtifactRegistry {
             return self.obstructed_invocation(invocation, obstruction);
         }
 
+        if let Some(obstruction) = Self::classify_aperture_request(&invocation.aperture_request) {
+            return self.obstructed_invocation(invocation, obstruction);
+        }
+
         let obstruction =
             Self::classify_capability_presentation(invocation.capability_presentation.as_ref());
         if obstruction != OpticInvocationObstruction::CapabilityValidationUnavailable {
@@ -1153,6 +1167,16 @@ impl OpticArtifactRegistry {
     ) -> Option<OpticInvocationObstruction> {
         if basis_request.bytes.is_empty() {
             return Some(OpticInvocationObstruction::MissingBasisRequest);
+        }
+
+        None
+    }
+
+    fn classify_aperture_request(
+        aperture_request: &OpticApertureRequest,
+    ) -> Option<OpticInvocationObstruction> {
+        if aperture_request.bytes.is_empty() {
+            return Some(OpticInvocationObstruction::MissingApertureRequest);
         }
 
         None
@@ -1355,8 +1379,14 @@ fn invocation_obstruction_kind(
         OpticInvocationObstruction::MissingBasisRequest => {
             InvocationObstructionKind::MissingBasisRequest
         }
+        OpticInvocationObstruction::MissingApertureRequest => {
+            InvocationObstructionKind::MissingApertureRequest
+        }
         OpticInvocationObstruction::UnsupportedBasisResolution => {
             InvocationObstructionKind::UnsupportedBasisResolution
+        }
+        OpticInvocationObstruction::UnsupportedApertureResolution => {
+            InvocationObstructionKind::UnsupportedApertureResolution
         }
         OpticInvocationObstruction::MissingCapability => {
             InvocationObstructionKind::MissingCapability

--- a/crates/warp-core/tests/optic_invocation_admission_tests.rs
+++ b/crates/warp-core/tests/optic_invocation_admission_tests.rs
@@ -179,6 +179,24 @@ fn optic_invocation_obstructs_missing_basis_request() -> Result<(), String> {
 }
 
 #[test]
+fn optic_invocation_obstructs_missing_aperture_request() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.aperture_request = OpticApertureRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        outcome,
+        expected_obstructed_posture(
+            &invocation,
+            OpticInvocationObstruction::MissingApertureRequest
+        )
+    );
+    Ok(())
+}
+
+#[test]
 fn optic_invocation_obstructs_malformed_capability_presentation() -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let mut invocation = fixture_invocation(handle);
@@ -456,7 +474,8 @@ fn invocation_with_requirements_digest_mismatch_publishes_grant_validation_obstr
 }
 
 #[test]
-fn identity_covered_grant_obstructs_unsupported_basis_resolution() -> Result<(), String> {
+fn identity_covered_grant_obstructs_unsupported_basis_resolution_after_basis_and_aperture_presence(
+) -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let invocation = fixture_invocation_with_presentation(handle, "grant:covered");
     let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
@@ -561,6 +580,33 @@ fn missing_basis_request_publishes_invocation_obstruction_fact() -> Result<(), S
 }
 
 #[test]
+fn aperture_obstruction_publishes_invocation_obstruction_fact() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.aperture_request = OpticApertureRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::MissingApertureRequest
+    );
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed {
+            aperture_request_digest,
+            obstruction,
+            ..
+        } if *aperture_request_digest == digest_invocation_request_bytes(
+                b"echo.optic-invocation.aperture-request.v0",
+                b""
+            )
+            && *obstruction == InvocationObstructionKind::MissingApertureRequest
+    ));
+    Ok(())
+}
+
+#[test]
 fn invocation_obstruction_fact_digest_is_deterministic() {
     let first = GraphFact::OpticInvocationObstructed {
         artifact_handle_id: "handle:1".to_owned(),
@@ -603,6 +649,27 @@ fn basis_obstruction_fact_digest_is_deterministic() {
 }
 
 #[test]
+fn aperture_obstruction_fact_digest_is_deterministic() {
+    let first = GraphFact::OpticInvocationObstructed {
+        artifact_handle_id: "handle:1".to_owned(),
+        operation_id: "operation:textWindow:v0".to_owned(),
+        canonical_variables_digest: b"vars".to_vec(),
+        basis_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.basis-request.v0",
+            b"basis",
+        ),
+        aperture_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.aperture-request.v0",
+            b"aperture",
+        ),
+        obstruction: InvocationObstructionKind::MissingApertureRequest,
+    };
+    let repeated = first.clone();
+
+    assert_eq!(first.digest(), repeated.digest());
+}
+
+#[test]
 fn invocation_obstruction_fact_is_not_counterfactual_candidate() -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let invocation = fixture_invocation(handle);
@@ -636,6 +703,30 @@ fn basis_obstruction_is_not_counterfactual_candidate() -> Result<(), String> {
     assert_eq!(
         obstruction_for(&outcome),
         OpticInvocationObstruction::MissingBasisRequest
+    );
+    let disposition = RewriteDisposition::Obstructed;
+    assert_ne!(
+        disposition,
+        RewriteDisposition::LegalUnselectedCounterfactual
+    );
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn aperture_obstruction_is_not_counterfactual_candidate() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.aperture_request = OpticApertureRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::MissingApertureRequest
     );
     let disposition = RewriteDisposition::Obstructed;
     assert_ne!(

--- a/docs/design/aperture-bound-optic-admission.md
+++ b/docs/design/aperture-bound-optic-admission.md
@@ -1,0 +1,211 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Aperture-Bound Optic Admission
+
+Status: implementation slice.
+Scope: obstruction-only aperture boundary for optic invocation admission.
+
+## Doctrine
+
+A basis answers which causal state is being evaluated.
+
+An aperture answers what graph, window, or scope the invocation may see or
+affect inside that resolved basis.
+
+Basis alone is too broad. Without an aperture, a valid invocation could imply
+ambient access to the whole resolved graph state. Aperture request presence is
+therefore mandatory before Echo can continue toward authority, footprint, or
+execution checks.
+
+This slice does not resolve apertures successfully. It only makes aperture
+participation explicit:
+
+```text
+empty basis request -> MissingBasisRequest
+non-empty basis + empty aperture request -> MissingApertureRequest
+non-empty basis + non-empty aperture + identity covered -> UnsupportedBasisResolution
+```
+
+`UnsupportedApertureResolution` exists as vocabulary for the future basis
+resolved path. It is not reachable in this slice because aperture resolution is
+defined only over a resolved basis.
+
+Refusal remains causal evidence. Aperture obstruction facts are not
+counterfactual candidates.
+
+## Ordering
+
+Presence checks happen before resolution checks. Basis resolution gates aperture
+resolution.
+
+```text
+handle
+-> operation
+-> basis existence
+-> aperture existence
+-> basis resolution
+-> aperture resolution
+-> authority validation
+-> footprint compatibility
+-> execution
+```
+
+Echo must not evaluate aperture resolution before basis resolution exists.
+Aperture is a constrained projection over a resolved basis, not a globally
+meaningful graph region independent of causal state.
+
+## Flow
+
+```mermaid
+flowchart TD
+  Invocation[OpticInvocation]
+  Registry[OpticArtifactRegistry]
+  Handle[handle resolution]
+  Operation[operation id check]
+  BasisPresence[basis request present?]
+  AperturePresence[aperture request present?]
+  Presentation[presentation classification]
+  Validator[CapabilityPresentationValidator]
+  BasisResolution[basis resolution unavailable]
+  FutureAperture[Aperture resolution future slot]
+  Fact[GraphFact::OpticInvocationObstructed]
+  Posture[OpticAdmissionTicketPosture]
+
+  Invocation --> Registry
+  Registry --> Handle
+  Handle --> Operation
+  Operation --> BasisPresence
+  BasisPresence -->|missing| Fact
+  BasisPresence -->|present| AperturePresence
+  AperturePresence -->|missing| Fact
+  AperturePresence -->|present| Presentation
+  Presentation -->|structurally unavailable| Fact
+  Presentation -->|structurally available| Validator
+  Validator -->|identity covered| BasisResolution
+  Validator -->|validation obstructed| Fact
+  BasisResolution --> Fact
+  BasisResolution -. future .-> FutureAperture
+  FutureAperture -. future .-> Fact
+  Fact --> Posture
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+  participant Caller as caller
+  participant Registry as OpticArtifactRegistry
+  participant Validator as CapabilityPresentationValidator
+  participant Facts as graph fact log
+
+  Caller->>Registry: admit_optic_invocation_with_capability_validator(invocation, validator)
+  Registry->>Registry: resolve artifact handle
+  Registry->>Registry: check operation id
+  Registry->>Registry: reject empty basis request
+  Registry->>Registry: reject empty aperture request
+  Registry->>Registry: classify presentation shape
+  alt presentation structurally available
+    Registry->>Validator: validate_capability_presentation(artifact, invocation, presentation)
+    Validator->>Facts: publish grant validation obstruction when validation fails
+    Registry->>Registry: obstruct identity-covered material at basis boundary
+  else missing, malformed, or unbound presentation
+    Registry->>Registry: skip validator
+  end
+  Registry->>Facts: publish OpticInvocationObstructed
+  Registry-->>Caller: Obstructed(...)
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class OpticInvocation {
+    +artifact_handle
+    +operation_id
+    +canonical_variables_digest
+    +basis_request
+    +aperture_request
+    +capability_presentation
+  }
+
+  class OpticBasisRequest {
+    +bytes
+  }
+
+  class OpticApertureRequest {
+    +bytes
+  }
+
+  class OpticInvocationObstruction {
+    MissingBasisRequest
+    MissingApertureRequest
+    UnsupportedBasisResolution
+    UnsupportedApertureResolution
+  }
+
+  class OpticAdmissionTicketPosture {
+    +basis_request
+    +aperture_request
+    +obstruction
+  }
+
+  OpticInvocation --> OpticBasisRequest
+  OpticInvocation --> OpticApertureRequest
+  OpticAdmissionTicketPosture --> OpticBasisRequest
+  OpticAdmissionTicketPosture --> OpticApertureRequest
+  OpticAdmissionTicketPosture --> OpticInvocationObstruction
+```
+
+## Entity relationship
+
+```mermaid
+erDiagram
+  BASIS_REQUEST ||--|| APERTURE_REQUEST : gates
+  OPTIC_INVOCATION ||--|| BASIS_REQUEST : names
+  OPTIC_INVOCATION ||--|| APERTURE_REQUEST : names
+  OPTIC_INVOCATION ||--|| INVOCATION_OBSTRUCTION_FACT : produces_when_refused
+  INVOCATION_OBSTRUCTION_FACT ||--|| BASIS_REQUEST_DIGEST : records
+  INVOCATION_OBSTRUCTION_FACT ||--|| APERTURE_REQUEST_DIGEST : records
+
+  OPTIC_INVOCATION {
+    string artifact_handle_id
+    string operation_id
+    bytes canonical_variables_digest
+  }
+
+  BASIS_REQUEST {
+    bytes opaque_request
+  }
+
+  APERTURE_REQUEST {
+    bytes opaque_request
+  }
+
+  INVOCATION_OBSTRUCTION_FACT {
+    bytes basis_request_digest
+    bytes aperture_request_digest
+    string obstruction
+  }
+```
+
+## Operating rule
+
+Basis establishes the universe. Aperture establishes the window.
+
+Echo must not resolve a window before the universe exists. Until basis
+resolution is real, `UnsupportedApertureResolution` remains future vocabulary,
+not a reachable runtime branch.
+
+## Non-goals
+
+- no successful aperture resolution;
+- no successful basis resolution;
+- no successful invocation admission;
+- no successful `AdmissionTicket`;
+- no `LawWitness`;
+- no scheduler work;
+- no execution;
+- no storage engine;
+- no WASM ABI;
+- no Continuum schema.


### PR DESCRIPTION
Adds the next obstruction-only optic admission boundary: aperture request presence is now mandatory, while aperture resolution remains future work gated by basis resolution.

Doctrine:
- A basis answers which causal state is being evaluated.
- An aperture answers what graph/window/scope the invocation may see or affect inside that resolved basis.
- Basis establishes the universe; aperture establishes the window.
- Echo must not resolve a window before the universe exists.

Behavior:
- Empty basis request bytes still obstruct as MissingBasisRequest.
- Non-empty basis plus empty aperture request obstructs as MissingApertureRequest.
- Non-empty basis plus non-empty aperture plus identity-covered material still obstructs as UnsupportedBasisResolution.
- UnsupportedApertureResolution is defined as future vocabulary but is not reachable until basis resolution exists.
- Aperture obstruction facts remain deterministic and are not counterfactual candidates.

Scope:
- docs/design/aperture-bound-optic-admission.md
- no successful aperture resolution
- no successful basis resolution
- no successful invocation admission
- no AdmissionTicket
- no LawWitness
- no scheduler work
- no execution
- no storage engine
- no WASM ABI
- no Continuum schema

Verification:
- cargo test -p warp-core --test optic_invocation_admission_tests
- cargo check -p warp-core
- cargo fmt --all -- --check
- npx markdownlint-cli2 docs/design/aperture-bound-optic-admission.md CHANGELOG.md
- git diff --check
- scripts/ban-nondeterminism.sh