### PR TITLE
fix(tooling): keep local rustdoc opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
             - name: cargo fmt
               run: cargo fmt --all -- --check
 
+    hook-regression:
+        name: Hook Regression Tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: false
+            - name: verify-local hook regression
+              run: bash tests/hooks/test_verify_local.sh
+
     clippy:
         name: Clippy
         runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,14 @@
   `scripts/verify-local.sh` skips local rustdoc lanes unless
   `VERIFY_LOCAL_RUSTDOC=1` is set, keeping pre-push and full local gates focused
   on faster edit-loop witnesses while preserving CI rustdoc coverage.
+- Tooling-only full verification now selects focused hook regression scripts by
+  changed file family, so a `scripts/verify-local.sh` edit runs the verify-local
+  hook regression without also running unrelated runtime-schema, PR-status, or
+  timing hook tests.
+- Local hook regression tests are now CI-owned by default. The local full gate
+  skips hook tests unless `VERIFY_LOCAL_HOOK_TESTS=1` is set, and the opt-in
+  hook-test lane clears verifier override variables before launching nested
+  hook regressions.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,11 @@
 
 ### Changed
 
+- Local verification now treats rustdoc warnings as CI-owned by default.
+  `scripts/verify-local.sh` skips local rustdoc lanes unless
+  `VERIFY_LOCAL_RUSTDOC=1` is set, keeping pre-push and full local gates focused
+  on faster edit-loop witnesses while preserving CI rustdoc coverage.
+
 ### Fixed
 
 - `Determinism Guards` no longer runs `apt-get install ripgrep`; static guard

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -66,9 +66,11 @@ or other non-Rust crate changes do not wake the Rust smoke lanes.
 `make verify-ultra-fast` is now the shortest edit-loop lane. It stays
 compile-first: Rust changes get `cargo check` on changed Rust crates plus the
 same targeted critical smoke selection used by the full gate, while clippy,
-rustdoc, guard scans, and exhaustive local proof stay on the heavier paths and
-in CI. Tooling-only changes stay on a syntax/smoke path instead of inheriting
-the full hook regression suite.
+guard scans, and exhaustive local proof stay on the heavier paths and in CI.
+Rustdoc warnings are CI-owned by default; use
+`VERIFY_LOCAL_RUSTDOC=1 make verify-full` only when you deliberately want to
+pay that local cost. Tooling-only changes stay on a syntax/smoke path instead
+of inheriting the full hook regression suite.
 
 A successful `make verify-full` run now shares the same success stamp as the
 canonical pre-push full gate for the same worktree, so commit-only churn

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -70,7 +70,10 @@ guard scans, and exhaustive local proof stay on the heavier paths and in CI.
 Rustdoc warnings are CI-owned by default; use
 `VERIFY_LOCAL_RUSTDOC=1 make verify-full` only when you deliberately want to
 pay that local cost. Tooling-only changes stay on a syntax/smoke path instead
-of inheriting the full hook regression suite.
+of inheriting the full hook regression suite. Hook regression tests are CI-owned
+by default; use `VERIFY_LOCAL_HOOK_TESTS=1 make verify-full` when you
+deliberately want the local hook regression lane. That opt-in lane selects tests
+by tooling file family instead of running every hook test for every tooling edit.
 
 A successful `make verify-full` run now shares the same success stamp as the
 canonical pre-push full gate for the same worktree, so commit-only churn

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -23,6 +23,7 @@ VERIFY_LANE_MODE="${VERIFY_LANE_MODE:-parallel}"
 VERIFY_LANE_ROOT="${VERIFY_LANE_ROOT:-target/verify-lanes}"
 VERIFY_TIMING_FILE="${VERIFY_TIMING_FILE:-$STAMP_DIR/timing.jsonl}"
 VERIFY_LOCAL_RUSTDOC="${VERIFY_LOCAL_RUSTDOC:-0}"
