### PR TITLE
feat(core): add budget and runtime support admission shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Added
 
+- `warp-core` optic invocation admission now has a budget/runtime-support
+  obstruction shell. Empty budget request bytes obstruct as
+  `MissingBudgetRequest`; `UnsupportedBudgetResolution` and
+  `RuntimeSupportUnavailable` are defined as future vocabulary but remain
+  unreachable until basis and aperture resolution exist.
+- `docs/design/budget-and-runtime-support-optic-admission.md` defines budget as
+  caller-supplied bounded-resource context and runtime support as Echo-owned
+  capability checking against registered artifact requirements, not caller
+  testimony.
 - `warp-core` optic invocation admission now has an aperture-bound obstruction
   shell. Empty aperture request bytes obstruct as `MissingApertureRequest`;
   `UnsupportedApertureResolution` is defined as future vocabulary but remains

--- a/crates/warp-core/src/causal_facts.rs
+++ b/crates/warp-core/src/causal_facts.rs
@@ -47,6 +47,8 @@ pub enum InvocationObstructionKind {
     MissingBasisRequest,
     /// Invocation supplied no aperture request bytes.
     MissingApertureRequest,
+    /// Invocation supplied no budget request bytes.
+    MissingBudgetRequest,
     /// Invocation reached the basis boundary before Echo had a resolver that
     /// can bind the request to a causal basis.
     UnsupportedBasisResolution,
@@ -54,6 +56,13 @@ pub enum InvocationObstructionKind {
     /// Echo had no aperture resolver that could bind the request to a graph
     /// region.
     UnsupportedApertureResolution,
+    /// Invocation reached the budget boundary after basis and aperture
+    /// resolution, but Echo had no budget evaluator that could bind the request
+    /// to spendable runtime capacity.
+    UnsupportedBudgetResolution,
+    /// Echo could not prove that its runtime support surface covers the
+    /// registered artifact requirements.
+    RuntimeSupportUnavailable,
     /// Invocation supplied no capability presentation.
     MissingCapability,
     /// Invocation supplied a malformed capability presentation.
@@ -94,8 +103,11 @@ impl InvocationObstructionKind {
             Self::OperationMismatch => b"operation-mismatch",
             Self::MissingBasisRequest => b"missing-basis-request",
             Self::MissingApertureRequest => b"missing-aperture-request",
+            Self::MissingBudgetRequest => b"missing-budget-request",
             Self::UnsupportedBasisResolution => b"unsupported-basis-resolution",
             Self::UnsupportedApertureResolution => b"unsupported-aperture-resolution",
+            Self::UnsupportedBudgetResolution => b"unsupported-budget-resolution",
+            Self::RuntimeSupportUnavailable => b"runtime-support-unavailable",
             Self::MissingCapability => b"missing-capability",
             Self::MalformedCapabilityPresentation => b"malformed-capability-presentation",
             Self::UnboundCapabilityPresentation => b"unbound-capability-presentation",
@@ -166,6 +178,8 @@ pub enum GraphFact {
         basis_request_digest: [u8; 32],
         /// Digest of the opaque aperture request bytes.
         aperture_request_digest: [u8; 32],
+        /// Digest of the opaque budget request bytes.
+        budget_request_digest: [u8; 32],
         /// Structured invocation obstruction kind.
         obstruction: InvocationObstructionKind,
     },
@@ -239,6 +253,7 @@ impl GraphFact {
                 canonical_variables_digest,
                 basis_request_digest,
                 aperture_request_digest,
+                budget_request_digest,
                 obstruction,
             } => {
                 push_digest_field(&mut bytes, b"variant", b"optic-invocation-obstructed");
@@ -259,6 +274,7 @@ impl GraphFact {
                     b"aperture-request-digest",
                     aperture_request_digest,
                 );
+                push_digest_field(&mut bytes, b"budget-request-digest", budget_request_digest);
                 push_digest_field(&mut bytes, b"obstruction", obstruction.digest_label());
             }
             Self::CapabilityGrantValidationObstructed {

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -261,9 +261,9 @@ pub use optic_artifact::{
     CapabilityGrantValidationPosture, CapabilityPresentationValidator, ObstructionReceipt,
     OpticAdmissionRequirements, OpticAdmissionTicketPosture, OpticApertureRequest, OpticArtifact,
     OpticArtifactHandle, OpticArtifactOperation, OpticArtifactRegistrationError,
-    OpticArtifactRegistry, OpticBasisRequest, OpticCapabilityPresentation, OpticInvocation,
-    OpticInvocationAdmissionOutcome, OpticInvocationObstruction, OpticRegistrationDescriptor,
-    PrincipalRef, RegisteredOpticArtifact, RewriteDisposition,
+    OpticArtifactRegistry, OpticBasisRequest, OpticBudgetRequest, OpticCapabilityPresentation,
+    OpticInvocation, OpticInvocationAdmissionOutcome, OpticInvocationObstruction,
+    OpticRegistrationDescriptor, PrincipalRef, RegisteredOpticArtifact, RewriteDisposition,
     CAPABILITY_GRANT_VALIDATION_POSTURE_KIND, OBSTRUCTION_RECEIPT_KIND,
     OPTIC_ADMISSION_TICKET_POSTURE_KIND, OPTIC_ARTIFACT_HANDLE_KIND,
 };

--- a/crates/warp-core/src/optic_artifact.rs
+++ b/crates/warp-core/src/optic_artifact.rs
@@ -11,7 +11,8 @@
 //! every presentation posture obstructs until Echo can validate a real bounded
 //! grant and admit authority. Basis request bytes are explicit admission
 //! context; aperture request bytes are explicit visibility/effect context.
-//! Neither is resolved into authority or execution in this slice.
+//! Budget request bytes are explicit bounded-resource context. None of these
+//! request shapes are resolved into authority or execution in this slice.
 
 use std::collections::BTreeMap;
 
@@ -136,6 +137,13 @@ pub struct OpticBasisRequest {
 /// Opaque aperture request bytes supplied at optic invocation time.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OpticApertureRequest {
+    /// Request bytes interpreted only below Echo's runtime admission boundary.
+    pub bytes: Vec<u8>,
+}
+
+/// Opaque budget request bytes supplied at optic invocation time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OpticBudgetRequest {
     /// Request bytes interpreted only below Echo's runtime admission boundary.
     pub bytes: Vec<u8>,
 }
@@ -582,6 +590,8 @@ pub struct OpticInvocation {
     pub basis_request: OpticBasisRequest,
     /// Requested aperture for the invocation.
     pub aperture_request: OpticApertureRequest,
+    /// Requested resource budget for the invocation.
+    pub budget_request: OpticBudgetRequest,
     /// Caller authority presentation. Registration alone is not authority.
     pub capability_presentation: Option<OpticCapabilityPresentation>,
 }
@@ -597,12 +607,20 @@ pub enum OpticInvocationObstruction {
     MissingBasisRequest,
     /// The invocation does not name any aperture request bytes.
     MissingApertureRequest,
+    /// The invocation does not name any budget request bytes.
+    MissingBudgetRequest,
     /// The invocation reached basis resolution, but Echo has no basis resolver
     /// wired into admission in this slice.
     UnsupportedBasisResolution,
     /// The invocation reached aperture resolution, but Echo has no aperture
     /// resolver wired into admission in this slice.
     UnsupportedApertureResolution,
+    /// The invocation reached budget resolution, but Echo has no budget
+    /// evaluator wired into admission in this slice.
+    UnsupportedBudgetResolution,
+    /// Echo cannot prove that this runtime supports the registered artifact
+    /// requirements in this slice.
+    RuntimeSupportUnavailable,
     /// The invocation does not carry authority to use the registered artifact.
     MissingCapability,
     /// The invocation carries a presentation that is structurally unusable.
@@ -635,6 +653,8 @@ pub struct OpticAdmissionTicketPosture {
     pub basis_request: OpticBasisRequest,
     /// Requested aperture for the invocation.
     pub aperture_request: OpticApertureRequest,
+    /// Requested resource budget for the invocation.
+    pub budget_request: OpticBudgetRequest,
     /// Structured reason Echo obstructed before runtime execution.
     pub obstruction: OpticInvocationObstruction,
 }
@@ -1101,6 +1121,10 @@ impl OpticArtifactRegistry {
             return self.obstructed_invocation(invocation, obstruction);
         }
 
+        if let Some(obstruction) = Self::classify_budget_request(&invocation.budget_request) {
+            return self.obstructed_invocation(invocation, obstruction);
+        }
+
         self.obstructed_invocation(
             invocation,
             Self::classify_capability_presentation(invocation.capability_presentation.as_ref()),
@@ -1138,6 +1162,10 @@ impl OpticArtifactRegistry {
         }
 
         if let Some(obstruction) = Self::classify_aperture_request(&invocation.aperture_request) {
+            return self.obstructed_invocation(invocation, obstruction);
+        }
+
+        if let Some(obstruction) = Self::classify_budget_request(&invocation.budget_request) {
             return self.obstructed_invocation(invocation, obstruction);
         }
 
@@ -1182,6 +1210,16 @@ impl OpticArtifactRegistry {
         None
     }
 
+    fn classify_budget_request(
+        budget_request: &OpticBudgetRequest,
+    ) -> Option<OpticInvocationObstruction> {
+        if budget_request.bytes.is_empty() {
+            return Some(OpticInvocationObstruction::MissingBudgetRequest);
+        }
+
+        None
+    }
+
     fn classify_capability_presentation(
         presentation: Option<&OpticCapabilityPresentation>,
     ) -> OpticInvocationObstruction {
@@ -1218,6 +1256,7 @@ impl OpticArtifactRegistry {
             canonical_variables_digest: invocation.canonical_variables_digest.clone(),
             basis_request: invocation.basis_request.clone(),
             aperture_request: invocation.aperture_request.clone(),
+            budget_request: invocation.budget_request.clone(),
             obstruction,
         })
     }
@@ -1339,6 +1378,10 @@ impl OpticArtifactRegistry {
                     b"echo.optic-invocation.aperture-request.v0",
                     &invocation.aperture_request.bytes,
                 ),
+                budget_request_digest: digest_invocation_request_bytes(
+                    b"echo.optic-invocation.budget-request.v0",
+                    &invocation.budget_request.bytes,
+                ),
                 obstruction: invocation_obstruction_kind(obstruction),
             },
         ));
@@ -1382,11 +1425,20 @@ fn invocation_obstruction_kind(
         OpticInvocationObstruction::MissingApertureRequest => {
             InvocationObstructionKind::MissingApertureRequest
         }
+        OpticInvocationObstruction::MissingBudgetRequest => {
+            InvocationObstructionKind::MissingBudgetRequest
+        }
         OpticInvocationObstruction::UnsupportedBasisResolution => {
             InvocationObstructionKind::UnsupportedBasisResolution
         }
         OpticInvocationObstruction::UnsupportedApertureResolution => {
             InvocationObstructionKind::UnsupportedApertureResolution
+        }
+        OpticInvocationObstruction::UnsupportedBudgetResolution => {
+            InvocationObstructionKind::UnsupportedBudgetResolution
+        }
+        OpticInvocationObstruction::RuntimeSupportUnavailable => {
+            InvocationObstructionKind::RuntimeSupportUnavailable
         }
         OpticInvocationObstruction::MissingCapability => {
             InvocationObstructionKind::MissingCapability

--- a/crates/warp-core/tests/optic_invocation_admission_tests.rs
+++ b/crates/warp-core/tests/optic_invocation_admission_tests.rs
@@ -7,9 +7,10 @@ use warp_core::{
     CapabilityGrantIntent, CapabilityGrantIntentGate, CapabilityGrantValidationObstructionKind,
     GraphFact, InvocationObstructionKind, OpticAdmissionRequirements, OpticAdmissionTicketPosture,
     OpticApertureRequest, OpticArtifact, OpticArtifactHandle, OpticArtifactOperation,
-    OpticArtifactRegistry, OpticBasisRequest, OpticCapabilityPresentation, OpticInvocation,
-    OpticInvocationAdmissionOutcome, OpticInvocationObstruction, OpticRegistrationDescriptor,
-    PrincipalRef, RewriteDisposition, OPTIC_ADMISSION_TICKET_POSTURE_KIND,
+    OpticArtifactRegistry, OpticBasisRequest, OpticBudgetRequest, OpticCapabilityPresentation,
+    OpticInvocation, OpticInvocationAdmissionOutcome, OpticInvocationObstruction,
+    OpticRegistrationDescriptor, PrincipalRef, RewriteDisposition,
+    OPTIC_ADMISSION_TICKET_POSTURE_KIND,
 };
 
 fn fixture_artifact() -> OpticArtifact {
@@ -93,6 +94,9 @@ fn fixture_invocation(handle: OpticArtifactHandle) -> OpticInvocation {
         aperture_request: OpticApertureRequest {
             bytes: b"aperture-request:fixture".to_vec(),
         },
+        budget_request: OpticBudgetRequest {
+            bytes: b"budget-request:fixture".to_vec(),
+        },
         capability_presentation: None,
     }
 }
@@ -108,6 +112,7 @@ fn expected_obstructed_posture(
         canonical_variables_digest: invocation.canonical_variables_digest.clone(),
         basis_request: invocation.basis_request.clone(),
         aperture_request: invocation.aperture_request.clone(),
+        budget_request: invocation.budget_request.clone(),
         obstruction,
     })
 }
@@ -191,6 +196,24 @@ fn optic_invocation_obstructs_missing_aperture_request() -> Result<(), String> {
         expected_obstructed_posture(
             &invocation,
             OpticInvocationObstruction::MissingApertureRequest
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn optic_invocation_obstructs_missing_budget_request() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.budget_request = OpticBudgetRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        outcome,
+        expected_obstructed_posture(
+            &invocation,
+            OpticInvocationObstruction::MissingBudgetRequest
         )
     );
     Ok(())
@@ -474,7 +497,7 @@ fn invocation_with_requirements_digest_mismatch_publishes_grant_validation_obstr
 }
 
 #[test]
-fn identity_covered_grant_obstructs_unsupported_basis_resolution_after_basis_and_aperture_presence(
+fn identity_covered_grant_obstructs_unsupported_basis_resolution_after_basis_aperture_and_budget_presence(
 ) -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let invocation = fixture_invocation_with_presentation(handle, "grant:covered");
@@ -607,6 +630,33 @@ fn aperture_obstruction_publishes_invocation_obstruction_fact() -> Result<(), St
 }
 
 #[test]
+fn budget_obstruction_publishes_invocation_obstruction_fact() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.budget_request = OpticBudgetRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::MissingBudgetRequest
+    );
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed {
+            budget_request_digest,
+            obstruction,
+            ..
+        } if *budget_request_digest == digest_invocation_request_bytes(
+                b"echo.optic-invocation.budget-request.v0",
+                b""
+            )
+            && *obstruction == InvocationObstructionKind::MissingBudgetRequest
+    ));
+    Ok(())
+}
+
+#[test]
 fn invocation_obstruction_fact_digest_is_deterministic() {
     let first = GraphFact::OpticInvocationObstructed {
         artifact_handle_id: "handle:1".to_owned(),
@@ -619,6 +669,10 @@ fn invocation_obstruction_fact_digest_is_deterministic() {
         aperture_request_digest: digest_invocation_request_bytes(
             b"echo.optic-invocation.aperture-request.v0",
             b"aperture",
+        ),
+        budget_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.budget-request.v0",
+            b"budget",
         ),
         obstruction: InvocationObstructionKind::MissingCapability,
     };
@@ -641,6 +695,10 @@ fn basis_obstruction_fact_digest_is_deterministic() {
             b"echo.optic-invocation.aperture-request.v0",
             b"aperture",
         ),
+        budget_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.budget-request.v0",
+            b"budget",
+        ),
         obstruction: InvocationObstructionKind::UnsupportedBasisResolution,
     };
     let repeated = first.clone();
