### PR TITLE
feat(core): add invocation admission v0 boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@
 
 ### Added
 
+- `warp-core` optic invocation admission now has a narrow InvocationAdmission v0
+  boundary. After BasisResolution v0, ApertureResolution v0, BudgetResolution
+  v0, RuntimeSupport v0, and capability identity coverage all resolve, Echo
+  checks runtime-owned admission facts for the registered artifact handle.
+  Without that Echo-owned admission fact, the ladder obstructs at
+  `InvocationAdmissionUnavailable`; with the exact
+  `invocation-admission:resolved-fixture:v0` admission fixture, the ladder
+  advances to `SchedulerAdmissionUnavailable`. Invocation admission fixture
+  recording is scoped through Echo-issued artifact handles, so caller-supplied
+  invocation bytes and capability presentations cannot supply admission
+  testimony. This does not add admission tickets, law witnesses, scheduler
+  admission, scheduler work, handler dispatch, execution, or successful grant
+  validation.
 - `warp-core` optic invocation admission now has a narrow RuntimeSupport v0
   boundary. After BasisResolution v0, ApertureResolution v0, and
   BudgetResolution v0 all resolve, Echo checks runtime-owned support facts for
   the registered requirements digest. Without that Echo-owned support fact,
   admission still obstructs at `RuntimeSupportUnavailable`; with the exact
-  `runtime-support:resolved-fixture:v0` support fixture, the ladder advances to
+  `runtime-support:resolved-fixture:v0` support fixture and no Echo-owned
+  invocation admission fact, the ladder advances to
   `InvocationAdmissionUnavailable`. Runtime support fixture recording is scoped
   through Echo-issued artifact handles, so unknown handles cannot publish
   support facts, repeated recordings for the same requirements digest do not

