### PR TITLE
feat(core): record witnessed intent submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 
 ### Added
 
+- `warp-core` now records a narrow WitnessedIntentSubmission v0 ledger when
+  `WorldlineRuntime::ingest(...)` accepts canonical application ingress. The
+  runtime derives a deterministic `submission_id` from the resolved writer head
+  and content-addressed `ingress_id`, assigns an Echo-owned
+  `submission_generation` for intake/audit correlation, and returns the same
+  submission identity for duplicate pending or committed ingress without
+  appending duplicate semantic submission history. This ledger does not tick,
+  mutate application state, dispatch handlers, enqueue scheduler work, issue law
+  witnesses, issue admission tickets, or make submission order decide scheduler
+  order. `DispatchResponse` now carries optional `submission_id` and
+  `submission_generation` fields for application ingress, and the WASM ABI
+  version is now 10.
 - `warp-core` optic invocation admission now has a narrow SchedulerAdmission v0
   boundary. After BasisResolution v0, ApertureResolution v0, BudgetResolution
   v0, RuntimeSupport v0, capability identity coverage, and InvocationAdmission

--- a/crates/echo-wasm-abi/src/kernel_port.rs
+++ b/crates/echo-wasm-abi/src/kernel_port.rs
@@ -10,7 +10,7 @@
 //!
 //! # ABI Version
 //!
-//! The current ABI version is [`ABI_VERSION`] (9). All response types are
+//! The current ABI version is [`ABI_VERSION`] (10). All response types are
 //! CBOR-encoded using the canonical rules defined in `docs/spec/js-cbor-mapping.md`.
 //! Breaking changes to response shapes or error codes require a bump to the
 //! ABI version.
@@ -40,7 +40,7 @@ use serde::{
 ///
 /// Increment when response types, error codes, or method signatures change
 /// in a backward-incompatible way.
-pub const ABI_VERSION: u32 = 9;
+pub const ABI_VERSION: u32 = 10;
 
 fn deserialize_opaque_id<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
 where
@@ -346,6 +346,17 @@ pub struct DispatchResponse {
     pub accepted: bool,
     /// Content-addressed intent identifier (BLAKE3 hash, 32 bytes).
     pub intent_id: Vec<u8>,
+    /// Content-addressed Echo submission event id for application ingress.
+    ///
+    /// `None` is used for trusted runtime control responses, which are not
+    /// application intent submissions.
+    pub submission_id: Option<Vec<u8>>,
+    /// Echo-owned intake/correlation generation for application ingress.
+    ///
+    /// This is audit metadata. It is not scheduler order, not a worldline tick,
+    /// and not wall-clock time. `None` is used for trusted runtime control
+    /// responses.
+    pub submission_generation: Option<u64>,
     /// Scheduler status after the intent is ingested or applied.
     pub scheduler_status: SchedulerStatus,
 }
@@ -2565,11 +2576,15 @@ pub trait KernelPort {
                 }
 
                 let dispatch = self.dispatch_intent(bytes)?;
+                let stage_ref = dispatch
+                    .submission_id
+                    .clone()
+                    .unwrap_or_else(|| dispatch.intent_id.clone());
                 Ok(IntentDispatchResult::Staged(StagedIntent {
                     optic_id: request.optic_id,
                     base_coordinate: request.base_coordinate,
                     intent_family: request.intent_family,
-                    stage_ref: dispatch.intent_id,
+                    stage_ref,
                     reason: StagedIntentReason::AwaitingExplicitAdmission,
                 }))
             }