@@ -662,11 +720,82 @@ fn aperture_obstruction_fact_digest_is_deterministic() {
             b"echo.optic-invocation.aperture-request.v0",
             b"aperture",
         ),
+        budget_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.budget-request.v0",
+            b"budget",
+        ),
         obstruction: InvocationObstructionKind::MissingApertureRequest,
     };
     let repeated = first.clone();
 
     assert_eq!(first.digest(), repeated.digest());
+}
+
+#[test]
+fn budget_obstruction_fact_digest_is_deterministic() {
+    let first = GraphFact::OpticInvocationObstructed {
+        artifact_handle_id: "handle:1".to_owned(),
+        operation_id: "operation:textWindow:v0".to_owned(),
+        canonical_variables_digest: b"vars".to_vec(),
+        basis_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.basis-request.v0",
+            b"basis",
+        ),
+        aperture_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.aperture-request.v0",
+            b"aperture",
+        ),
+        budget_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.budget-request.v0",
+            b"budget",
+        ),
+        obstruction: InvocationObstructionKind::MissingBudgetRequest,
+    };
+    let repeated = first.clone();
+
+    assert_eq!(first.digest(), repeated.digest());
+}
+
+#[test]
+fn runtime_support_unavailable_is_defined_but_unreachable_until_basis_resolution_exists(
+) -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let invocation = fixture_invocation_with_presentation(handle, "grant:covered");
+    let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
+
+    let outcome = registry.admit_optic_invocation_with_capability_validator(&invocation, &mut gate);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::UnsupportedBasisResolution
+    );
+    assert_ne!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::RuntimeSupportUnavailable
+    );
+    let future_support_fact = GraphFact::OpticInvocationObstructed {
+        artifact_handle_id: "handle:future".to_owned(),
+        operation_id: "operation:textWindow:v0".to_owned(),
+        canonical_variables_digest: b"vars".to_vec(),
+        basis_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.basis-request.v0",
+            b"basis",
+        ),
+        aperture_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.aperture-request.v0",
+            b"aperture",
+        ),
+        budget_request_digest: digest_invocation_request_bytes(
+            b"echo.optic-invocation.budget-request.v0",
+            b"budget",
+        ),
+        obstruction: InvocationObstructionKind::RuntimeSupportUnavailable,
+    };
+    assert_eq!(
+        future_support_fact.digest(),
+        future_support_fact.clone().digest()
+    );
+    Ok(())
 }
 
 #[test]