--- a/crates/warp-core/src/causal_facts.rs
+++ b/crates/warp-core/src/causal_facts.rs
@@ -66,6 +66,9 @@ pub enum InvocationObstructionKind {
     /// Echo proved runtime support, but this slice still has no lawful
     /// invocation admission path.
     InvocationAdmissionUnavailable,
+    /// Echo proved invocation admission, but scheduler admission/work enqueueing
+    /// does not exist in this slice.
+    SchedulerAdmissionUnavailable,
     /// Invocation supplied no capability presentation.
     MissingCapability,
     /// Invocation supplied a malformed capability presentation.
@@ -112,6 +115,7 @@ impl InvocationObstructionKind {
             Self::UnsupportedBudgetResolution => b"unsupported-budget-resolution",
             Self::RuntimeSupportUnavailable => b"runtime-support-unavailable",
             Self::InvocationAdmissionUnavailable => b"invocation-admission-unavailable",
+            Self::SchedulerAdmissionUnavailable => b"scheduler-admission-unavailable",
             Self::MissingCapability => b"missing-capability",
             Self::MalformedCapabilityPresentation => b"malformed-capability-presentation",
             Self::UnboundCapabilityPresentation => b"unbound-capability-presentation",
@@ -177,6 +181,19 @@ pub enum GraphFact {
         requirements_digest: String,
         /// Digest of the Echo-owned runtime support material.
         support_digest: [u8; 32],
+    },
+    /// Echo recorded runtime-owned invocation admission evidence for a
+    /// registered artifact handle.
+    InvocationAdmissionRecorded {
+        /// Echo-owned runtime-local artifact handle id covered by the admission
+        /// fact.
+        artifact_handle_id: String,
+        /// Registered operation id covered by the admission fact.
+        operation_id: String,
+        /// Registered requirements digest covered by the admission fact.
+        requirements_digest: String,
+        /// Digest of the Echo-owned invocation admission material.
+        admission_digest: [u8; 32],
     },
     /// Echo refused optic invocation before admission success.
     OpticInvocationObstructed {
@@ -270,6 +287,26 @@ impl GraphFact {
                     requirements_digest.as_bytes(),
                 );
                 push_digest_field(&mut bytes, b"support-digest", support_digest);
+            }
+            Self::InvocationAdmissionRecorded {
+                artifact_handle_id,
+                operation_id,
+                requirements_digest,
+                admission_digest,
+            } => {
+                push_digest_field(&mut bytes, b"variant", b"invocation-admission-recorded");
+                push_digest_field(
+                    &mut bytes,
+                    b"artifact-handle-id",
+                    artifact_handle_id.as_bytes(),
+                );
+                push_digest_field(&mut bytes, b"operation-id", operation_id.as_bytes());
+                push_digest_field(
+                    &mut bytes,
+                    b"requirements-digest",
+                    requirements_digest.as_bytes(),
+                );
+                push_digest_field(&mut bytes, b"admission-digest", admission_digest);
             }
             Self::OpticInvocationObstructed {
                 artifact_handle_id,

--- a/crates/warp-core/src/optic_artifact.rs
+++ b/crates/warp-core/src/optic_artifact.rs
@@ -602,6 +602,10 @@ const OPTIC_BUDGET_RESOLUTION_V0_FIXTURE_BYTES: &[u8] = b"budget-request:resolve
 const OPTIC_RUNTIME_SUPPORT_V0_FIXTURE_BYTES: &[u8] = b"runtime-support:resolved-fixture:v0";
 const OPTIC_RUNTIME_SUPPORT_V0_FIXTURE_DIGEST_DOMAIN: &[u8] =
     b"echo.optic-runtime-support.fixture.v0";
+const OPTIC_INVOCATION_ADMISSION_V0_FIXTURE_BYTES: &[u8] =
+    b"invocation-admission:resolved-fixture:v0";
+const OPTIC_INVOCATION_ADMISSION_V0_FIXTURE_DIGEST_DOMAIN: &[u8] =
+    b"echo.optic-invocation-admission.fixture.v0";
 
 /// Admission obstruction for an optic invocation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -632,6 +636,9 @@ pub enum OpticInvocationObstruction {
     /// Echo proved runtime support, but this slice still cannot lawfully admit
     /// the invocation.
     InvocationAdmissionUnavailable,
+    /// Echo proved invocation admission, but scheduler admission/work enqueueing
+    /// does not exist in this slice.
+    SchedulerAdmissionUnavailable,
     /// The invocation does not carry authority to use the registered artifact.
     MissingCapability,
     /// The invocation carries a presentation that is structurally unusable.
@@ -1034,12 +1041,20 @@ fn runtime_support_v0_fixture_digest() -> [u8; 32] {
     )
 }
 
+fn invocation_admission_v0_fixture_digest() -> [u8; 32] {
+    digest_invocation_request_bytes(
+        OPTIC_INVOCATION_ADMISSION_V0_FIXTURE_DIGEST_DOMAIN,
+        OPTIC_INVOCATION_ADMISSION_V0_FIXTURE_BYTES,
+    )
+}
+
 /// Echo-owned runtime-local registry for Wesley-compiled optic artifacts.
 #[derive(Clone, Debug, Default)]
 pub struct OpticArtifactRegistry {
     next_handle_index: u64,
     artifacts_by_handle: BTreeMap<String, RegisteredOpticArtifact>,
     runtime_support_v0_by_requirements: BTreeMap<String, [u8; 32]>,
+    invocation_admission_v0_by_artifact: BTreeMap<String, [u8; 32]>,
     published_graph_facts: Vec<PublishedGraphFact>,
     artifact_registration_receipts: Vec<ArtifactRegistrationReceipt>,
 }
@@ -1117,6 +1132,33 @@ impl OpticArtifactRegistry {
         Ok(())
     }
 
+    /// Records Echo-owned InvocationAdmission v0 fixture evidence for a
+    /// registered artifact handle.
+    ///
+    /// This is runtime context, not invocation context. Callers cannot provide
+    /// admission evidence through [`OpticInvocation`]; the admission ladder only
+    /// consults facts recorded on this registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OpticArtifactRegistrationError::UnknownHandle`] if Echo did not
+    /// issue the handle in this registry instance.
+    pub fn record_invocation_admission_v0_fixture_for_artifact(
+        &mut self,
+        handle: &OpticArtifactHandle,
+    ) -> Result<(), OpticArtifactRegistrationError> {
+        let registered = self.resolve_optic_artifact_handle(handle)?;
+        let artifact_handle_id = registered.handle.id.clone();
+        let operation_id = registered.operation_id.clone();
+        let requirements_digest = registered.requirements_digest.clone();
+        self.record_invocation_admission_v0_fixture_for_artifact_id(
+            artifact_handle_id,
+            operation_id,
+            requirements_digest,
+        );
+        Ok(())
+    }
+
     fn record_runtime_support_v0_fixture_for_requirements_digest(
         &mut self,
         requirements_digest: String,
@@ -1128,6 +1170,27 @@ impl OpticArtifactRegistry {
             .is_none()
         {
             self.publish_runtime_support_recorded_fact(requirements_digest, support_digest);
+        }
+    }
+
+    fn record_invocation_admission_v0_fixture_for_artifact_id(
+        &mut self,
+        artifact_handle_id: String,
+        operation_id: String,
+        requirements_digest: String,
+    ) {
+        let admission_digest = invocation_admission_v0_fixture_digest();
+        if self
+            .invocation_admission_v0_by_artifact
+            .insert(artifact_handle_id.clone(), admission_digest)
+            .is_none()
+        {
+            self.publish_invocation_admission_recorded_fact(
+                artifact_handle_id,
+                operation_id,
+                requirements_digest,
+                admission_digest,
+            );
         }
     }
 
@@ -1248,9 +1311,14 @@ impl OpticArtifactRegistry {
                                         self.resolve_runtime_support_v0_for_requirements(
                                             &registered.requirements_digest,
                                         )
-                                        .unwrap_or(
-                                            OpticInvocationObstruction::InvocationAdmissionUnavailable,
-                                        )
+                                        .unwrap_or_else(|| {
+                                            self.resolve_invocation_admission_v0_for_artifact(
+                                                &registered.handle.id,
+                                            )
+                                            .unwrap_or(
+                                                OpticInvocationObstruction::SchedulerAdmissionUnavailable,
+                                            )
+                                        })
                                     },
                                 )
                             },
@@ -1312,6 +1380,20 @@ impl OpticArtifactRegistry {
         }
 
         Some(OpticInvocationObstruction::RuntimeSupportUnavailable)
+    }
+
+    fn resolve_invocation_admission_v0_for_artifact(
+        &self,
+        artifact_handle_id: &str,
+    ) -> Option<OpticInvocationObstruction> {
+        if self
+            .invocation_admission_v0_by_artifact
+            .contains_key(artifact_handle_id)
+        {
+            return None;
+        }
+
+        Some(OpticInvocationObstruction::InvocationAdmissionUnavailable)
     }
 
     fn classify_aperture_request(
@@ -1490,6 +1572,23 @@ impl OpticArtifactRegistry {
         ));
     }
 