+VERIFY_LOCAL_HOOK_TESTS="${VERIFY_LOCAL_HOOK_TESTS:-0}"
 VERIFY_RUN_CACHE_STATE="${VERIFY_RUN_CACHE_STATE:-fresh}"
 VERIFY_CLASSIFICATION="${VERIFY_CLASSIFICATION:-unknown}"
 SECONDS=0
@@ -389,6 +390,10 @@ use_nextest() {
 
 local_rustdoc_enabled() {
   [[ "$VERIFY_LOCAL_RUSTDOC" == "1" ]]
+}
+
+local_hook_tests_enabled() {
+  [[ "$VERIFY_LOCAL_HOOK_TESTS" == "1" ]]
 }
 
 list_changed_branch_files() {
@@ -1383,22 +1388,92 @@ run_full_lane_rustdoc() {
 }
 
 run_full_lane_hook_tests() {
+  if ! local_hook_tests_enabled; then
+    echo "[verify-local][hook-tests] CI-owned by default; set VERIFY_LOCAL_HOOK_TESTS=1 to opt in"
+    return
+  fi
   if [[ "$FULL_SCOPE_HAS_TOOLING" != "1" ]]; then
     echo "[verify-local][hook-tests] no tooling changes detected"
     return
   fi
-  shopt -s nullglob
-  local -a hook_tests=(tests/hooks/test_*.sh)
-  shopt -u nullglob
+  local -a hook_tests=()
+  mapfile -t hook_tests < <(select_hook_tests)
   if [[ ${#hook_tests[@]} -eq 0 ]]; then
-    echo "[verify-local][hook-tests] no hook regression scripts present"
+    echo "[verify-local][hook-tests] no focused hook regression scripts selected"
     return
   fi
   echo "[verify-local][hook-tests] hook regression coverage"
   local hook_test
   for hook_test in "${hook_tests[@]}"; do
-    bash "$hook_test"
+    (
+      unset VERIFY_CHANGED_FILES_FILE VERIFY_FORCE VERIFY_STAMP_DIR VERIFY_STAMP_SUBJECT
+      bash "$hook_test"
+    )
   done
+}
+
+select_hook_tests() {
+  local -a selected_hook_tests=()
+  local run_all=0
+  local file test_path
+
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    case "$file" in
+      scripts/verify-local.sh|Makefile|.github/workflows/*)
+        test_path="tests/hooks/test_verify_local.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      .githooks/*|scripts/hooks/pre-commit|scripts/hooks/pre-push|scripts/test-hook-issues.sh)
+        test_path="tests/hooks/test_hook_issues.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        test_path="tests/hooks/test_hook_timing.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      scripts/hooks/README.md)
+        ;;
+      scripts/plot-prepush-timing.mjs)
+        test_path="tests/hooks/test_plot_prepush_timing.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      scripts/pr-status.sh)
+        test_path="tests/hooks/test_pr_status.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      schemas/runtime/*.graphql|scripts/validate-runtime-schema-fragments.mjs)
+        test_path="tests/hooks/test_runtime_schema_validation.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      scripts/generate-dependency-dags.js|scripts/parse-tasks-dag.js|scripts/dag-utils.js|docs/assets/dags/*)
+        test_path="tests/hooks/test_dependency_dags.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      .coderabbit.yaml)
+        test_path="tests/hooks/test_coderabbit_config.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      crates/warp-core/src/optic.rs)
+        test_path="tests/hooks/test_module_size.sh"
+        [[ -f "$test_path" ]] && append_unique "$test_path" selected_hook_tests
+        ;;
+      tests/hooks/test_*.sh)
+        [[ -f "$file" ]] && append_unique "$file" selected_hook_tests
+        ;;
+      scripts/*.sh|scripts/*.mjs|scripts/*.cjs|scripts/*.js|.githooks/*|scripts/hooks/*)
+        run_all=1
+        ;;
+    esac
+  done <<< "${CHANGED_FILES}"
+
+  if [[ "$run_all" == "1" ]]; then
+    shopt -s nullglob
+    selected_hook_tests=(tests/hooks/test_*.sh)
+    shopt -u nullglob
+  fi
+
+  if [[ ${#selected_hook_tests[@]} -gt 0 ]]; then
+    printf '%s\n' "${selected_hook_tests[@]}"
+  fi
 }
 
 run_ultra_fast_tooling_smoke() {
@@ -1428,7 +1503,9 @@ run_full_lane_guards() {
 run_full_checks_sequential() {
   echo "[verify-local] critical local gate (${FULL_SCOPE_MODE})"
   run_timed_step "fmt" run_full_lane_fmt
-  run_timed_step "hook-tests" run_full_lane_hook_tests
+  if local_hook_tests_enabled; then
+    run_timed_step "hook-tests" run_full_lane_hook_tests
+  fi
   run_timed_step "clippy-core" run_full_lane_clippy_core
   run_timed_step "clippy-support" run_full_lane_clippy_support
   run_timed_step "clippy-bins" run_full_lane_clippy_bins
@@ -1446,7 +1523,7 @@ run_full_checks_parallel() {
 
   echo "[verify-local] critical local gate (${FULL_SCOPE_MODE})"
 
-  if [[ "$FULL_SCOPE_HAS_TOOLING" == "1" ]]; then
+  if local_hook_tests_enabled && [[ "$FULL_SCOPE_HAS_TOOLING" == "1" ]]; then
     lanes+=("hook-tests" run_full_lane_hook_tests)
   fi
   if [[ ${#FULL_SCOPE_CLIPPY_CORE_PACKAGES[@]} -gt 0 ]]; then

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -22,6 +22,7 @@ VERIFY_USE_NEXTEST="${VERIFY_USE_NEXTEST:-0}"
 VERIFY_LANE_MODE="${VERIFY_LANE_MODE:-parallel}"
 VERIFY_LANE_ROOT="${VERIFY_LANE_ROOT:-target/verify-lanes}"
 VERIFY_TIMING_FILE="${VERIFY_TIMING_FILE:-$STAMP_DIR/timing.jsonl}"
+VERIFY_LOCAL_RUSTDOC="${VERIFY_LOCAL_RUSTDOC:-0}"
 VERIFY_RUN_CACHE_STATE="${VERIFY_RUN_CACHE_STATE:-fresh}"
 VERIFY_CLASSIFICATION="${VERIFY_CLASSIFICATION:-unknown}"
 SECONDS=0
@@ -384,6 +385,10 @@ ensure_toolchain() {
 
 use_nextest() {
   [[ "$VERIFY_USE_NEXTEST" == "1" ]] && command -v cargo-nextest >/dev/null 2>&1
+}
+
+local_rustdoc_enabled() {
+  [[ "$VERIFY_LOCAL_RUSTDOC" == "1" ]]
 }
 
 list_changed_branch_files() {
@@ -753,16 +758,18 @@ run_targeted_checks() {
 
   run_crate_lint_and_check targeted "${crates[@]}"
 
-  for crate in "${FULL_LOCAL_RUSTDOC_PACKAGES[@]}"; do
-    if printf '%s\n' "${crates[@]}" | grep -qx "$crate"; then
-      rustdoc_crates+=("$crate")
-    fi
-  done
+  if local_rustdoc_enabled; then
+    for crate in "${FULL_LOCAL_RUSTDOC_PACKAGES[@]}"; do
+      if printf '%s\n' "${crates[@]}" | grep -qx "$crate"; then
+        rustdoc_crates+=("$crate")
+      fi
+    done
 
-  for crate in "${rustdoc_crates[@]}"; do
-    echo "[verify-local] rustdoc warnings gate (${crate})"
-    RUSTDOCFLAGS="-D warnings" cargo +"$PINNED" doc -p "$crate" --no-deps
-  done
+    for crate in "${rustdoc_crates[@]}"; do
+      echo "[verify-local] rustdoc warnings gate (${crate})"
+      RUSTDOCFLAGS="-D warnings" cargo +"$PINNED" doc -p "$crate" --no-deps
+    done
+  fi
 
   for crate in "${crates[@]}"; do
     if [[ ! -f "crates/${crate}/Cargo.toml" ]]; then
@@ -1358,6 +1365,10 @@ run_full_lane_tests_warp_core() {
 }
 
 run_full_lane_rustdoc() {
+  if ! local_rustdoc_enabled; then
+    echo "[verify-local][rustdoc] CI-owned by default; set VERIFY_LOCAL_RUSTDOC=1 to opt in"
+    return
+  fi
   if [[ ${#FULL_SCOPE_RUSTDOC_PACKAGES[@]} -eq 0 ]]; then
     echo "[verify-local][rustdoc] no selected public-doc crates"
     return
@@ -1424,7 +1435,9 @@ run_full_checks_sequential() {
   run_timed_step "tests-support" run_full_lane_tests_support
   run_timed_step "tests-runtime" run_full_lane_tests_runtime
   run_timed_step "tests-warp-core" run_full_lane_tests_warp_core
-  run_timed_step "rustdoc" run_full_lane_rustdoc
+  if local_rustdoc_enabled; then
+    run_timed_step "rustdoc" run_full_lane_rustdoc
+  fi
   run_timed_step "guards" run_full_lane_guards
 }
 
@@ -1454,7 +1467,7 @@ run_full_checks_parallel() {
   if [[ "$FULL_SCOPE_RUN_WARP_CORE_SMOKE" == "1" ]]; then
     lanes+=("tests-warp-core" run_full_lane_tests_warp_core)
   fi
-  if [[ ${#FULL_SCOPE_RUSTDOC_PACKAGES[@]} -gt 0 ]]; then
+  if local_rustdoc_enabled && [[ ${#FULL_SCOPE_RUSTDOC_PACKAGES[@]} -gt 0 ]]; then
     lanes+=("rustdoc" run_full_lane_rustdoc)
   fi
 

--- a/tests/hooks/test_verify_local.sh
+++ b/tests/hooks/test_verify_local.sh
@@ -264,6 +264,9 @@ EOF
   if [[ -n "${VERIFY_FAKE_TIMING_FILE:-}" ]]; then
     verify_env+=("VERIFY_TIMING_FILE=$VERIFY_FAKE_TIMING_FILE")
   fi
+  if [[ -n "${VERIFY_LOCAL_RUSTDOC+x}" ]]; then
+    verify_env+=("VERIFY_LOCAL_RUSTDOC=$VERIFY_LOCAL_RUSTDOC")
+  fi
   output="$(
     cd "$tmp" && \
     env "${verify_env[@]}" \
@@ -1020,6 +1023,21 @@ if printf '%s\n' "$fake_full_output" | grep -q 'target/verify-lanes/full-tests-w
 else
   fail "full verification should route warp-core tests through an isolated target dir"
   printf '%s\n' "$fake_full_output"
+fi
+if printf '%s\n' "$fake_full_output" | grep -q 'doc -p warp-core'; then
+  fail "full local verification should leave rustdoc to CI by default"
+  printf '%s\n' "$fake_full_output"
+else
+  pass "full local verification leaves rustdoc to CI by default"
+fi
+VERIFY_LOCAL_RUSTDOC=1
+fake_full_rustdoc_output="$(run_fake_verify full crates/warp-core/src/lib.rs)"
+unset VERIFY_LOCAL_RUSTDOC
+if printf '%s\n' "$fake_full_rustdoc_output" | grep -q 'doc -p warp-core'; then
+  pass "full local verification keeps an explicit rustdoc opt-in"
+else
+  fail "full local verification should keep an explicit rustdoc opt-in"
+  printf '%s\n' "$fake_full_rustdoc_output"
 fi
 
 fake_full_seq_output="$(run_fake_verify full crates/warp-core/src/lib.rs sequential)"

--- a/tests/hooks/test_verify_local.sh
+++ b/tests/hooks/test_verify_local.sh
@@ -936,7 +936,7 @@ else
   printf '%s\n' "$deleted_pre_commit_output"
 fi
 
-if rg -q 'scripts/verify-local\.sh pre-commit' .githooks/pre-commit; then
+if grep -Eq 'scripts/verify-local\.sh pre-commit' .githooks/pre-commit; then
   pass "canonical pre-commit hook delegates staged crate verification to verify-local"
 else
   fail "canonical pre-commit hook should delegate staged crate verification to verify-local"

--- a/tests/hooks/test_verify_local.sh
+++ b/tests/hooks/test_verify_local.sh
@@ -219,10 +219,20 @@ exit 1
 EOF
   chmod +x "$tmp/bin/cargo" "$tmp/bin/cargo-nextest" "$tmp/bin/rustup" "$tmp/bin/rg" "$tmp/bin/npx" "$tmp/bin/pnpm" "$tmp/bin/git"
 
-  cat >"$tmp/tests/hooks/test_verify_local.sh" <<'EOF'
+cat >"$tmp/tests/hooks/test_verify_local.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-echo "fake hook coverage"
+printf '%s\n' "test_verify_local.sh" >>"$VERIFY_FAKE_HOOK_LOG"
+EOF
+  cat >"$tmp/tests/hooks/test_hook_timing.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "test_hook_timing.sh" >>"$VERIFY_FAKE_HOOK_LOG"
+EOF
+  cat >"$tmp/tests/hooks/test_runtime_schema_validation.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "test_runtime_schema_validation.sh" >>"$VERIFY_FAKE_HOOK_LOG"
 EOF
   cat >"$tmp/.githooks/pre-push" <<'EOF'
 #!/usr/bin/env bash
@@ -234,7 +244,12 @@ EOF
 set -euo pipefail
 echo "fake legacy pre-commit shim"
 EOF
-  chmod +x "$tmp/tests/hooks/test_verify_local.sh" "$tmp/.githooks/pre-push" "$tmp/scripts/hooks/pre-commit"
+  chmod +x \
+    "$tmp/tests/hooks/test_verify_local.sh" \
+    "$tmp/tests/hooks/test_hook_timing.sh" \
+    "$tmp/tests/hooks/test_runtime_schema_validation.sh" \
+    "$tmp/.githooks/pre-push" \
+    "$tmp/scripts/hooks/pre-commit"
 
   local changed
   changed="$(mktemp)"
@@ -247,6 +262,8 @@ EOF
   pnpm_log="$(mktemp)"
   local nextest_log
   nextest_log="$(mktemp)"
+  local hook_log
+  hook_log="$(mktemp)"
 
   local output
   local -a verify_env=(
@@ -260,12 +277,16 @@ EOF
     "VERIFY_FAKE_NPX_LOG=$npx_log"
     "VERIFY_FAKE_PNPM_LOG=$pnpm_log"
     "VERIFY_FAKE_NEXTEST_LOG=$nextest_log"
+    "VERIFY_FAKE_HOOK_LOG=$hook_log"
   )
   if [[ -n "${VERIFY_FAKE_TIMING_FILE:-}" ]]; then
     verify_env+=("VERIFY_TIMING_FILE=$VERIFY_FAKE_TIMING_FILE")
   fi
   if [[ -n "${VERIFY_LOCAL_RUSTDOC+x}" ]]; then
     verify_env+=("VERIFY_LOCAL_RUSTDOC=$VERIFY_LOCAL_RUSTDOC")
+  fi
+  if [[ -n "${VERIFY_LOCAL_HOOK_TESTS+x}" ]]; then
+    verify_env+=("VERIFY_LOCAL_HOOK_TESTS=$VERIFY_LOCAL_HOOK_TESTS")
   fi
   output="$(
     cd "$tmp" && \
@@ -282,8 +303,10 @@ EOF
   cat "$pnpm_log"
   echo "--- nextest-log ---"
   cat "$nextest_log"
+  echo "--- hook-log ---"
+  cat "$hook_log"
 
-  rm -f "$changed" "$cargo_log" "$npx_log" "$pnpm_log" "$nextest_log"
+  rm -f "$changed" "$cargo_log" "$npx_log" "$pnpm_log" "$nextest_log" "$hook_log"
   rm -rf "$tmp"
 }
 
@@ -1353,18 +1376,44 @@ else
   printf '%s\n' "$fake_tooling_output"
 fi
 if printf '%s\n' "$fake_tooling_output" | grep -q 'fmt' \
-  && printf '%s\n' "$fake_tooling_output" | grep -q 'guards' \
-  && printf '%s\n' "$fake_tooling_output" | grep -q 'hook-tests'; then
-  pass "tooling-only full verification runs hook regression coverage"
+  && printf '%s\n' "$fake_tooling_output" | grep -q 'guards'; then
+  pass "tooling-only full verification keeps the local syntax and guard coverage"
 else
-  fail "tooling-only full verification should run hook regression coverage"
+  fail "tooling-only full verification should keep the local syntax and guard coverage"
   printf '%s\n' "$fake_tooling_output"
+fi
+if printf '%s\n' "$fake_tooling_output" | grep -q 'hook-tests'; then
+  fail "tooling-only full verification should leave hook regressions to CI by default"
+  printf '%s\n' "$fake_tooling_output"
+else
+  pass "tooling-only full verification leaves hook regressions to CI by default"
 fi
 if printf '%s\n' "$fake_tooling_output" | grep -q 'target/verify-lanes/full-clippy-core'; then
   fail "tooling-only full verification should not launch core Rust lanes"
   printf '%s\n' "$fake_tooling_output"
 else
   pass "tooling-only full verification skips core Rust lanes"
+fi
+VERIFY_LOCAL_HOOK_TESTS=1
+fake_tooling_hook_output="$(run_fake_verify full scripts/verify-local.sh)"
+unset VERIFY_LOCAL_HOOK_TESTS
+if printf '%s\n' "$fake_tooling_hook_output" | grep -q 'hook-tests'; then
+  pass "tooling-only full verification keeps an explicit hook regression opt-in"
+else
+  fail "tooling-only full verification should keep an explicit hook regression opt-in"
+  printf '%s\n' "$fake_tooling_hook_output"
+fi
+if printf '%s\n' "$fake_tooling_hook_output" | grep -q '^test_verify_local\.sh$'; then
+  pass "verify-local changes run the focused verify-local hook regression"
+else
+  fail "verify-local changes should run the focused verify-local hook regression"
+  printf '%s\n' "$fake_tooling_hook_output"
+fi
+if printf '%s\n' "$fake_tooling_hook_output" | grep -q '^test_runtime_schema_validation\.sh$'; then
+  fail "verify-local changes should skip unrelated runtime schema hook tests"
+  printf '%s\n' "$fake_tooling_hook_output"
+else
+  pass "verify-local changes skip unrelated runtime schema hook tests"
 fi
 
 fake_runtime_schema_output="$(run_fake_verify full schemas/runtime/artifact-a-identifiers.graphql)"


### PR DESCRIPTION
## Summary
- Make local rustdoc verification opt-in via `VERIFY_LOCAL_RUSTDOC=1`
- Make local hook regression tests opt-in via `VERIFY_LOCAL_HOOK_TESTS=1`
- Add a CI hook-regression job for `tests/hooks/test_verify_local.sh`
- Keep the opt-in local hook-test lane focused by changed tooling file family

## Verification
- `bash -n scripts/verify-local.sh tests/hooks/test_verify_local.sh`
- `bash tests/hooks/test_verify_local.sh`
- `VERIFY_FORCE=1 scripts/verify-local.sh full` (`real 3.29s`)
- `git diff --check`
- `cargo fmt --all --check`
- `npx markdownlint-cli2 CHANGELOG.md scripts/hooks/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in environment variables (`VERIFY_LOCAL_RUSTDOC` and `VERIFY_LOCAL_HOOK_TESTS`) to enable local Rustdoc and hook regression testing during development.

* **Documentation**
  * Enhanced verification lane documentation, clarifying `verify-ultra-fast` as the quickest edit-loop option with focused tooling checks.

* **Tests**
  * Expanded test coverage for local verification behaviors and optional gates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/echo/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->