--- a/crates/echo-wasm-abi/src/lib.rs
+++ b/crates/echo-wasm-abi/src/lib.rs
@@ -1286,6 +1286,8 @@ mod tests {
                 Ok(DispatchResponse {
                     accepted: true,
                     intent_id: vec![10; 32],
+                    submission_id: Some(vec![11; 32]),
+                    submission_generation: Some(1),
                     scheduler_status: SchedulerStatus {
                         state: SchedulerState::Inactive,
                         active_mode: Some(SchedulerMode::UntilIdle {
@@ -1376,7 +1378,7 @@ mod tests {
             IntentDispatchResult::Staged(staged)
                 if staged.base_coordinate == base_coordinate
                     && staged.intent_family == intent_family
-                    && staged.stage_ref == vec![10; 32]
+                    && staged.stage_ref == vec![11; 32]
                     && staged.reason == StagedIntentReason::AwaitingExplicitAdmission
         ));
     }
@@ -1401,6 +1403,8 @@ mod tests {
                 Ok(DispatchResponse {
                     accepted: true,
                     intent_id: vec![10; 32],
+                    submission_id: Some(vec![11; 32]),
+                    submission_generation: Some(1),
                     scheduler_status: SchedulerStatus {
                         state: SchedulerState::Inactive,
                         active_mode: Some(SchedulerMode::UntilIdle {

--- a/crates/echo-wesley-gen/tests/generation.rs
+++ b/crates/echo-wesley-gen/tests/generation.rs
@@ -271,6 +271,8 @@ mod tests {
             Ok(DispatchResponse {
                 accepted: true,
                 intent_id: vec![7; 32],
+                submission_id: Some(vec![17; 32]),
+                submission_generation: Some(1),
                 scheduler_status: idle_status(),
             })
         }

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -1511,23 +1511,41 @@ mod tests {
             b"same-payload".to_vec(),
         );
 
-        let IngressDisposition::Accepted {
-            ingress_id: default_ingress,
-            head_key: default_head,
-            submission_id: default_submission,
-            submission_generation: default_generation,
-        } = runtime.ingest(default_env.clone()).unwrap()
-        else {
-            panic!("default submission should be accepted");
+        let default_accepted = match runtime.ingest(default_env.clone()).unwrap() {
+            IngressDisposition::Accepted {
+                ingress_id,
+                head_key,
+                submission_id,
+                submission_generation,
+            } => Some((ingress_id, head_key, submission_id, submission_generation)),
+            IngressDisposition::Duplicate { .. } => None,
         };
-        let IngressDisposition::Accepted {
-            ingress_id: named_ingress,
-            head_key: named_head,
-            submission_id: named_submission,
-            submission_generation: named_generation,
-        } = runtime.ingest(named_env.clone()).unwrap()
+        assert!(
+            default_accepted.is_some(),
+            "default submission should be accepted"
+        );
+        let Some((default_ingress, default_head, default_submission, default_generation)) =
+            default_accepted
         else {
-            panic!("named submission should be accepted");
+            return;
+        };
+
+        let named_accepted = match runtime.ingest(named_env.clone()).unwrap() {
+            IngressDisposition::Accepted {
+                ingress_id,
+                head_key,
+                submission_id,
+                submission_generation,
+            } => Some((ingress_id, head_key, submission_id, submission_generation)),
+            IngressDisposition::Duplicate { .. } => None,
+        };
+        assert!(
+            named_accepted.is_some(),
+            "named submission should be accepted"
+        );
+        let Some((named_ingress, named_head, named_submission, named_generation)) = named_accepted
+        else {
+            return;
         };
 
         assert_eq!(default_ingress, default_env.ingress_id());
@@ -1542,16 +1560,26 @@ mod tests {
         assert_eq!(default_generation.as_u64(), 1);
         assert_eq!(named_generation.as_u64(), 2);
 
-        let default_record = runtime
-            .witnessed_submission(&default_submission)
-            .expect("default submission should be recorded");
+        let default_record = runtime.witnessed_submission(&default_submission);
+        assert!(
+            default_record.is_some(),
+            "default submission should be recorded"
+        );
+        let Some(default_record) = default_record else {
+            return;
+        };
         assert_eq!(default_record.ingress_id, default_env.ingress_id());
         assert_eq!(default_record.head_key, default_key);
         assert_eq!(default_record.submission_generation, default_generation);
 
-        let named_record = runtime
-            .witnessed_submission(&named_submission)
-            .expect("named submission should be recorded");
+        let named_record = runtime.witnessed_submission(&named_submission);
+        assert!(
+            named_record.is_some(),
+            "named submission should be recorded"
+        );
+        let Some(named_record) = named_record else {
+            return;
+        };
         assert_eq!(named_record.ingress_id, named_env.ingress_id());
         assert_eq!(named_record.head_key, named_key);
         assert_eq!(named_record.submission_generation, named_generation);
@@ -1581,21 +1609,36 @@ mod tests {
         let first = runtime.ingest(env.clone()).unwrap();
         let duplicate = runtime.ingest(env).unwrap();
 
-        let IngressDisposition::Accepted {
-            submission_id: first_submission,
-            submission_generation: first_generation,
-            ..
-        } = first
-        else {
-            panic!("first submission should be accepted");
+        let first_accepted = match first {
+            IngressDisposition::Accepted {
+                submission_id,
+                submission_generation,
+                ..
+            } => Some((submission_id, submission_generation)),
+            IngressDisposition::Duplicate { .. } => None,
         };
-        let IngressDisposition::Duplicate {
-            submission_id: duplicate_submission,
-            submission_generation: duplicate_generation,
-            ..
-        } = duplicate
-        else {
-            panic!("second submission should be duplicate");
+        assert!(
+            first_accepted.is_some(),
+            "first submission should be accepted"
+        );
+        let Some((first_submission, first_generation)) = first_accepted else {
+            return;
+        };
+
+        let duplicate_posture = match duplicate {
+            IngressDisposition::Duplicate {
+                submission_id,
+                submission_generation,
+                ..
+            } => Some((submission_id, submission_generation)),
+            IngressDisposition::Accepted { .. } => None,
+        };
+        assert!(
+            duplicate_posture.is_some(),
+            "second submission should be duplicate"
+        );
+        let Some((duplicate_submission, duplicate_generation)) = duplicate_posture else {
+            return;
         };
 
         assert_eq!(first_submission, duplicate_submission);

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -88,6 +88,61 @@ pub enum RuntimeError {
     /// Attempted to advance the global tick past `u64::MAX`.
     #[error("global tick overflow")]
     GlobalTickOverflow,
+    /// Attempted to allocate more witnessed intent submission generations than
+    /// the runtime counter can represent.
+    #[error("intent submission generation overflow")]
+    IntentSubmissionGenerationOverflow,
+}
+
+/// Echo-owned intake/correlation generation for witnessed intent submissions.
+///
+/// This is audit metadata for accepted ingress history. It is not scheduler
+/// order, not worldline tick identity, and not wall-clock time.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct IngressSubmissionGeneration(u64);
+
+impl IngressSubmissionGeneration {
+    /// Zero value used when Echo can derive a duplicate submission identity but
+    /// no local generation record is present.
+    pub const ZERO: Self = Self(0);
+    /// Largest representable submission generation.
+    pub const MAX: Self = Self(u64::MAX);
+
+    /// Builds a submission generation from its raw value.
+    #[must_use]
+    pub const fn from_raw(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw logical value.
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Increments by one, returning `None` on overflow.
+    #[must_use]
+    pub fn checked_increment(self) -> Option<Self> {
+        self.0.checked_add(1).map(Self)
+    }
+}
+
+/// Witnessed Echo ingress submission accepted by the runtime.
+///
+/// This record says Echo accepted a canonical ingress claim into its witnessed
+/// ingress history. It is not execution, not application state mutation, and not
+/// a scheduler-owned tick decision.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntentSubmissionRecord {
+    /// Content-addressed submission event id.
+    pub submission_id: Hash,
+    /// Content-addressed canonical intent ingress id.
+    pub ingress_id: Hash,
+    /// Resolved semantic writer-head target.
+    pub head_key: WriterHeadKey,
+    /// Echo-owned intake/correlation generation.
+    pub submission_generation: IngressSubmissionGeneration,
 }
 
 /// Result of ingesting an envelope into the runtime.
@@ -99,6 +154,10 @@ pub enum IngressDisposition {
         ingress_id: Hash,
         /// The head that accepted the ingress.
         head_key: WriterHeadKey,
+        /// Witnessed submission event id.
+        submission_id: Hash,
+        /// Echo-owned intake/correlation generation.
+        submission_generation: IngressSubmissionGeneration,
     },
     /// The envelope was already pending or already committed.
     Duplicate {
@@ -106,6 +165,11 @@ pub enum IngressDisposition {
         ingress_id: Hash,
         /// The head that owns the duplicate route target.
         head_key: WriterHeadKey,
+        /// Existing or deterministically derived witnessed submission event id.
+        submission_id: Hash,
+        /// Existing submission generation, or zero when only the duplicate
+        /// identity can be derived from replayed committed state.
+        submission_generation: IngressSubmissionGeneration,
     },
 }
 
@@ -159,6 +223,13 @@ pub struct WorldlineRuntime {
     default_writers: BTreeMap<WorldlineId, WriterHeadKey>,
     /// Deterministic route table for named public inboxes.
     public_inboxes: BTreeMap<WorldlineId, BTreeMap<InboxAddress, WriterHeadKey>>,
+    /// Next Echo-owned submission generation to assign.
+    next_submission_generation: IngressSubmissionGeneration,
+    /// Witnessed submission records keyed by content-addressed submission id.
+    witnessed_submissions: BTreeMap<Hash, IntentSubmissionRecord>,
+    /// Deterministic lookup from resolved semantic target and ingress id to
+    /// witnessed submission id.
+    submission_by_target: BTreeMap<(WriterHeadKey, Hash), Hash>,
     /// Registry of live speculative strands attached to the runtime.
     strands: StrandRegistry,
 }
@@ -228,6 +299,23 @@ impl WorldlineRuntime {
     #[must_use]
     pub fn heads(&self) -> &PlaybackHeadRegistry {
         &self.heads
+    }
+
+    /// Returns a witnessed submission by content-addressed submission id.
+    #[must_use]
+    pub fn witnessed_submission(&self, submission_id: &Hash) -> Option<&IntentSubmissionRecord> {
+        self.witnessed_submissions.get(submission_id)
+    }
+
+    /// Iterates witnessed submissions in deterministic submission-id order.
+    pub fn witnessed_submissions(&self) -> impl Iterator<Item = &IntentSubmissionRecord> {
+        self.witnessed_submissions.values()
+    }
+
+    /// Returns the number of witnessed submission records.
+    #[must_use]
+    pub fn witnessed_submission_count(&self) -> usize {
+        self.witnessed_submissions.len()
     }
 
     /// Returns the current correlation tick.
@@ -518,9 +606,12 @@ impl WorldlineRuntime {
                     .contains_committed_ingress(&head_key, &ingress_id)
             })
         {
+            let record = self.duplicate_submission_record(head_key, ingress_id);
             return Ok(IngressDisposition::Duplicate {
                 ingress_id,
                 head_key,
+                submission_id: record.submission_id,
+                submission_generation: record.submission_generation,
             });
         }
 
@@ -531,15 +622,78 @@ impl WorldlineRuntime {
             .ingest(envelope);
 
         match outcome {
-            InboxIngestResult::Accepted => Ok(IngressDisposition::Accepted {
-                ingress_id,
-                head_key,
-            }),
-            InboxIngestResult::Duplicate => Ok(IngressDisposition::Duplicate {
-                ingress_id,
-                head_key,
-            }),
+            InboxIngestResult::Accepted => {
+                let record = self.record_witnessed_submission(head_key, ingress_id)?;
+                Ok(IngressDisposition::Accepted {
+                    ingress_id,
+                    head_key,
+                    submission_id: record.submission_id,
+                    submission_generation: record.submission_generation,
+                })
+            }
+            InboxIngestResult::Duplicate => {
+                let record = self.duplicate_submission_record(head_key, ingress_id);
+                Ok(IngressDisposition::Duplicate {
+                    ingress_id,
+                    head_key,
+                    submission_id: record.submission_id,
+                    submission_generation: record.submission_generation,
+                })
+            }
             InboxIngestResult::Rejected => Err(RuntimeError::RejectedByPolicy(head_key)),
+        }
+    }
+
+    fn record_witnessed_submission(
+        &mut self,
+        head_key: WriterHeadKey,
+        ingress_id: Hash,
+    ) -> Result<IntentSubmissionRecord, RuntimeError> {
+        if let Some(record) = self
+            .submission_by_target
+            .get(&(head_key, ingress_id))
+            .and_then(|submission_id| self.witnessed_submissions.get(submission_id))
+        {
+            return Ok(record.clone());
+        }
+
+        let generation = self
+            .next_submission_generation
+            .checked_increment()
+            .ok_or(RuntimeError::IntentSubmissionGenerationOverflow)?;
+        let submission_id = derive_intent_submission_id(head_key, ingress_id);
+        let record = IntentSubmissionRecord {
+            submission_id,
+            ingress_id,
+            head_key,
+            submission_generation: generation,
+        };
+        self.next_submission_generation = generation;
+        self.submission_by_target
+            .insert((head_key, ingress_id), submission_id);
+        self.witnessed_submissions
+            .insert(submission_id, record.clone());
+        Ok(record)
+    }
+
+    fn duplicate_submission_record(
+        &self,
+        head_key: WriterHeadKey,
+        ingress_id: Hash,
+    ) -> IntentSubmissionRecord {
+        if let Some(record) = self
+            .submission_by_target
+            .get(&(head_key, ingress_id))
+            .and_then(|submission_id| self.witnessed_submissions.get(submission_id))
+        {
+            return record.clone();
+        }
+
+        IntentSubmissionRecord {
+            submission_id: derive_intent_submission_id(head_key, ingress_id),
+            ingress_id,
+            head_key,
+            submission_generation: IngressSubmissionGeneration::ZERO,
         }
     }
 
@@ -569,6 +723,15 @@ impl WorldlineRuntime {
                 .ok_or(RuntimeError::UnknownHead(*key)),
         }
     }
+}
+
+fn derive_intent_submission_id(head_key: WriterHeadKey, ingress_id: Hash) -> Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"echo.intent-submission.v0");
+    hasher.update(head_key.worldline_id.as_bytes());
+    hasher.update(head_key.head_id.as_bytes());
+    hasher.update(&ingress_id);
+    hasher.finalize().into()
 }
 
 // =============================================================================
@@ -1194,20 +1357,16 @@ mod tests {
         )
         .ingress_id();
 
-        assert_eq!(
+        assert!(matches!(
             default_result,
-            IngressDisposition::Accepted {
-                ingress_id: default_id,
-                head_key: default_key,
-            }
-        );
-        assert_eq!(
+            IngressDisposition::Accepted { ingress_id, head_key, .. }
+                if ingress_id == default_id && head_key == default_key
+        ));
+        assert!(matches!(
             named_result,
-            IngressDisposition::Accepted {
-                ingress_id: named_id,
-                head_key: named_key,
-            }
-        );
+            IngressDisposition::Accepted { ingress_id, head_key, .. }
+                if ingress_id == named_id && head_key == named_key
+        ));
     }
 
     #[test]
@@ -1285,40 +1444,323 @@ mod tests {
             b"same-payload".to_vec(),
         );
 
-        assert_eq!(
+        assert!(matches!(
             runtime.ingest(default_env.clone()).unwrap(),
-            IngressDisposition::Accepted {
-                ingress_id: default_env.ingress_id(),
-                head_key: default_key,
-            }
-        );
-        assert_eq!(
+            IngressDisposition::Accepted { ingress_id, head_key, .. }
+                if ingress_id == default_env.ingress_id() && head_key == default_key
+        ));
+        assert!(matches!(
             runtime.ingest(default_env.clone()).unwrap(),
-            IngressDisposition::Duplicate {
-                ingress_id: default_env.ingress_id(),
-                head_key: default_key,
-            }
-        );
+            IngressDisposition::Duplicate { ingress_id, head_key, .. }
+                if ingress_id == default_env.ingress_id() && head_key == default_key
+        ));
 
         let mut provenance = mirrored_provenance(&runtime);
         let records =
             SchedulerCoordinator::super_tick(&mut runtime, &mut provenance, &mut engine).unwrap();
         assert_eq!(records.len(), 1);
 
-        assert_eq!(
+        assert!(matches!(
             runtime.ingest(named_env.clone()).unwrap(),
-            IngressDisposition::Accepted {
-                ingress_id: named_env.ingress_id(),
-                head_key: named_key,
-            }
-        );
-        assert_eq!(
+            IngressDisposition::Accepted { ingress_id, head_key, .. }
+                if ingress_id == named_env.ingress_id() && head_key == named_key
+        ));
+        assert!(matches!(
             runtime.ingest(named_env).unwrap(),
-            IngressDisposition::Duplicate {
-                ingress_id: default_env.ingress_id(),
-                head_key: named_key,
-            }
+            IngressDisposition::Duplicate { ingress_id, head_key, .. }
+                if ingress_id == default_env.ingress_id() && head_key == named_key
+        ));
+    }
+
+    #[test]
+    fn submission_event_is_content_addressed_by_intent_bytes_and_target() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(1);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let default_key = register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
         );
+        let named_key = register_head(
+            &mut runtime,
+            worldline_id,
+            "orders",
+            Some("orders"),
+            false,
+            InboxPolicy::AcceptAll,
+        );
+
+        let kind = make_intent_kind("test");
+        let default_env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            kind,
+            b"same-payload".to_vec(),
+        );
+        let named_env = IngressEnvelope::local_intent(
+            IngressTarget::InboxAddress {
+                worldline_id,
+                inbox: InboxAddress("orders".to_owned()),
+            },
+            kind,
+            b"same-payload".to_vec(),
+        );
+
+        let IngressDisposition::Accepted {
+            ingress_id: default_ingress,
+            head_key: default_head,
+            submission_id: default_submission,
+            submission_generation: default_generation,
+        } = runtime.ingest(default_env.clone()).unwrap()
+        else {
+            panic!("default submission should be accepted");
+        };
+        let IngressDisposition::Accepted {
+            ingress_id: named_ingress,
+            head_key: named_head,
+            submission_id: named_submission,
+            submission_generation: named_generation,
+        } = runtime.ingest(named_env.clone()).unwrap()
+        else {
+            panic!("named submission should be accepted");
+        };
+
+        assert_eq!(default_ingress, default_env.ingress_id());
+        assert_eq!(named_ingress, named_env.ingress_id());
+        assert_eq!(default_ingress, named_ingress);
+        assert_eq!(default_head, default_key);
+        assert_eq!(named_head, named_key);
+        assert_ne!(
+            default_submission, named_submission,
+            "same canonical intent bytes routed to different heads must have distinct submission ids"
+        );
+        assert_eq!(default_generation.as_u64(), 1);
+        assert_eq!(named_generation.as_u64(), 2);
+
+        let default_record = runtime
+            .witnessed_submission(&default_submission)
+            .expect("default submission should be recorded");
+        assert_eq!(default_record.ingress_id, default_env.ingress_id());
+        assert_eq!(default_record.head_key, default_key);
+        assert_eq!(default_record.submission_generation, default_generation);
+
+        let named_record = runtime
+            .witnessed_submission(&named_submission)
+            .expect("named submission should be recorded");
+        assert_eq!(named_record.ingress_id, named_env.ingress_id());
+        assert_eq!(named_record.head_key, named_key);
+        assert_eq!(named_record.submission_generation, named_generation);
+    }
+
+    #[test]
+    fn duplicate_submission_returns_same_submission_identity_without_duplicate_history() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(1);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"duplicate".to_vec(),
+        );
+
+        let first = runtime.ingest(env.clone()).unwrap();
+        let duplicate = runtime.ingest(env).unwrap();
+
+        let IngressDisposition::Accepted {
+            submission_id: first_submission,
+            submission_generation: first_generation,
+            ..
+        } = first
+        else {
+            panic!("first submission should be accepted");
+        };
+        let IngressDisposition::Duplicate {
+            submission_id: duplicate_submission,
+            submission_generation: duplicate_generation,
+            ..
+        } = duplicate
+        else {
+            panic!("second submission should be duplicate");
+        };
+
+        assert_eq!(first_submission, duplicate_submission);
+        assert_eq!(first_generation, duplicate_generation);
+        assert_eq!(runtime.witnessed_submission_count(), 1);
+    }
+
+    #[test]
+    fn submission_history_does_not_advance_worldline_tick() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(1);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let head_key = register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"pending".to_vec(),
+        );
+        let ingress_id = env.ingress_id();
+
+        assert!(matches!(
+            runtime.ingest(env).unwrap(),
+            IngressDisposition::Accepted { .. }
+        ));
+
+        assert_eq!(runtime.global_tick(), gt(0));
+        let frontier = runtime.worldlines().get(&worldline_id).unwrap();
+        assert_eq!(frontier.frontier_tick(), wt(0));
+        assert!(!frontier
+            .state()
+            .contains_committed_ingress(&head_key, &ingress_id));
+        assert_eq!(
+            runtime
+                .heads
+                .get(&head_key)
+                .unwrap()
+                .inbox()
+                .pending_count(),
+            1
+        );
+        assert_eq!(runtime.witnessed_submission_count(), 1);
+    }
+
+    #[test]
+    fn submission_order_does_not_define_scheduler_order() {
+        let worldline_id = wl(1);
+        let kind = make_intent_kind("test");
+        let first = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            kind,
+            b"first-submitted".to_vec(),
+        );
+        let second = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            kind,
+            b"second-submitted".to_vec(),
+        );
+
+        let mut runtime_ab = WorldlineRuntime::new();
+        runtime_ab
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let head_ab = register_head(
+            &mut runtime_ab,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        runtime_ab.ingest(first.clone()).unwrap();
+        runtime_ab.ingest(second.clone()).unwrap();
+        let admitted_ab = runtime_ab
+            .heads
+            .inbox_mut(&head_ab)
+            .unwrap()
+            .admit()
+            .into_iter()
+            .map(|env| env.ingress_id())
+            .collect::<Vec<_>>();
+
+        let mut runtime_ba = WorldlineRuntime::new();
+        runtime_ba
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let head_ba = register_head(
+            &mut runtime_ba,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        runtime_ba.ingest(second).unwrap();
+        runtime_ba.ingest(first).unwrap();
+        let admitted_ba = runtime_ba
+            .heads
+            .inbox_mut(&head_ba)
+            .unwrap()
+            .admit()
+            .into_iter()
+            .map(|env| env.ingress_id())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            admitted_ab, admitted_ba,
+            "scheduler admission order must follow canonical ingress ids, not submission order"
+        );
+    }
+
+    #[test]
+    fn submission_history_has_deterministic_replay_shape() {
+        fn record_shape(runtime: &WorldlineRuntime) -> Vec<(Hash, Hash, WriterHeadKey, u64)> {
+            runtime
+                .witnessed_submissions()
+                .map(|record| {
+                    (
+                        record.submission_id,
+                        record.ingress_id,
+                        record.head_key,
+                        record.submission_generation.as_u64(),
+                    )
+                })
+                .collect()
+        }
+
+        fn build_runtime_with_submissions() -> WorldlineRuntime {
+            let mut runtime = WorldlineRuntime::new();
+            let worldline_id = wl(1);
+            runtime
+                .register_worldline(worldline_id, WorldlineState::empty())
+                .unwrap();
+            register_head(
+                &mut runtime,
+                worldline_id,
+                "default",
+                None,
+                true,
+                InboxPolicy::AcceptAll,
+            );
+            for bytes in [b"alpha".as_slice(), b"beta".as_slice(), b"gamma".as_slice()] {
+                runtime
+                    .ingest(IngressEnvelope::local_intent(
+                        IngressTarget::DefaultWriter { worldline_id },
+                        make_intent_kind("test"),
+                        bytes.to_vec(),
+                    ))
+                    .unwrap();
+            }
+            runtime
+        }
+
+        let first = build_runtime_with_submissions();
+        let second = build_runtime_with_submissions();
+
+        assert_eq!(record_shape(&first), record_shape(&second));
     }
 
     #[test]
@@ -1344,20 +1786,16 @@ mod tests {
             b"exact".to_vec(),
         );
 
-        assert_eq!(
+        assert!(matches!(
             runtime.ingest(envelope.clone()).unwrap(),
-            IngressDisposition::Accepted {
-                ingress_id: envelope.ingress_id(),
-                head_key: exact_key,
-            }
-        );
-        assert_eq!(
+            IngressDisposition::Accepted { ingress_id, head_key, .. }
+                if ingress_id == envelope.ingress_id() && head_key == exact_key
+        ));
+        assert!(matches!(
             runtime.ingest(envelope.clone()).unwrap(),
-            IngressDisposition::Duplicate {
-                ingress_id: envelope.ingress_id(),
-                head_key: exact_key,
-            }
-        );
+            IngressDisposition::Duplicate { ingress_id, head_key, .. }
+                if ingress_id == envelope.ingress_id() && head_key == exact_key
+        ));
     }
 
     #[test]

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -324,8 +324,8 @@ pub use worldline::{
 ///
 /// Prefer this coordinator/runtime API for new stepping and routing code.
 pub use coordinator::{
-    ForkStrandReceipt, ForkStrandRequest, IngressDisposition, RuntimeError, SchedulerCoordinator,
-    StepRecord, WorldlineRuntime,
+    ForkStrandReceipt, ForkStrandRequest, IngressDisposition, IngressSubmissionGeneration,
+    IntentSubmissionRecord, RuntimeError, SchedulerCoordinator, StepRecord, WorldlineRuntime,
 };
 /// Writer-head registry and routing primitives used by the runtime-owned ingress path.
 pub use head::{

--- a/crates/warp-core/tests/inbox.rs
+++ b/crates/warp-core/tests/inbox.rs
@@ -91,13 +91,14 @@ fn runtime_ingest_commits_without_legacy_graph_inbox_nodes() {
         make_intent_kind("test/runtime"),
         b"runtime-intent".to_vec(),
     );
-    assert_eq!(
+    assert!(matches!(
         runtime.ingest(envelope.clone()).unwrap(),
         IngressDisposition::Accepted {
-            ingress_id: envelope.ingress_id(),
-            head_key,
-        }
-    );
+            ingress_id,
+            head_key: routed_head_key,
+            ..
+        } if ingress_id == envelope.ingress_id() && routed_head_key == head_key
+    ));
 
     let mut provenance = registered_worldlines_provenance(&runtime);
     let records =
@@ -138,39 +139,43 @@ fn runtime_ingest_is_idempotent_per_resolved_head_after_commit() {
     );
     let default_ingress_id = default_env.ingress_id();
 
-    assert_eq!(
+    assert!(matches!(
         runtime.ingest(default_env.clone()).unwrap(),
         IngressDisposition::Accepted {
-            ingress_id: default_ingress_id,
-            head_key: default_key,
-        }
-    );
+            ingress_id,
+            head_key,
+            ..
+        } if ingress_id == default_ingress_id && head_key == default_key
+    ));
     let mut provenance = registered_worldlines_provenance(&runtime);
     SchedulerCoordinator::super_tick(&mut runtime, &mut provenance, &mut engine).unwrap();
 
-    assert_eq!(
+    assert!(matches!(
         runtime.ingest(default_env).unwrap(),
         IngressDisposition::Duplicate {
-            ingress_id: default_ingress_id,
-            head_key: default_key,
-        }
-    );
-    assert_eq!(
+            ingress_id,
+            head_key,
+            ..
+        } if ingress_id == default_ingress_id && head_key == default_key
+    ));
+    assert!(matches!(
         runtime.ingest(named_env.clone()).unwrap(),
         IngressDisposition::Accepted {
-            ingress_id: named_env.ingress_id(),
-            head_key: named_key,
-        }
-    );
+            ingress_id,
+            head_key,
+            ..
+        } if ingress_id == named_env.ingress_id() && head_key == named_key
+    ));
     SchedulerCoordinator::super_tick(&mut runtime, &mut provenance, &mut engine).unwrap();
     let named_ingress_id = named_env.ingress_id();