+    fn publish_invocation_admission_recorded_fact(
+        &mut self,
+        artifact_handle_id: String,
+        operation_id: String,
+        requirements_digest: String,
+        admission_digest: [u8; 32],
+    ) {
+        self.published_graph_facts.push(PublishedGraphFact::new(
+            GraphFact::InvocationAdmissionRecorded {
+                artifact_handle_id,
+                operation_id,
+                requirements_digest,
+                admission_digest,
+            },
+        ));
+    }
+
     fn publish_invocation_obstruction_fact(
         &mut self,
         invocation: &OpticInvocation,
@@ -1572,6 +1671,9 @@ fn invocation_obstruction_kind(
         }
         OpticInvocationObstruction::InvocationAdmissionUnavailable => {
             InvocationObstructionKind::InvocationAdmissionUnavailable
+        }
+        OpticInvocationObstruction::SchedulerAdmissionUnavailable => {
+            InvocationObstructionKind::SchedulerAdmissionUnavailable
         }
         OpticInvocationObstruction::MissingCapability => {
             InvocationObstructionKind::MissingCapability

--- a/crates/warp-core/tests/causal_fact_publication_tests.rs
+++ b/crates/warp-core/tests/causal_fact_publication_tests.rs
@@ -197,6 +197,93 @@ fn runtime_support_v0_fixture_rejects_unknown_handle_without_graph_fact() -> Res
 }
 
 #[test]
+fn invocation_admission_v0_fixture_publishes_graph_fact_without_registration_receipt(
+) -> Result<(), String> {
+    let mut registry = OpticArtifactRegistry::new();
+    let handle = registry
+        .register_optic_artifact(fixture_artifact(), fixture_descriptor())
+        .map_err(|err| format!("fixture descriptor should register: {err:?}"))?;
+
+    registry
+        .record_invocation_admission_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record invocation admission: {err:?}"))?;
+
+    assert_eq!(registry.published_graph_facts().len(), 2);
+    assert_eq!(registry.artifact_registration_receipts().len(), 1);
+    let published = &registry.published_graph_facts()[1];
+    assert_eq!(published.digest, published.fact.digest());
+    assert!(matches!(
+        &published.fact,
+        GraphFact::InvocationAdmissionRecorded {
+            artifact_handle_id,
+            operation_id,
+            requirements_digest,
+            admission_digest,
+        } if artifact_handle_id == &handle.id
+            && operation_id == "operation:textWindow:v0"
+            && requirements_digest == "requirements-digest:stack-witness-0001"
+            && *admission_digest != [0_u8; 32]
+    ));
+    Ok(())
+}
+
+#[test]
+fn invocation_admission_v0_fixture_publishes_once_per_artifact_handle() -> Result<(), String> {
+    let mut registry = OpticArtifactRegistry::new();
+    let handle = registry
+        .register_optic_artifact(fixture_artifact(), fixture_descriptor())
+        .map_err(|err| format!("fixture descriptor should register: {err:?}"))?;
+
+    registry
+        .record_invocation_admission_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record invocation admission: {err:?}"))?;
+    registry
+        .record_invocation_admission_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("repeated handle should remain idempotent: {err:?}"))?;
+
+    let admission_fact_count = registry
+        .published_graph_facts()
+        .iter()
+        .filter(|published| {
+            matches!(
+                published.fact,
+                GraphFact::InvocationAdmissionRecorded { .. }
+            )
+        })
+        .count();
+    assert_eq!(admission_fact_count, 1);
+    Ok(())
+}
+
+#[test]
+fn invocation_admission_v0_fixture_rejects_unknown_handle_without_graph_fact() -> Result<(), String>
+{
+    let mut registry = OpticArtifactRegistry::new();
+    registry
+        .register_optic_artifact(fixture_artifact(), fixture_descriptor())
+        .map_err(|err| format!("fixture descriptor should register: {err:?}"))?;
+    let unknown_handle = OpticArtifactHandle {
+        kind: "optic-artifact-handle".to_owned(),
+        id: "unregistered-handle".to_owned(),
+    };
+
+    let err = registration_err_or_panic(
+        registry.record_invocation_admission_v0_fixture_for_artifact(&unknown_handle),
+        "unknown artifact handle should reject invocation admission recording",
+    )?;
+
+    assert!(matches!(err, OpticArtifactRegistrationError::UnknownHandle));
+    assert_eq!(registry.published_graph_facts().len(), 1);
+    assert!(!registry.published_graph_facts().iter().any(|published| {
+        matches!(
+            published.fact,
+            GraphFact::InvocationAdmissionRecorded { .. }
+        )
+    }));
+    Ok(())
+}
+
+#[test]
 fn graph_fact_digest_is_deterministic_and_kind_separated() {
     let registered = GraphFact::ArtifactRegistered {
         handle_id: "handle-1".to_owned(),
@@ -215,12 +302,22 @@ fn graph_fact_digest_is_deterministic_and_kind_separated() {
         support_digest: [7_u8; 32],
     };
     let repeated_support = support.clone();
+    let admission = GraphFact::InvocationAdmissionRecorded {
+        artifact_handle_id: "handle-1".to_owned(),
+        operation_id: "operation".to_owned(),
+        requirements_digest: "requirements".to_owned(),
+        admission_digest: [8_u8; 32],
+    };
+    let repeated_admission = admission.clone();
 
     assert_eq!(registered.digest(), repeated.digest());
     assert_ne!(registered.digest(), obstructed.digest());
     assert_eq!(support.digest(), repeated_support.digest());
+    assert_eq!(admission.digest(), repeated_admission.digest());
     assert_ne!(registered.digest(), support.digest());
     assert_ne!(obstructed.digest(), support.digest());
+    assert_ne!(support.digest(), admission.digest());
+    assert_ne!(registered.digest(), admission.digest());
 }
 
 #[test]

--- a/crates/warp-core/tests/optic_invocation_admission_tests.rs
+++ b/crates/warp-core/tests/optic_invocation_admission_tests.rs
@@ -1208,6 +1208,215 @@ fn resolved_runtime_support_still_does_not_admit_invocation() -> Result<(), Stri
 }
 
 #[test]