@@ -727,6 +856,30 @@ fn aperture_obstruction_is_not_counterfactual_candidate() -> Result<(), String> 
     assert_eq!(
         obstruction_for(&outcome),
         OpticInvocationObstruction::MissingApertureRequest
+    );
+    let disposition = RewriteDisposition::Obstructed;
+    assert_ne!(
+        disposition,
+        RewriteDisposition::LegalUnselectedCounterfactual
+    );
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn budget_obstruction_is_not_counterfactual_candidate() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    let mut invocation = fixture_invocation(handle);
+    invocation.budget_request = OpticBudgetRequest { bytes: Vec::new() };
+
+    let outcome = registry.admit_optic_invocation(&invocation);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::MissingBudgetRequest
     );
     let disposition = RewriteDisposition::Obstructed;
     assert_ne!(

--- a/crates/warp-core/tests/optic_invocation_admission_tests.rs
+++ b/crates/warp-core/tests/optic_invocation_admission_tests.rs
@@ -791,10 +791,7 @@ fn runtime_support_unavailable_is_defined_but_unreachable_until_basis_resolution
         ),
         obstruction: InvocationObstructionKind::RuntimeSupportUnavailable,
     };
-    assert_eq!(
-        future_support_fact.digest(),
-        future_support_fact.clone().digest()
-    );
+    assert_eq!(future_support_fact.digest(), future_support_fact.digest());
     Ok(())
 }
 