-    assert_eq!(
+    assert!(matches!(
         runtime.ingest(named_env).unwrap(),
         IngressDisposition::Duplicate {
-            ingress_id: named_ingress_id,
-            head_key: named_key,
-        }
-    );
+            ingress_id,
+            head_key,
+            ..
+        } if ingress_id == named_ingress_id && head_key == named_key
+    ));
 }
 
 #[test]

--- a/crates/warp-core/tests/invariant_property_tests.rs
+++ b/crates/warp-core/tests/invariant_property_tests.rs
@@ -256,10 +256,12 @@ proptest! {
                 IngressDisposition::Accepted {
                     ingress_id: id1,
                     head_key: routed_1,
+                    ..
                 },
                 IngressDisposition::Accepted {
                     ingress_id: id2,
                     head_key: routed_2,
+                    ..
                 },
             ) => {
                 prop_assert_eq!(id1, id2, "same bytes must produce same intent_id");
@@ -275,6 +277,7 @@ proptest! {
             IngressDisposition::Duplicate {
                 ingress_id,
                 head_key,
+                ..
             } => {
                 prop_assert_eq!(ingress_id, env2.ingress_id());
                 prop_assert_eq!(head_key, head_key_1);

--- a/crates/warp-wasm/README.md
+++ b/crates/warp-wasm/README.md
@@ -13,9 +13,11 @@ See the repository root `README.md` for the full overview.
   Echo’s deterministic wire protocol can be used from JavaScript/TypeScript in
   web-based tools and playgrounds.
 - Exposes the current observation-first and intent-shaped control surface
-  (`ABI_VERSION` 9 in `echo-wasm-abi`): `observe(...)` is the only public
+  (`ABI_VERSION` 10 in `echo-wasm-abi`): `observe(...)` is the only public
   world-state read export, `scheduler_status()` is the read-only scheduler
   metadata export, and `dispatch_intent(...)` is application intent ingress.
+  Accepted application ingress returns witnessed submission identity in addition
+  to canonical intent identity.
   The current ABI also publishes strand settlement comparison, planning,
   execution entrypoints, settlement basis evidence, overlap revalidation
   evidence, and read-side basis plus residual posture on observation artifacts.

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -776,6 +776,8 @@ mod init_tests {
             Ok(DispatchResponse {
                 accepted: true,
                 intent_id: vec![0; 32],
+                submission_id: Some(vec![1; 32]),
+                submission_generation: Some(1),
                 scheduler_status: SchedulerStatus {
                     state: SchedulerState::Inactive,
                     active_mode: Some(SchedulerMode::UntilIdle {

--- a/crates/warp-wasm/src/warp_kernel.rs
+++ b/crates/warp-wasm/src/warp_kernel.rs
@@ -1091,6 +1091,21 @@ impl KernelPort for WarpKernel {
         match self.runtime.ingest(envelope) {
             Ok(disposition) => {
                 let accepted = matches!(disposition, IngressDisposition::Accepted { .. });
+                let (submission_id, submission_generation) = match disposition {
+                    IngressDisposition::Accepted {
+                        submission_id,
+                        submission_generation,
+                        ..
+                    }
+                    | IngressDisposition::Duplicate {
+                        submission_id,
+                        submission_generation,
+                        ..
+                    } => (
+                        Some(submission_id.to_vec()),
+                        Some(submission_generation.as_u64()),
+                    ),
+                };
                 if accepted {
                     let admitted_at = self.current_head()?.worldline_tick;
                     self.record_stack_witness_fixture_admission(op_id, vars, admitted_at);
@@ -1099,6 +1114,8 @@ impl KernelPort for WarpKernel {
                 Ok(DispatchResponse {
                     accepted,
                     intent_id,
+                    submission_id,
+                    submission_generation,
                     scheduler_status: self.scheduler_status()?,
                 })
             }
@@ -1235,6 +1252,8 @@ impl TrustedKernelControlPort for WarpKernel {
         Ok(DispatchResponse {
             accepted: true,
             intent_id,
+            submission_id: None,
+            submission_generation: None,
             scheduler_status: self.scheduler_status()?,
         })
     }
@@ -2102,6 +2121,8 @@ mod tests {
         let resp = kernel.dispatch_intent(&intent).unwrap();
         assert!(resp.accepted);
         assert_eq!(resp.intent_id.len(), 32);
+        assert_eq!(resp.submission_id.as_ref().map(Vec::len), Some(32));
+        assert_eq!(resp.submission_generation, Some(1));
         assert_eq!(
             kernel.current_head().unwrap().worldline_tick,
             AbiWorldlineTick(0)
@@ -2119,6 +2140,8 @@ mod tests {
         assert!(r1.accepted);
         assert!(!r2.accepted);
         assert_eq!(r1.intent_id, r2.intent_id);
+        assert_eq!(r1.submission_id, r2.submission_id);
+        assert_eq!(r1.submission_generation, r2.submission_generation);
     }
 
     #[test]

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -3,72 +3,128 @@
 
 # BEARING
 
-Last updated: 2026-05-09.
+Last updated: 2026-05-20.
 
 This signpost summarizes current direction. It does not create commitments or
 replace backlog items, design docs, retros, or CLI status. If it disagrees with
 code, the code wins and this file should be corrected.
 
-## Where are we going?
+## Current Bearing
 
-Current priority: make Echo's WARP optics observable, documented, and fast to
-iterate without turning docs into a museum or a second codebase:
+Echo already has deterministic execution; it does not yet have a continuous
+witnessed intent pipeline into that execution.
 
-- Echo owns hot runtime truth in `warp-core`.
-- Echo exposes current browser-hostable substrate through the WASM ABI, not a
-  pile of historical ABI versions.
-- Observer-relative reading metadata travels in `ReadingEnvelope`.
-- Retained holograms should converge on WSC-backed bytes, CAS retention, and
-  future Verkle/IPA-style proof-carrying apertures without making any storage or
-  proof layer the ontology.
-- Method cycles and dated audit ledgers track planning decisions.
-- Local iteration speed is a first-class hill, because slow gates make every
-  design/code/doc correction more expensive.
+The current priority is to finish the path from application ingress to
+scheduler-owned tick outcome without giving application code tick authority.
 
-## What just shipped?
+## What Is Already True
 
-The runtime-doctrine cutover is no longer just design text:
+- Echo has deterministic execution through `WorldlineRuntime`,
+  `SchedulerCoordinator::super_tick(...)`, and `Engine::commit_with_state(...)`.
+- Application-facing `dispatch_intent(...)` submits canonical EINT bytes; it does
+  not tick the runtime.
+- Trusted runtime control owns scheduler runs through the separate
+  `TrustedKernelControlPort` boundary.
+- Fixed logical timestep doctrine exists. Wall-clock cadence is host/runtime
+  owner policy, not semantic Echo history.
+- Tick receipts exist and witness scheduler-owned candidate outcomes.
+- Footprint conflicts are explicit receipt rejections, not hidden retries.
+- The optic admission ladder resolves through SchedulerAdmission v0 and
+  currently stops before scheduler work.
 
-- `0007` has runtime shape through `crates/warp-core/src/neighborhood.rs` and
-  `NeighborhoodSiteService`.
-- `0008` has runtime shape through `crates/warp-core/src/settlement.rs` and
-  `SettlementService`.
-- `crates/warp-wasm/src/warp_kernel.rs` exposes neighborhood and settlement
-  surfaces through the WASM kernel boundary.
-- `crates/echo-wasm-abi/src/kernel_port.rs` is currently ABI version 9 and
-  makes observation requests name observer plan, optional instance, budget, and
-  rights while carrying `ReadingEnvelope` inside observation artifacts.
-- `docs/design/0019-reading-envelope-family-boundary/reading-envelope-family-boundary.md`
-  names the shared read-side family boundary for authored observer plans,
-  installed artifacts, runtime reading values, and retained reading identity.
-- `docs/architecture/wsc-verkle-ipa-retained-readings.md` locks the future
-  retained-reading stack: WSC as canonical columnar reading bytes, Verkle as
-  authenticated commitment/index, IPA as compact aperture proof, and `echo-cas`
-  as byte retention.
-- `docs/spec/SPEC-0009-wasm-abi.md` now documents the current ABI contract
-  instead of pretending to preserve ABI v1-v5.
+## What Is Not Yet True
 
-## What is next?
+- Accepted submissions are not yet complete witnessed ingress history.
+- Optic admission has no successful outcome.
+- Scheduler work candidates do not exist.
+- Law witnesses do not exist.
+- Admission tickets do not exist.
+- Ticketed runtime ingress is not wired.
+- Tick receipts are not cleanly correlated to intent, submission, and ticket ids.
+- Clients cannot observe intent outcome by id.
+- Installed Wesley handler dispatch is not wired into scheduler-owned execution.
+- Generic QueryView remains unsupported in core.
 
-1. Audit `docs/` five documents at a time, score each one against code, and
-   delete or relocate aggressively. The live docs corpus contains current,
-   useful, navigable truth; git history is the archive.
-2. Fold the Optic/Observer doctrine into the runtime path toward WARP optics,
-   anchored by `docs/design/0011-optic-observer-runtime-doctrine/design.md`.
-3. Improve local iteration by separating quick doc/code lanes from full release
-   gates while keeping full verification before publication.
-4. Implement QueryView observers against the accepted reading-envelope family
-   boundary instead of adding a parallel read-result wrapper.
-5. Keep the first `jedit` contract-hosting proof generic: `jedit` owns the hot
-   rope model, Echo retains WSC/proof-ready readings by generic CAS and reading
-   identity surfaces.
+## Doctrine
 
-## What feels wrong?
+Echo accepts intent submissions as witnessed ingress history.
 
-- `docs/` still mixes living specs, Method backlog items, generated assets,
-  historical audits, book sources, and stale top-level signposts.
-- The docs site still has broken or stale navigation surfaces from earlier
-  reorganizations.
-- Local verification remains too coarse for doc-only or narrow ABI changes.
-- We still lack one boring, inspectable agent boundary for "observe runtime,
-  ask question, get evidence-backed answer."
+Echo does not execute submissions synchronously.
+
+Echo's trusted runtime owner controls tick boundaries.
+
+A tick receipt witnesses the scheduler-owned decision.
+
+A rejected candidate remains witnessed history.
+
+Retry is a new explicit causal act.
+
+AdmissionTicket is not execution.
+
+TickReceipt is not AdmissionTicket.
+
+QueryView waits until the write-side pipeline is credible.
+
+Transport arrival is not semantic Echo history. Echo acceptance is semantic
+ingress history.
+
+Submission order may be witnessed. Submission order must not decide scheduler
+order.
+
+## Pipeline
+
+Evidence phase:
+
+```text
+canonical EINT
+-> witnessed submission
+-> admission gates
+-> scheduler work candidate
+-> law witness
+-> admission ticket
+```
+
+Runtime phase:
+
+```text
+admission ticket
+-> ticketed runtime ingress
+-> scheduler-owned tick
+-> tick receipt
+-> observable intent outcome
+```
+
+The hinge is:
+
+```text
+AdmissionTicket + witnessed submission -> ticketed runtime ingress
+```
+
+## Locked Sequence
+
+1. WitnessedIntentSubmission v0.
+2. SchedulerWorkCandidate v0.
+3. LawWitness v0.
+4. AdmissionTicket v0.
+5. TicketedRuntimeIngress v0.
+6. ReceiptCorrelation v0.
+7. IntentOutcomeObservation v0.
+8. InstalledContractHostDispatch v0.
+9. ConflictPolicy / ExplicitRetry v0.
+10. QueryViewObserverBridge v0.
+11. Replay/DIND proof.
+
+## Immediate Next Slice
+
+WitnessedIntentSubmission v0 proves that accepted canonical application intent
+bytes become witnessed Echo ingress history without running the scheduler.
+
+This slice must not implement scheduler work candidates, law witnesses,
+admission tickets, ticketed runtime ingress, receipt correlation, outcome
+observation, installed handler dispatch, QueryView, streaming subscriptions,
+automatic retry, or wall-clock cadence semantics.
+
+If full restart persistence is too large for the first implementation, keep the
+v0 ledger narrow and deterministic, then add a separate
+WitnessedIntentSubmissionPersistence v0 slice. Pending inbox memory alone is not
+the end state.

--- a/docs/method/backlog/up-next/KERNEL_witnessed-intent-submission-persistence.md
+++ b/docs/method/backlog/up-next/KERNEL_witnessed-intent-submission-persistence.md
@@ -1,0 +1,59 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Witnessed Intent Submission Persistence
+
+Status: follow-up implementation slice.
+
+Depends on:
+
+- WitnessedIntentSubmission v0.
+
+## Why now
+
+WitnessedIntentSubmission v0 records accepted application ingress as
+deterministic Echo-owned submission history, but the first slice intentionally
+does not build a durable restart/recovery substrate for accepted but not yet
+ticked submissions.
+
+Pending inbox memory alone is not the end state. Echo needs restart replay for
+accepted submission history without giving application code tick authority or
+making transport arrival semantic history.
+
+## RED
+
+Add a failing replay/recovery test:
+
+- submit canonical application intent bytes;
+- assert Echo records a witnessed submission and leaves the intent pending;
+- snapshot or persist the runtime using the narrowest existing storage hook;
+- reconstruct the runtime;
+- assert the same submission id, generation, target head, ingress id, and
+  pending ingress membership are restored;
+- assert no tick, handler dispatch, scheduler work, or application mutation
+  occurs during recovery.
+
+## GREEN
+
+Persist and restore witnessed submission records and pending ingress membership
+through the existing runtime/provenance storage boundary, or add the smallest
+new storage shell needed to make accepted-but-not-yet-ticked submissions
+replayable after restart.
+
+## Acceptance Criteria
+
+- Accepted pending submissions survive restart with stable submission identity.
+- Duplicate resubmission after restart returns duplicate posture, not a second
+  semantic submission event.
+- Submission recovery does not advance `GlobalTick` or `WorldlineTick`.
+- Submission recovery does not call `SchedulerCoordinator::super_tick(...)`.
+- Submission recovery does not dispatch installed handlers or execute contracts.
+- Raw transport arrival order remains outside semantic Echo history.
+
+## Non-goals
+
+- Do not implement scheduler work candidates.
+- Do not issue law witnesses or admission tickets.
+- Do not add outcome subscriptions.
+- Do not add QueryView.
+- Do not add automatic retry.

--- a/docs/spec/SPEC-0009-wasm-abi.md
+++ b/docs/spec/SPEC-0009-wasm-abi.md
@@ -7,7 +7,7 @@ _Define the current deterministic browser boundary for intent ingress, scheduler
 
 Legend: PLATFORM
 
-Current ABI version: 9
+Current ABI version: 10
 
 Depends on:
 
@@ -19,10 +19,11 @@ Depends on:
 
 The WASM boundary is where browser and host code meet the Echo runtime. It must be small, deterministic, and explicit about what kind of operation is crossing: intent admission, scheduler inspection, or observation.
 
-ABI version 9 keeps the current export shape and makes observation requests
-name their observer plan, optional hosted observer instance, read budget, and
-rights posture explicitly. Observation artifacts continue to carry
-reading-envelope metadata for emitted readings.
+ABI version 10 keeps the export shape from version 9 and extends
+`DispatchResponse` with witnessed submission identity for accepted application
+ingress. Observation requests still name their observer plan, optional hosted
+observer instance, read budget, and rights posture explicitly. Observation
+artifacts continue to carry reading-envelope metadata for emitted readings.
 
 ## Human users / jobs / hills
 
@@ -50,6 +51,12 @@ Removed exports stay removed: `step`, `snapshot_at`, `render_snapshot`, `execute
 The reserved scheduler/control op id is not an application intent. Public
 application dispatch rejects it before the kernel can run scheduler control.
 Trusted host/runtime control uses a separate authority path.
+
+For accepted or duplicate application ingress, `DispatchResponse` carries both
+the canonical `intent_id` and a witnessed `submission_id` plus
+`submission_generation`. The submission fields are intake/audit correlation
+metadata, not scheduler order, not worldline ticks, and not wall-clock time.
+Trusted runtime control responses do not carry application submission identity.
 
 ## Decision 3: Observation is the only public world-state read
 


### PR DESCRIPTION
## Summary
- Refocus BEARING on the witnessed intent pipeline into existing deterministic execution.
- Record accepted application ingress as Echo-owned witnessed submission history without ticking or executing.
- Return submission identity/generation through WASM ABI v10 and document the persistence follow-up.

## Tests
- cargo test -p warp-core --lib submission_
- cargo test -p warp-wasm --features engine dispatch_intent
- cargo test -p echo-wasm-abi dispatch_optic_intent
- cargo check
- cargo fmt --all
- git diff --check
- push hook full verification: fmt, guards, clippy-core, tests-runtime, tests-warp-core, rustdoc

## Notes
- Submission is not execution, application state mutation, or a tick.
- Durable restart replay for pending submissions is recorded as a follow-up backlog item.