+fn identity_coverage_and_runtime_support_still_require_invocation_admission() -> Result<(), String>
+{
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    registry
+        .record_runtime_support_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record runtime support: {err:?}"))?;
+    let invocation = fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+        handle,
+        "grant:covered",
+    );
+    let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
+
+    let outcome = registry.admit_optic_invocation_with_capability_validator(&invocation, &mut gate);
+
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::InvocationAdmissionUnavailable
+    );
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed {
+            obstruction,
+            ..
+        } if *obstruction == InvocationObstructionKind::InvocationAdmissionUnavailable
+    ));
+    Ok(())
+}
+
+#[test]
+fn caller_cannot_supply_invocation_admission_testimony() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    registry
+        .record_runtime_support_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record runtime support: {err:?}"))?;
+    let mut invocation = fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+        handle,
+        "grant:covered",
+    );
+    invocation.canonical_variables_digest = b"invocation-admission:resolved-fixture:v0".to_vec();
+    invocation.capability_presentation = Some(OpticCapabilityPresentation {
+        presentation_id: "invocation-admission:resolved-fixture:v0".to_owned(),
+        bound_grant_id: Some("grant:covered".to_owned()),
+    });
+    let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
+
+    let outcome = registry.admit_optic_invocation_with_capability_validator(&invocation, &mut gate);
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::InvocationAdmissionUnavailable
+    );
+
+    registry
+        .record_invocation_admission_v0_fixture_for_artifact(&invocation.artifact_handle)
+        .map_err(|err| format!("registered handle should record invocation admission: {err:?}"))?;
+    let outcome = registry.admit_optic_invocation_with_capability_validator(&invocation, &mut gate);
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::SchedulerAdmissionUnavailable
+    );
+    Ok(())
+}
+
+#[test]
+fn invocation_admission_uses_echo_owned_admission_fixture_only() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    registry
+        .record_runtime_support_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record runtime support: {err:?}"))?;
+    let mut invocation = fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+        handle,
+        "grant:covered",
+    );
+    invocation.basis_request.bytes = b"basis-request:resolved-fixture:v0".to_vec();
+    invocation.aperture_request.bytes = b"aperture-request:resolved-fixture:v0".to_vec();
+    invocation.budget_request.bytes = b"budget-request:resolved-fixture:v0".to_vec();
+    invocation.canonical_variables_digest = b"caller-claims:invocation-admission-resolved".to_vec();
+    let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
+
+    let outcome = registry.admit_optic_invocation_with_capability_validator(&invocation, &mut gate);
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::InvocationAdmissionUnavailable
+    );
+
+    registry
+        .record_invocation_admission_v0_fixture_for_artifact(&invocation.artifact_handle)
+        .map_err(|err| format!("registered handle should record invocation admission: {err:?}"))?;
+    let outcome = registry.admit_optic_invocation_with_capability_validator(&invocation, &mut gate);
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::SchedulerAdmissionUnavailable
+    );
+    Ok(())
+}
+
+#[test]
+fn invocation_admission_is_checked_only_after_runtime_support() -> Result<(), String> {
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    registry
+        .record_invocation_admission_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record invocation admission: {err:?}"))?;
+    let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
+
+    let mut unsupported_basis =
+        fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+            handle.clone(),
+            "grant:covered",
+        );
+    unsupported_basis.basis_request = OpticBasisRequest {
+        bytes: b"basis-request:unsupported".to_vec(),
+    };
+    let outcome =
+        registry.admit_optic_invocation_with_capability_validator(&unsupported_basis, &mut gate);
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::UnsupportedBasisResolution
+    );
+
+    let mut unsupported_aperture =
+        fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+            handle.clone(),
+            "grant:covered",
+        );
+    unsupported_aperture.aperture_request = OpticApertureRequest {
+        bytes: b"aperture-request:unsupported".to_vec(),
+    };
+    let outcome =
+        registry.admit_optic_invocation_with_capability_validator(&unsupported_aperture, &mut gate);
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::UnsupportedApertureResolution
+    );
+
+    let mut unsupported_budget =
+        fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+            handle.clone(),
+            "grant:covered",
+        );
+    unsupported_budget.budget_request = OpticBudgetRequest {
+        bytes: b"budget-request:unsupported".to_vec(),
+    };
+    let outcome =
+        registry.admit_optic_invocation_with_capability_validator(&unsupported_budget, &mut gate);
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::UnsupportedBudgetResolution
+    );
+
+    let supported_shape_without_support_fact =
+        fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+            handle,
+            "grant:covered",
+        );
+    let outcome = registry.admit_optic_invocation_with_capability_validator(
+        &supported_shape_without_support_fact,
+        &mut gate,
+    );
+    assert_eq!(
+        obstruction_for(&outcome),
+        OpticInvocationObstruction::RuntimeSupportUnavailable
+    );
+    Ok(())
+}
+
+#[test]
+fn resolved_invocation_admission_advances_to_scheduler_admission_unavailable() -> Result<(), String>
+{
+    let (mut registry, handle) = fixture_registry_and_handle()?;
+    registry
+        .record_runtime_support_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record runtime support: {err:?}"))?;
+    registry
+        .record_invocation_admission_v0_fixture_for_artifact(&handle)
+        .map_err(|err| format!("registered handle should record invocation admission: {err:?}"))?;
+    let invocation = fixture_invocation_with_resolved_basis_aperture_budget_and_presentation(
+        handle,
+        "grant:covered",
+    );
+    let mut gate = fixture_gate_with_grant(fixture_grant("grant:covered"));
+
+    let outcome = registry.admit_optic_invocation_with_capability_validator(&invocation, &mut gate);
+
+    assert!(matches!(
+        outcome,
+        OpticInvocationAdmissionOutcome::Obstructed(OpticAdmissionTicketPosture {
+            obstruction: OpticInvocationObstruction::SchedulerAdmissionUnavailable,
+            ..
+        })
+    ));
+    assert!(matches!(
+        latest_invocation_obstruction_fact(&registry)?,
+        GraphFact::OpticInvocationObstructed {
+            obstruction,
+            ..
+        } if *obstruction == InvocationObstructionKind::SchedulerAdmissionUnavailable
+    ));
+    assert!(registry.published_graph_facts().iter().all(|published| {
+        matches!(
+            published.fact,
+            GraphFact::ArtifactRegistered { .. }
+                | GraphFact::RuntimeSupportRecorded { .. }
+                | GraphFact::InvocationAdmissionRecorded { .. }
+                | GraphFact::OpticInvocationObstructed { .. }
+        )
+    }));
+    Ok(())
+}
+
+#[test]
 fn invocation_obstruction_fact_is_not_counterfactual_candidate() -> Result<(), String> {
     let (mut registry, handle) = fixture_registry_and_handle()?;
     let invocation = fixture_invocation(handle);

--- a/docs/design/budget-and-runtime-support-optic-admission.md
+++ b/docs/design/budget-and-runtime-support-optic-admission.md
@@ -31,12 +31,17 @@ This slice remains obstruction-only:
 empty basis request -> MissingBasisRequest
 non-empty basis + empty aperture request -> MissingApertureRequest
 non-empty basis + non-empty aperture + empty budget request -> MissingBudgetRequest
-non-empty basis + non-empty aperture + non-empty budget + identity covered -> UnsupportedBasisResolution
+identity covered + unsupported basis -> UnsupportedBasisResolution
+resolved basis + unsupported aperture -> UnsupportedApertureResolution
+resolved aperture + unsupported budget -> UnsupportedBudgetResolution
+resolved budget + no Echo-owned runtime support fact -> RuntimeSupportUnavailable
+resolved runtime support -> InvocationAdmissionUnavailable
 ```
 
-`UnsupportedBudgetResolution` and `RuntimeSupportUnavailable` exist as future
-vocabulary. They are not reachable in this slice because basis resolution gates
-aperture resolution, and aperture resolution gates later budget/support checks.
+`UnsupportedBudgetResolution` and `RuntimeSupportUnavailable` are current
+obstruction vocabulary. They are reachable only after the earlier gates resolve:
+basis resolution gates aperture resolution, aperture resolution gates budget
+resolution, and budget resolution gates the Echo-owned runtime support check.
 
 Refusal remains causal evidence. Budget and support obstruction facts are not
 counterfactual candidates.
@@ -59,13 +64,11 @@ handle
 -> aperture resolution
 -> budget evaluation
 -> runtime support evaluation
--> grant validation / admitted authority
--> footprint compatibility
--> AdmissionTicket
+-> invocation admission unavailable
 ```
 
-This slice only reaches the presence checks and the existing unsupported basis
-resolution obstruction.
+This slice reaches the narrow fixture gates through RuntimeSupport v0. It still
+has no successful invocation admission, no scheduler work, and no execution.
 
 ## Flow
 
@@ -80,9 +83,10 @@ flowchart TD
   BudgetPresence[budget request present?]
   Presentation[presentation classification]
   Validator[CapabilityPresentationValidator]
-  BasisResolution[basis resolution unavailable]
-  FutureBudget[Budget resolution future slot]
-  FutureSupport[Runtime support future slot]
+  BasisResolution[BasisResolution v0]
+  ApertureResolution[ApertureResolution v0]
+  BudgetResolution[BudgetResolution v0]
+  RuntimeSupport[RuntimeSupport v0]
   Fact[GraphFact::OpticInvocationObstructed]
   Posture[OpticAdmissionTicketPosture]
 
@@ -100,10 +104,14 @@ flowchart TD
   Presentation -->|structurally available| Validator
   Validator -->|identity covered| BasisResolution
   Validator -->|validation obstructed| Fact
-  BasisResolution --> Fact
-  BasisResolution -. future .-> FutureBudget
-  FutureBudget -. future .-> FutureSupport
-  FutureSupport -. future .-> Fact
+  BasisResolution -->|unsupported| Fact
+  BasisResolution -->|resolved| ApertureResolution
+  ApertureResolution -->|unsupported| Fact
+  ApertureResolution -->|resolved| BudgetResolution
+  BudgetResolution -->|unsupported| Fact
+  BudgetResolution -->|resolved| RuntimeSupport
+  RuntimeSupport -->|missing support fact| Fact
+  RuntimeSupport -->|resolved| Fact
   Fact --> Posture
 ```
 
@@ -126,7 +134,8 @@ sequenceDiagram
   alt presentation structurally available
     Registry->>Validator: validate_capability_presentation(artifact, invocation, presentation)
     Validator->>Facts: publish grant validation obstruction when validation fails
-    Registry->>Registry: obstruct identity-covered material at basis boundary
+    Registry->>Registry: resolve basis, aperture, budget, and runtime support fixtures
+    Registry->>Registry: obstruct identity-covered material at invocation admission boundary
   else missing, malformed, or unbound presentation
     Registry->>Registry: skip validator
   end
@@ -156,6 +165,7 @@ classDiagram
     MissingBudgetRequest
     UnsupportedBudgetResolution
     RuntimeSupportUnavailable
+    InvocationAdmissionUnavailable
   }
 
   class RegisteredOpticArtifact {
@@ -166,7 +176,7 @@ classDiagram
   }
 
   class EchoRuntimeSupportSurface {
-    +future runtime-owned support facts
+    +runtime-owned support facts
   }
 
   OpticInvocation --> OpticBudgetRequest
@@ -182,7 +192,7 @@ erDiagram
   OPTIC_INVOCATION ||--|| APERTURE_REQUEST : names
   OPTIC_INVOCATION ||--|| BUDGET_REQUEST : names
   OPTIC_INVOCATION ||--|| INVOCATION_OBSTRUCTION_FACT : produces_when_refused
-  REGISTERED_OPTIC_ARTIFACT ||--|| RUNTIME_SUPPORT_SURFACE : checked_against_future
+  REGISTERED_OPTIC_ARTIFACT ||--|| RUNTIME_SUPPORT_SURFACE : checked_against
   INVOCATION_OBSTRUCTION_FACT ||--|| BUDGET_REQUEST_DIGEST : records
 
   OPTIC_INVOCATION {
@@ -213,16 +223,14 @@ erDiagram
 
 Budget is caller context. Runtime support is Echo context.
 
-Echo must not accept caller testimony about runtime support. Future support
-checks must compare registered artifact requirements against Echo-owned runtime
-support facts.
+Echo must not accept caller testimony about runtime support. Support checks
+compare registered artifact requirements against Echo-owned runtime support
+facts recorded by the registry.
 
 ## Non-goals
 
 - no `MissingSupportRequest`;
 - no support request bytes;
-- no successful budget resolution;
-- no successful runtime support check;
 - no successful invocation admission;
 - no successful `AdmissionTicket`;
 - no `LawWitness`;

--- a/docs/design/budget-and-runtime-support-optic-admission.md
+++ b/docs/design/budget-and-runtime-support-optic-admission.md
@@ -35,7 +35,8 @@ identity covered + unsupported basis -> UnsupportedBasisResolution
 resolved basis + unsupported aperture -> UnsupportedApertureResolution
 resolved aperture + unsupported budget -> UnsupportedBudgetResolution
 resolved budget + no Echo-owned runtime support fact -> RuntimeSupportUnavailable
-resolved runtime support -> InvocationAdmissionUnavailable
+resolved runtime support + no Echo-owned admission fact -> InvocationAdmissionUnavailable
+resolved invocation admission -> SchedulerAdmissionUnavailable
 ```
 
 `UnsupportedBudgetResolution` and `RuntimeSupportUnavailable` are current
@@ -64,11 +65,12 @@ handle
 -> aperture resolution
 -> budget evaluation
 -> runtime support evaluation
--> invocation admission unavailable
+-> invocation admission evaluation
+-> scheduler admission unavailable
 ```
 
 This slice reaches the narrow fixture gates through RuntimeSupport v0. It still
-has no successful invocation admission, no scheduler work, and no execution.
+has no successful scheduler admission, no scheduler work, and no execution.
 
 ## Flow
 
@@ -87,6 +89,7 @@ flowchart TD
   ApertureResolution[ApertureResolution v0]
   BudgetResolution[BudgetResolution v0]
   RuntimeSupport[RuntimeSupport v0]
+  InvocationAdmission[InvocationAdmission v0]
   Fact[GraphFact::OpticInvocationObstructed]
   Posture[OpticAdmissionTicketPosture]
 
@@ -111,7 +114,9 @@ flowchart TD
   BudgetResolution -->|unsupported| Fact
   BudgetResolution -->|resolved| RuntimeSupport
   RuntimeSupport -->|missing support fact| Fact
-  RuntimeSupport -->|resolved| Fact
+  RuntimeSupport -->|resolved| InvocationAdmission
+  InvocationAdmission -->|missing admission fact| Fact
+  InvocationAdmission -->|resolved| Fact
   Fact --> Posture
 ```
 
@@ -134,8 +139,8 @@ sequenceDiagram
   alt presentation structurally available
     Registry->>Validator: validate_capability_presentation(artifact, invocation, presentation)
     Validator->>Facts: publish grant validation obstruction when validation fails
-    Registry->>Registry: resolve basis, aperture, budget, and runtime support fixtures
-    Registry->>Registry: obstruct identity-covered material at invocation admission boundary
+    Registry->>Registry: resolve basis, aperture, budget, runtime support, and admission fixtures
+    Registry->>Registry: obstruct resolved admission before scheduler admission
   else missing, malformed, or unbound presentation
     Registry->>Registry: skip validator
   end
@@ -166,6 +171,7 @@ classDiagram
     UnsupportedBudgetResolution
     RuntimeSupportUnavailable
     InvocationAdmissionUnavailable
+    SchedulerAdmissionUnavailable
   }
 
   class RegisteredOpticArtifact {
@@ -177,6 +183,7 @@ classDiagram
 
   class EchoRuntimeSupportSurface {
     +runtime-owned support facts
+    +runtime-owned admission facts
   }
 
   OpticInvocation --> OpticBudgetRequest
@@ -227,11 +234,17 @@ Echo must not accept caller testimony about runtime support. Support checks
 compare registered artifact requirements against Echo-owned runtime support
 facts recorded by the registry.
 
+As of InvocationAdmission v0, Echo also records a narrow runtime-owned
+invocation admission fixture through Echo-issued artifact handles. That
+admission fact advances the ladder past `InvocationAdmissionUnavailable`, but
+only to `SchedulerAdmissionUnavailable`; it still does not schedule work or
+execute an invocation.
+
 ## Non-goals
 
 - no `MissingSupportRequest`;
 - no support request bytes;
-- no successful invocation admission;
+- no successful scheduler admission;
 - no successful `AdmissionTicket`;
 - no `LawWitness`;
 - no scheduler work;

--- a/docs/design/optic-admission-ladder-checkpoint.md
+++ b/docs/design/optic-admission-ladder-checkpoint.md
@@ -3,17 +3,19 @@
 
 # Optic Admission Ladder Checkpoint
 
-Status: RuntimeSupport v0 boundary checkpoint.
+Status: InvocationAdmission v0 boundary checkpoint.
 Scope: refusal ladder with narrow controlled basis, aperture, budget, and
-runtime-support fixtures.
+runtime-owned admission fixtures.
 
 ## Doctrine
 
 This checkpoint records the optic invocation admission ladder at the first
-controlled runtime-support boundary.
+controlled invocation-admission boundary.
 
-Echo can now explain why an optic invocation is refused, but it cannot yet admit
-one. There is no successful admission path in this checkpoint.
+Echo can now explain why an optic invocation is refused and can positively
+resolve a narrow Echo-owned invocation admission fixture. It still cannot issue
+a successful `AdmissionTicket`, enqueue scheduler work, dispatch a handler, or
+execute the invocation.
 
 A registered artifact handle is not authority. A capability presentation slot is
 not a validated grant. A basis request is not a resolved basis unless it matches
@@ -25,7 +27,9 @@ fixture after aperture resolution.
 A resolved aperture is not permission to act. A budget request is not spendable
 runtime capacity. Runtime support is Echo-owned context recorded by the
 registry; it is not caller-provided testimony. Resolved runtime support is not
-permission to act.
+permission to act. Invocation admission is Echo-owned context recorded by the
+registry; it is not caller-provided testimony. Resolved invocation admission is
+not scheduler admission, scheduler work, handler dispatch, or execution.
 
 Refusal is causal evidence. Refusal is not admission, not execution, not a law
 witness, and not a counterfactual candidate.
@@ -50,9 +54,12 @@ The current optic invocation admission path evaluates checks in this order:
     fixture or obstruct unsupported budget material.
 12. If that budget fixture resolves, check Echo-owned RuntimeSupport v0 facts
     for the registered requirements or obstruct at `RuntimeSupportUnavailable`.
-13. If RuntimeSupport v0 resolves, obstruct at
+13. If RuntimeSupport v0 resolves, check Echo-owned InvocationAdmission v0
+    facts for the registered artifact handle or obstruct at
     `InvocationAdmissionUnavailable`.
-14. Publish the invocation obstruction fact.
+14. If InvocationAdmission v0 resolves, obstruct at
+    `SchedulerAdmissionUnavailable`.
+15. Publish the invocation obstruction fact.
 
 Presence checks come before resolution checks. Basis resolution gates aperture
 resolution. Aperture resolution gates budget evaluation and runtime support
@@ -69,6 +76,12 @@ requirements. Artifact registration requires the stored requirements digest to
 match the registered artifact requirements digest. Recording the fixture is
 idempotent per requirements digest, and runtime support is not carried by
 `OpticInvocation`.
+
+The current Echo-owned invocation admission fixture is
+`invocation-admission:resolved-fixture:v0`. It is recorded by the runtime
+registry through an Echo-issued artifact handle for that artifact's registered
+operation and requirements. Recording the fixture is idempotent per artifact
+handle, and invocation admission evidence is not carried by `OpticInvocation`.
 
 ## Obstruction reachability
 
@@ -87,15 +100,20 @@ idempotent per requirements digest, and runtime support is not carried by
 | `UnsupportedApertureResolution`   | Reachable today | BasisResolution v0 succeeded, but the aperture shape is outside ApertureResolution v0.                   |
 | `UnsupportedBudgetResolution`     | Reachable today | ApertureResolution v0 succeeded, but the budget shape is outside BudgetResolution v0.                    |
 | `RuntimeSupportUnavailable`       | Reachable today | BudgetResolution v0 succeeded, but Echo has no runtime support fact for the registered requirements.     |
-| `InvocationAdmissionUnavailable`  | Reachable today | RuntimeSupport v0 succeeded, but invocation admission does not exist yet.                                |
+| `InvocationAdmissionUnavailable`  | Reachable today | RuntimeSupport v0 succeeded, but Echo has no invocation admission fact for the artifact handle.          |
+| `SchedulerAdmissionUnavailable`   | Reachable today | InvocationAdmission v0 succeeded, but scheduler admission/work enqueueing does not exist yet.            |
 
 `RuntimeSupportUnavailable` is lawfully reachable after BasisResolution v0,
 ApertureResolution v0, and BudgetResolution v0 all resolve when Echo has no
 runtime-owned support fact for the registered requirements.
 
 `InvocationAdmissionUnavailable` is lawfully reachable after RuntimeSupport v0
-resolves. It is the current terminal refusal after Echo proves support but
-before successful invocation admission exists.
+resolves when Echo has no runtime-owned admission fact for the artifact handle.
+
+`SchedulerAdmissionUnavailable` is lawfully reachable after InvocationAdmission
+v0 resolves. It is the current terminal refusal after Echo proves invocation
+admission but before any scheduler admission, scheduler work, handler dispatch,
+or execution exists.
 
 `UnsupportedApertureResolution` is reachable only after the exact
 BasisResolution v0 fixture resolves. For identity-covered material, unsupported
@@ -109,16 +127,18 @@ stop at `UnsupportedApertureResolution`.
 
 This checkpoint does not introduce:
 
-- successful admission
-- `AdmissionTicket`
+- successful `AdmissionTicket` issuance
 - `LawWitness`
-- scheduler behavior
+- scheduler admission
+- scheduler work
+- handler dispatch
 - execution behavior
 - storage behavior
 - WASM behavior
 - Continuum behavior
 - authority success
 - caller-supplied runtime support testimony
+- caller-supplied invocation admission testimony
 - general runtime support enforcement
 - budget reservation
 
@@ -164,7 +184,7 @@ Budget resolution establishes a bounded resource envelope under consideration.
 It does not create permission to act, reserve spendable capacity, validate a
 grant, or admit an invocation. The next boundary is RuntimeSupport v0: absent
 Echo-owned support obstructs at `RuntimeSupportUnavailable`; resolved support
-advances to `InvocationAdmissionUnavailable`.
+advances to InvocationAdmission v0.
 
 ## RuntimeSupport v0
 
@@ -178,26 +198,51 @@ runtime-support:resolved-fixture:v0
 Runtime support establishes only that Echo has recorded runtime-owned support
 evidence for the artifact handle's registered requirements digest. It is not an
 invocation request field, not caller testimony, not authority, not admission,
-not scheduler work, and not execution. If runtime support resolves, the only
-lawful next refusal in this slice is `InvocationAdmissionUnavailable`.
+not scheduler work, and not execution. If runtime support resolves, the next
+boundary is InvocationAdmission v0: absent Echo-owned admission evidence
+obstructs at `InvocationAdmissionUnavailable`; resolved admission evidence
+advances to `SchedulerAdmissionUnavailable`.
+
+## InvocationAdmission v0
+
+InvocationAdmission v0 is not general invocation admission. It recognizes
+exactly one Echo-owned fixture for a registered artifact handle:
+
+```text
+invocation-admission:resolved-fixture:v0
+```
+
+Invocation admission establishes only that Echo has recorded runtime-owned
+admission evidence for the artifact handle's registered operation and
+requirements. It is not an invocation request field, not caller testimony, not
+an `AdmissionTicket`, not a law witness, not scheduler admission, not scheduler
+work, not handler dispatch, and not execution. If invocation admission resolves,
+the only lawful next refusal in this slice is
+`SchedulerAdmissionUnavailable`.
 
 ## Next transition point
 
-The next transition point is InvocationAdmission v0.
+The next transition point is SchedulerAdmission v0.
 
 That transition must be narrow and explicit. It must not imply successful
-execution, scheduler work, or unconstrained authority validation.
+execution, handler dispatch, or unconstrained authority validation.
 
 ## Tripwire
 
 If a future slice makes `RuntimeSupportUnavailable` reachable before a lawful
 budget resolution boundary exists, the admission ladder is wrong.
 
-If a future slice introduces a successful admission path before a resolved basis,
-resolved aperture, evaluated budget, runtime support check, and validated grant
-exist, the admission ladder is wrong.
+If a future slice introduces scheduler admission before a resolved basis,
+resolved aperture, evaluated budget, runtime support check, validated grant, and
+Echo-owned invocation admission fact exist, the admission ladder is wrong.
 
 If a future slice makes `InvocationAdmissionUnavailable` reachable before a
 lawful Echo-owned runtime support fact exists, the admission ladder is wrong.
 
+If a future slice makes `SchedulerAdmissionUnavailable` reachable before a
+lawful Echo-owned invocation admission fact exists, the admission ladder is
+wrong.
+
 RuntimeSupport v0 is controlled resolved runtime context, not admission.
+InvocationAdmission v0 is controlled resolved admission context, not scheduler
+admission or execution.


### PR DESCRIPTION
## Summary

- Adds an Echo-owned InvocationAdmission v0 fixture boundary after basis, aperture, budget, runtime support, and capability identity coverage resolve.
- Keeps caller-supplied invocation bytes and capability presentation from supplying admission testimony.
- Advances resolved invocation admission to the new honest terminal obstruction `SchedulerAdmissionUnavailable` without scheduler work, handler dispatch, or execution.
- Updates the ladder checkpoint, budget/runtime support checkpoint, and changelog.

## Validation

- `cargo test -p warp-core --test optic_invocation_admission_tests --test causal_fact_publication_tests --test optic_artifact_registry_tests`
- `cargo check`
- `cargo fmt --check`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/design/optic-admission-ladder-checkpoint.md docs/design/budget-and-runtime-support-optic-admission.md`
- `git diff --check`

## Notes

This does not implement QueryView, installed Wesley handler dispatch, contract execution, scheduler admission, scheduler work, file-history substrate, or generated handler dispatch.