--- a/docs/design/budget-and-runtime-support-optic-admission.md
+++ b/docs/design/budget-and-runtime-support-optic-admission.md
@@ -1,0 +1,233 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Budget and Runtime Support Optic Admission
+
+Status: implementation slice.
+Scope: obstruction-only budget request and runtime support boundary for optic
+invocation admission.
+
+## Doctrine
+
+A basis request is not a resolved basis.
+
+An aperture request is not a resolved scope.
+
+A budget request is not spendable runtime capacity.
+
+Runtime support is not caller-provided testimony.
+
+Budget is invocation context supplied by the caller. It describes bounded
+resource intent, but Echo has not evaluated or reserved any capacity in this
+slice.
+
+Runtime support is checked by Echo against registered artifact requirements and
+Echo's own runtime support surface. The caller does not supply a support request
+and Echo must not ask the caller whether Echo supports an operation.
+
+This slice remains obstruction-only:
+
+```text
+empty basis request -> MissingBasisRequest
+non-empty basis + empty aperture request -> MissingApertureRequest
+non-empty basis + non-empty aperture + empty budget request -> MissingBudgetRequest
+non-empty basis + non-empty aperture + non-empty budget + identity covered -> UnsupportedBasisResolution
+```
+
+`UnsupportedBudgetResolution` and `RuntimeSupportUnavailable` exist as future
+vocabulary. They are not reachable in this slice because basis resolution gates
+aperture resolution, and aperture resolution gates later budget/support checks.
+
+Refusal remains causal evidence. Budget and support obstruction facts are not
+counterfactual candidates.
+
+## Ordering
+
+Presence checks happen before resolution checks.
+
+Basis resolution gates aperture resolution.
+
+Aperture resolution gates budget evaluation and runtime support checks.
+
+```text
+handle
+-> operation
+-> basis request presence
+-> aperture request presence
+-> budget request presence
+-> basis resolution
+-> aperture resolution
+-> budget evaluation
+-> runtime support evaluation
+-> grant validation / admitted authority
+-> footprint compatibility
+-> AdmissionTicket
+```
+
+This slice only reaches the presence checks and the existing unsupported basis
+resolution obstruction.
+
+## Flow
+
+```mermaid
+flowchart TD
+  Invocation[OpticInvocation]
+  Registry[OpticArtifactRegistry]
+  Handle[handle resolution]
+  Operation[operation id check]
+  BasisPresence[basis request present?]
+  AperturePresence[aperture request present?]
+  BudgetPresence[budget request present?]
+  Presentation[presentation classification]
+  Validator[CapabilityPresentationValidator]
+  BasisResolution[basis resolution unavailable]
+  FutureBudget[Budget resolution future slot]
+  FutureSupport[Runtime support future slot]
+  Fact[GraphFact::OpticInvocationObstructed]
+  Posture[OpticAdmissionTicketPosture]
+
+  Invocation --> Registry
+  Registry --> Handle
+  Handle --> Operation
+  Operation --> BasisPresence
+  BasisPresence -->|missing| Fact
+  BasisPresence -->|present| AperturePresence
+  AperturePresence -->|missing| Fact
+  AperturePresence -->|present| BudgetPresence
+  BudgetPresence -->|missing| Fact
+  BudgetPresence -->|present| Presentation
+  Presentation -->|structurally unavailable| Fact
+  Presentation -->|structurally available| Validator
+  Validator -->|identity covered| BasisResolution
+  Validator -->|validation obstructed| Fact
+  BasisResolution --> Fact
+  BasisResolution -. future .-> FutureBudget
+  FutureBudget -. future .-> FutureSupport
+  FutureSupport -. future .-> Fact
+  Fact --> Posture
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+  participant Caller as caller
+  participant Registry as OpticArtifactRegistry
+  participant Validator as CapabilityPresentationValidator
+  participant Facts as graph fact log
+
+  Caller->>Registry: admit_optic_invocation_with_capability_validator(invocation, validator)
+  Registry->>Registry: resolve artifact handle
+  Registry->>Registry: check operation id
+  Registry->>Registry: reject empty basis request
+  Registry->>Registry: reject empty aperture request
+  Registry->>Registry: reject empty budget request
+  Registry->>Registry: classify presentation shape
+  alt presentation structurally available
+    Registry->>Validator: validate_capability_presentation(artifact, invocation, presentation)
+    Validator->>Facts: publish grant validation obstruction when validation fails
+    Registry->>Registry: obstruct identity-covered material at basis boundary
+  else missing, malformed, or unbound presentation
+    Registry->>Registry: skip validator
+  end
+  Registry->>Facts: publish OpticInvocationObstructed
+  Registry-->>Caller: Obstructed(...)
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class OpticInvocation {
+    +artifact_handle
+    +operation_id
+    +canonical_variables_digest
+    +basis_request
+    +aperture_request
+    +budget_request
+    +capability_presentation
+  }
+
+  class OpticBudgetRequest {
+    +bytes
+  }
+
+  class OpticInvocationObstruction {
+    MissingBudgetRequest
+    UnsupportedBudgetResolution
+    RuntimeSupportUnavailable
+  }
+
+  class RegisteredOpticArtifact {
+    +artifact_hash
+    +operation_id
+    +requirements_digest
+    +requirements
+  }
+
+  class EchoRuntimeSupportSurface {
+    +future runtime-owned support facts
+  }
+
+  OpticInvocation --> OpticBudgetRequest
+  RegisteredOpticArtifact --> EchoRuntimeSupportSurface
+  EchoRuntimeSupportSurface --> OpticInvocationObstruction
+```
+
+## Entity relationship
+
+```mermaid
+erDiagram
+  OPTIC_INVOCATION ||--|| BASIS_REQUEST : names
+  OPTIC_INVOCATION ||--|| APERTURE_REQUEST : names
+  OPTIC_INVOCATION ||--|| BUDGET_REQUEST : names
+  OPTIC_INVOCATION ||--|| INVOCATION_OBSTRUCTION_FACT : produces_when_refused
+  REGISTERED_OPTIC_ARTIFACT ||--|| RUNTIME_SUPPORT_SURFACE : checked_against_future
+  INVOCATION_OBSTRUCTION_FACT ||--|| BUDGET_REQUEST_DIGEST : records
+
+  OPTIC_INVOCATION {
+    string artifact_handle_id
+    string operation_id
+    bytes canonical_variables_digest
+  }
+
+  BUDGET_REQUEST {
+    bytes opaque_request
+  }
+
+  REGISTERED_OPTIC_ARTIFACT {
+    string artifact_hash
+    string operation_id
+    string requirements_digest
+  }
+
+  INVOCATION_OBSTRUCTION_FACT {
+    bytes basis_request_digest
+    bytes aperture_request_digest
+    bytes budget_request_digest
+    string obstruction
+  }
+```
+
+## Operating rule
+
+Budget is caller context. Runtime support is Echo context.
+
+Echo must not accept caller testimony about runtime support. Future support
+checks must compare registered artifact requirements against Echo-owned runtime
+support facts.
+
+## Non-goals
+
+- no `MissingSupportRequest`;
+- no support request bytes;
+- no successful budget resolution;
+- no successful runtime support check;
+- no successful invocation admission;
+- no successful `AdmissionTicket`;
+- no `LawWitness`;
+- no scheduler work;
+- no execution;
+- no storage engine;
+- no WASM ABI;
+- no Continuum schema.


### PR DESCRIPTION
Adds the next obstruction-only optic admission boundary: budget request presence is now mandatory, while budget evaluation and runtime support checks remain future work gated by basis and aperture resolution.

Doctrine:
- A basis request is not a resolved basis.
- An aperture request is not a resolved scope.
- A budget request is not spendable runtime capacity.
- Runtime support is not caller-provided testimony.
- Budget is caller context; runtime support is Echo context.

Behavior:
- Empty budget request bytes obstruct as MissingBudgetRequest.
- UnsupportedBudgetResolution is defined as future vocabulary but is not reachable yet.
- RuntimeSupportUnavailable is defined as future vocabulary but is not reachable yet.
- No MissingSupportRequest or support request bytes are introduced.
- Budget obstruction facts remain deterministic and are not counterfactual candidates.

Current admission ordering:
1. resolve handle
2. reject unknown handle
3. reject operation mismatch
4. reject missing basis request
5. reject missing aperture request
6. reject missing budget request
7. classify capability presentation
8. optionally publish grant validation obstruction evidence
9. obstruct identity-covered material at UnsupportedBasisResolution
10. publish invocation obstruction fact

Scope:
- docs/design/budget-and-runtime-support-optic-admission.md
- no successful budget resolution
- no successful runtime support check
- no successful invocation admission
- no AdmissionTicket
- no LawWitness
- no scheduler work
- no execution
- no storage engine
- no WASM ABI
- no Continuum schema

Verification:
- cargo test -p warp-core --test optic_invocation_admission_tests
- cargo check -p warp-core
- cargo fmt --all -- --check
- npx markdownlint-cli2 docs/design/budget-and-runtime-support-optic-admission.md CHANGELOG.md
- git diff --check
- scripts/ban-nondeterminism.sh