### PR TITLE
feat(core): add installed contract host dispatch seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ### Added
 
+- `warp-core` now exposes a scheduler-owned installed contract host seam for
+  EINT-backed mutation handlers. Host/generated `cmd/*` rules can read a
+  scheduler-materialized runtime ingress event, match its EINT operation id,
+  borrow canonical vars bytes for generated decoding, and extend a standard
+  runtime-ingress read footprint with handler-specific writes. Tests prove an
+  installed toy contract handler does not run during application dispatch, runs
+  only during `SchedulerCoordinator::super_tick(...)`, and ignores nonmatching
+  EINT operation ids. This does not generate Wesley handler rules, implement
+  QueryView, add dynamic plugin loading, or allow application code to tick the
+  runtime.
 - `warp-core` now records runtime-local scheduler fault quarantine posture after internal
   scheduler faults. Lawful receipt-level rejections remain normal tick outcomes
   and do not fault heads. Scoped internal head faults roll back the failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Added
 
+- `echo-wesley-gen` now supports `--contract-host`, an opt-in generated helper
+  surface for installed `warp-core` mutation handlers. Generated mutation
+  helpers now include stable contract command-rule names, op-id matchers,
+  typed vars decoding from scheduler-materialized EINT runtime ingress events,
+  base runtime-ingress read footprints, and rule constructors that accept
+  host-supplied executor and footprint functions. A generated toy-counter smoke
+  crate proves the emitted helpers install into `warp-core` and run only during
+  scheduler-owned ticks. This flag is std-only and does not implement QueryView,
+  dynamic plugin loading, or a generated application mutation body.
 - `warp-core` now exposes a scheduler-owned installed contract host seam for
   EINT-backed mutation handlers. Host/generated `cmd/*` rules can read a
   scheduler-materialized runtime ingress event, match its EINT operation id,

--- a/crates/echo-wesley-gen/README.md
+++ b/crates/echo-wesley-gen/README.md
@@ -25,6 +25,9 @@ cat ir.json | cargo run -p echo-wesley-gen --
 
 # Write to a file
 cat ir.json | cargo run -p echo-wesley-gen -- --out generated.rs
+
+# Emit std-only warp-core contract-host helpers for installed mutation handlers
+cat ir.json | cargo run -p echo-wesley-gen -- --contract-host --out generated.rs
 ```
 
 ## Notes
@@ -43,6 +46,13 @@ cat ir.json | cargo run -p echo-wesley-gen -- --out generated.rs
 - Generated query optic helpers use Echo ABI's domain-separated BLAKE3
   `query_vars_digest_v1(...)`; ad hoc variable digests are not accepted for
   retained reading identity.
+- `--contract-host` emits opt-in, std-only mutation helpers for installing
+  generated operations as `warp-core` command rules. The generated surface
+  matches scheduler-materialized EINT runtime ingress events by op id, decodes
+  typed vars, provides the base runtime-ingress read footprint, and builds a
+  `RewriteRule` from host-supplied executor and footprint functions. It does
+  not generate the application mutation body or grant application code tick
+  authority.
 - Optional fields become `Option<T>`; lists become `Vec<T>` (wrapped in Option when not required).
 - Unknown scalar names are emitted as identifiers as-is (so ensure upstream IR types are valid Rust idents).
 - Runtime optic artifact imports preserve Wesley-owned canonical admission

--- a/crates/echo-wesley-gen/src/main.rs
+++ b/crates/echo-wesley-gen/src/main.rs
@@ -48,10 +48,17 @@ struct Args {
     /// Emit minicbor Encode/Decode implementations for all types
     #[arg(long, default_value_t = false)]
     minicbor: bool,
+
+    /// Emit warp-core contract-host helpers for installed mutation handlers
+    #[arg(long, default_value_t = false)]
+    contract_host: bool,
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    if args.no_std && args.contract_host {
+        bail!("--contract-host requires std and cannot be combined with --no-std");
+    }
 
     let ir = if let Some(schema_path) = &args.schema {
         let schema_sdl = std::fs::read_to_string(schema_path)?;
@@ -516,6 +523,15 @@ fn generate_rust(ir: &WesleyIR, args: &Args) -> Result<String> {
             });
         }
 
+        if args.contract_host && has_mutation_ops {
+            helper_prelude.extend(quote! {
+                use warp_core::{
+                    ConflictPolicy, Footprint, GraphView, NodeId, PatternGraph, RewriteRule,
+                    TickDelta,
+                };
+            });
+        }
+
         if has_query_ops {
             helper_tokens.extend(quote! {
                 fn generated_vars_digest(vars_bytes: &[u8]) -> Vec<u8> {
@@ -574,6 +590,18 @@ fn generate_rust(ir: &WesleyIR, args: &Args) -> Result<String> {
                     helper_exports.push(raw_fn_name.clone());
                     helper_exports.push(optic_fn_name.clone());
                     helper_exports.push(optic_raw_fn_name.clone());
+                    let contract_rule_name_const =
+                        format_ident!("{}_CONTRACT_RULE_NAME", const_name);
+                    let contract_rule_id_label_const =
+                        format_ident!("{}_CONTRACT_RULE_ID_LABEL", const_name);
+                    let contract_match_fn_name = format_ident!("{}_contract_matches", helper_name);
+                    let contract_vars_fn_name = format_ident!("{}_contract_vars", helper_name);
+                    let contract_footprint_fn_name =
+                        format_ident!("{}_contract_runtime_ingress_footprint", helper_name);
+                    let contract_rule_fn_name = format_ident!("{}_contract_rule", helper_name);
+                    let contract_rule_name =
+                        format!("cmd/contract/{}/{}/{}", schema_sha, op.op_id, op.name);
+                    let contract_rule_id_label = format!("rule:{contract_rule_name}");
                     helper_tokens.extend(quote! {
                         /// Encode this mutation's vars and pack them into an EINT v1 intent.
                         pub fn #fn_name(vars: &#vars_name) -> Result<Vec<u8>, GeneratedIntentError> {
@@ -637,6 +665,61 @@ fn generate_rust(ir: &WesleyIR, args: &Args) -> Result<String> {
                             })
                         }
                     });
+                    if args.contract_host {
+                        helper_exports.push(contract_rule_name_const.clone());
+                        helper_exports.push(contract_rule_id_label_const.clone());
+                        helper_exports.push(contract_match_fn_name.clone());
+                        helper_exports.push(contract_vars_fn_name.clone());
+                        helper_exports.push(contract_footprint_fn_name.clone());
+                        helper_exports.push(contract_rule_fn_name.clone());
+                        helper_tokens.extend(quote! {
+                            /// Stable command-rule name for this generated contract mutation.
+                            pub const #contract_rule_name_const: &str = #contract_rule_name;
+
+                            /// Stable rule-id label for this generated contract mutation.
+                            pub const #contract_rule_id_label_const: &str = #contract_rule_id_label;
+
+                            /// Return true when a scheduler-materialized runtime ingress event
+                            /// carries this mutation's EINT operation id.
+                            pub fn #contract_match_fn_name(view: GraphView<'_>, scope: &NodeId) -> bool {
+                                warp_core::matches_eint_op(view, scope, super::#const_name)
+                            }
+
+                            /// Decode this mutation's generated vars from a scheduler-materialized
+                            /// EINT runtime ingress event.
+                            pub fn #contract_vars_fn_name(view: GraphView<'_>, scope: &NodeId) -> Option<#vars_name> {
+                                let vars = warp_core::eint_vars_for_op(view, scope, super::#const_name)?;
+                                echo_wasm_abi::decode_cbor(vars).ok()
+                            }
+
+                            /// Base footprint for reading this mutation's runtime ingress event.
+                            ///
+                            /// Installed executors must extend this with their handler-specific
+                            /// graph, edge, attachment, and port writes.
+                            pub fn #contract_footprint_fn_name(view: GraphView<'_>, scope: &NodeId) -> Footprint {
+                                warp_core::runtime_ingress_eint_read_footprint(view, scope)
+                            }
+
+                            /// Build a `warp-core` command rule for this generated contract
+                            /// mutation using a host-supplied executor and footprint function.
+                            pub fn #contract_rule_fn_name(
+                                executor: for<'a> fn(GraphView<'a>, &NodeId, &mut TickDelta),
+                                compute_footprint: for<'a> fn(GraphView<'a>, &NodeId) -> Footprint,
+                            ) -> RewriteRule {
+                                RewriteRule {
+                                    id: warp_core::make_type_id(#contract_rule_id_label_const).0,
+                                    name: #contract_rule_name_const,
+                                    left: PatternGraph { nodes: Vec::new() },
+                                    matcher: #contract_match_fn_name,
+                                    executor,
+                                    compute_footprint,
+                                    factor_mask: 0,
+                                    conflict_policy: ConflictPolicy::Abort,
+                                    join_fn: None,
+                                }
+                            }
+                        });
+                    }
                 }
                 OpKind::Query => {
                     let fn_name = format_ident!("{}_observation_request", helper_name);

--- a/crates/echo-wesley-gen/tests/generation.rs
+++ b/crates/echo-wesley-gen/tests/generation.rs
@@ -589,6 +589,224 @@ mod tests {
     crate_dir
 }
 
+fn write_contract_host_smoke_crate(generated: &str) -> PathBuf {
+    let workspace = workspace_root();
+    let crate_dir = workspace
+        .join("target")
+        .join("echo-wesley-gen-contract-host-smoke")
+        .join(std::process::id().to_string());
+    if crate_dir.exists() {
+        fs::remove_dir_all(&crate_dir).expect("failed to remove old contract-host smoke crate");
+    }
+    fs::create_dir_all(crate_dir.join("src")).expect("failed to create contract-host smoke crate");
+
+    let registry_path = workspace.join("crates/echo-registry-api");
+    let wasm_abi_path = workspace.join("crates/echo-wasm-abi");
+    let warp_core_path = workspace.join("crates/warp-core");
+    fs::write(
+        crate_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "echo-wesley-gen-contract-host-smoke"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+echo-registry-api = {{ path = "{}" }}
+echo-wasm-abi = {{ path = "{}" }}
+warp-core = {{ path = "{}", features = ["native_rule_bootstrap"] }}
+bytes = "1"
+serde = {{ version = "1.0", features = ["derive"] }}
+"#,
+            registry_path.display(),
+            wasm_abi_path.display(),
+            warp_core_path.display()
+        ),
+    )
+    .expect("failed to write contract-host smoke Cargo.toml");
+    fs::write(crate_dir.join("src/generated.rs"), generated)
+        .expect("failed to write generated module");
+    fs::write(
+        crate_dir.join("src/lib.rs"),
+        r#"
+mod generated;
+
+#[cfg(test)]
+mod tests {
+    use super::generated::{
+        __echo_wesley_generated::{
+            increment_contract_rule, increment_contract_runtime_ingress_footprint,
+            increment_contract_vars, IncrementVars,
+        },
+        pack_increment_intent, IncrementInput,
+    };
+    use warp_core::{
+        make_edge_id, make_head_id, make_intent_kind, make_node_id, make_type_id, AttachmentKey,
+        AttachmentValue, AtomPayload, EdgeRecord, EngineBuilder, GraphStore, GraphView,
+        InboxPolicy, IngressEnvelope, IngressTarget, NodeId, NodeKey, NodeRecord, PlaybackMode,
+        ProvenanceService, SchedulerCoordinator, TickDelta, WarpOp, WorldlineId, WorldlineRuntime,
+        WorldlineState, WriterHead, WriterHeadKey,
+    };
+
+    const RESULT_BYTES: &[u8] = b"value=42";
+    const RESULT_TYPE: &str = "test/generated-contract-host/result";
+
+    fn result_node_id() -> NodeId {
+        make_node_id("generated-contract-host/result")
+    }
+
+    fn result_edge_id() -> warp_core::EdgeId {
+        make_edge_id("generated-contract-host/result-edge")
+    }
+
+    fn increment_executor(view: GraphView<'_>, scope: &NodeId, delta: &mut TickDelta) {
+        let Some(vars) = increment_contract_vars(view, scope) else {
+            return;
+        };
+        if vars.input.amount != 42 {
+            return;
+        }
+
+        let warp_id = view.warp_id();
+        let result = result_node_id();
+        delta.push(WarpOp::UpsertNode {
+            node: NodeKey {
+                warp_id,
+                local_id: result,
+            },
+            record: NodeRecord {
+                ty: make_type_id(RESULT_TYPE),
+            },
+        });
+        delta.push(WarpOp::UpsertEdge {
+            warp_id,
+            record: EdgeRecord {
+                id: result_edge_id(),
+                from: *scope,
+                to: result,
+                ty: make_type_id("test/generated-contract-host/result-edge"),
+            },
+        });
+        delta.push(WarpOp::SetAttachment {
+            key: AttachmentKey::node_alpha(NodeKey {
+                warp_id,
+                local_id: result,
+            }),
+            value: Some(AttachmentValue::Atom(AtomPayload::new(
+                make_type_id(RESULT_TYPE),
+                bytes::Bytes::copy_from_slice(RESULT_BYTES),
+            ))),
+        });
+    }
+
+    fn increment_footprint(view: GraphView<'_>, scope: &NodeId) -> warp_core::Footprint {
+        let mut footprint = increment_contract_runtime_ingress_footprint(view, scope);
+        let warp_id = view.warp_id();
+        let result = result_node_id();
+        footprint.n_write.insert_with_warp(warp_id, *scope);
+        footprint.n_write.insert_with_warp(warp_id, result);
+        footprint.e_write.insert_with_warp(warp_id, result_edge_id());
+        footprint.a_write.insert(AttachmentKey::node_alpha(NodeKey {
+            warp_id,
+            local_id: result,
+        }));
+        footprint
+    }
+
+    fn runtime_store(runtime: &WorldlineRuntime, worldline_id: WorldlineId) -> &GraphStore {
+        let frontier = runtime.worldlines().get(&worldline_id).unwrap();
+        frontier
+            .state()
+            .warp_state()
+            .store(&frontier.state().root().warp_id)
+            .unwrap()
+    }
+
+    #[test]
+    fn generated_contract_host_rule_runs_during_scheduler_tick() {
+        let mut store = GraphStore::default();
+        let root = make_node_id("root");
+        store.insert_node(
+            root,
+            NodeRecord {
+                ty: make_type_id("world"),
+            },
+        );
+        let mut engine = EngineBuilder::new(store, root).workers(1).build();
+        engine
+            .register_rule(increment_contract_rule(
+                increment_executor,
+                increment_footprint,
+            ))
+            .unwrap();
+
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = WorldlineId::from_bytes([1; 32]);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        runtime
+            .register_writer_head(WriterHead::with_routing(
+                WriterHeadKey {
+                    worldline_id,
+                    head_id: make_head_id("default"),
+                },
+                PlaybackMode::Play,
+                InboxPolicy::AcceptAll,
+                None,
+                true,
+            ))
+            .unwrap();
+
+        let intent = pack_increment_intent(&IncrementVars {
+            input: IncrementInput { amount: 42 },
+        })
+        .unwrap();
+        runtime
+            .ingest(IngressEnvelope::local_intent(
+                IngressTarget::DefaultWriter { worldline_id },
+                make_intent_kind("echo.intent/eint-v1"),
+                intent,
+            ))
+            .unwrap();
+        assert!(runtime_store(&runtime, worldline_id)
+            .node(&result_node_id())
+            .is_none());
+
+        let mut provenance = ProvenanceService::new();
+        provenance
+            .register_worldline(
+                worldline_id,
+                runtime.worldlines().get(&worldline_id).unwrap().state(),
+            )
+            .unwrap();
+        let records =
+            SchedulerCoordinator::super_tick(&mut runtime, &mut provenance, &mut engine).unwrap();
+        assert_eq!(records.len(), 1);
+
+        let store = runtime_store(&runtime, worldline_id);
+        assert_eq!(
+            store.node(&result_node_id()).map(|node| node.ty),
+            Some(make_type_id(RESULT_TYPE))
+        );
+        assert!(matches!(
+            store.node_attachment(&result_node_id()),
+            Some(AttachmentValue::Atom(payload))
+                if payload.type_id == make_type_id(RESULT_TYPE)
+                    && payload.bytes.as_ref() == RESULT_BYTES
+        ));
+    }
+}
+"#,
+    )
+    .expect("failed to write contract-host smoke lib.rs");
+
+    crate_dir
+}
+
 fn write_basic_generated_crate(generated: &str, label: &str, no_std: bool) -> PathBuf {
     let workspace = workspace_root();
     let crate_dir = workspace
@@ -1384,6 +1602,33 @@ fn test_toy_contract_generated_output_compiles_in_consumer_crate() {
 }
 
 #[test]
+fn test_toy_contract_generated_contract_host_helpers_compile_in_consumer_crate() {
+    let output = run_wesley_gen_with_args(TOY_COUNTER_IR, &["--contract-host"]);
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let generated = String::from_utf8_lossy(&output.stdout);
+    assert!(generated.contains("pub fn increment_contract_rule"));
+    assert!(generated.contains("pub fn increment_contract_vars"));
+    assert!(generated.contains("pub fn increment_contract_runtime_ingress_footprint"));
+    let crate_dir = write_contract_host_smoke_crate(&generated);
+    let output = Command::new("cargo")
+        .args(["test", "--manifest-path"])
+        .arg(crate_dir.join("Cargo.toml"))
+        .output()
+        .expect("failed to run generated contract-host smoke");
+
+    assert!(
+        output.status.success(),
+        "generated contract-host smoke failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_toy_contract_no_std_generated_output_checks_in_consumer_crate() {
     let output = run_wesley_gen_with_args(TOY_COUNTER_IR, &["--no-std"]);
     assert!(
@@ -1402,6 +1647,17 @@ fn test_toy_contract_no_std_generated_output_checks_in_consumer_crate() {
         "toy-no-std",
         true,
     ));
+}
+
+#[test]
+fn test_contract_host_generation_rejects_no_std() {
+    let output = run_wesley_gen_with_args(TOY_COUNTER_IR, &["--no-std", "--contract-host"]);
+    assert!(
+        !output.status.success(),
+        "contract-host generation should reject no_std output"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("--contract-host requires std and cannot be combined with --no-std"));
 }
 
 #[test]

--- a/crates/warp-core/src/contract_host.rs
+++ b/crates/warp-core/src/contract_host.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Helpers for installed contract handlers hosted by Echo scheduler ticks.
+//!
+//! Generated or host-installed contract handlers are ordinary `cmd/*`
+//! [`RewriteRule`](crate::RewriteRule)s. They must not run from application
+//! dispatch. During scheduler-owned execution, Echo materializes each admitted
+//! EINT as a runtime ingress event node with the canonical intent bytes attached.
+//! This module provides the small, op-id-aware read helpers those handlers need
+//! to recognize their operation and decode their own generated vars.
+
+use crate::attachment::{AttachmentKey, AttachmentValue};
+use crate::footprint::{AttachmentSet, EdgeSet, Footprint, NodeSet, PortSet};
+use crate::graph_view::GraphView;
+use crate::ident::{make_type_id, NodeId, NodeKey};
+use crate::inbox::INTENT_ATTACHMENT_TYPE;
+
+/// Returns the EINT operation id attached to a scheduler-materialized runtime
+/// ingress event.
+///
+/// This reads only the event node's attachment plane. Malformed or non-EINT
+/// ingress returns `None`, leaving installed command rules unmatched.
+#[must_use]
+pub fn eint_op_id(view: GraphView<'_>, scope: &NodeId) -> Option<u32> {
+    let (op_id, _) = runtime_ingress_eint(view, scope)?;
+    Some(op_id)
+}
+
+/// Returns `true` when the scheduler-materialized runtime ingress event carries
+/// the expected EINT operation id.
+#[must_use]
+pub fn matches_eint_op(view: GraphView<'_>, scope: &NodeId, expected_op_id: u32) -> bool {
+    eint_op_id(view, scope) == Some(expected_op_id)
+}
+
+/// Returns the canonical EINT vars bytes for the expected operation id.
+///
+/// The returned slice is borrowed from the runtime ingress event attachment.
+/// Generated handlers remain responsible for decoding these bytes with their
+/// generated codec. Echo core only verifies the envelope boundary and op id.
+#[must_use]
+pub fn eint_vars_for_op<'a>(
+    view: GraphView<'a>,
+    scope: &NodeId,
+    expected_op_id: u32,
+) -> Option<&'a [u8]> {
+    let (op_id, vars) = runtime_ingress_eint(view, scope)?;
+    (op_id == expected_op_id).then_some(vars)
+}
+
+/// Returns the standard read footprint for a handler that inspects the EINT
+/// attached to a runtime ingress event.
+///
+/// Contract handlers should extend this footprint with any handler-specific
+/// graph, edge, attachment, or port writes they emit. This helper deliberately
+/// declares no write authority by itself.
+#[must_use]
+pub fn runtime_ingress_eint_read_footprint(view: GraphView<'_>, scope: &NodeId) -> Footprint {
+    let warp_id = view.warp_id();
+    let mut n_read = NodeSet::default();
+    let mut a_read = AttachmentSet::default();
+    if view.node(scope).is_some() {
+        n_read.insert_with_warp(warp_id, *scope);
+        a_read.insert(AttachmentKey::node_alpha(NodeKey {
+            warp_id,
+            local_id: *scope,
+        }));
+    }
+    Footprint {
+        n_read,
+        n_write: NodeSet::default(),
+        e_read: EdgeSet::default(),
+        e_write: EdgeSet::default(),
+        a_read,
+        a_write: AttachmentSet::default(),
+        b_in: PortSet::default(),
+        b_out: PortSet::default(),
+        factor_mask: 0,
+    }
+}
+
+fn runtime_ingress_eint<'a>(view: GraphView<'a>, scope: &NodeId) -> Option<(u32, &'a [u8])> {
+    let Some(AttachmentValue::Atom(atom)) = view.node_attachment(scope) else {
+        return None;
+    };
+    if atom.type_id != make_type_id(INTENT_ATTACHMENT_TYPE) {
+        return None;
+    }
+    echo_wasm_abi::unpack_intent_v1(atom.bytes.as_ref()).ok()
+}

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -2605,6 +2605,197 @@ mod tests {
         )
     }
 
+    const TOY_INCREMENT_OP_ID: u32 = 1001;
+    const TOY_INCREMENT_VARS: &[u8] = b"amount=42";
+    const TOY_INCREMENT_RESULT_BYTES: &[u8] = b"value=42";
+    const TOY_INCREMENT_RESULT_TYPE: &str = "test/toy-counter/increment-result";
+    const TOY_INCREMENT_RESULT_EDGE_TYPE: &str = "test/toy-counter/increment-result-edge";
+
+    fn toy_increment_result_node_id(scope: &NodeId) -> NodeId {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"test.toy-counter.increment.result.node");
+        hasher.update(scope.as_bytes());
+        NodeId(hasher.finalize().into())
+    }
+
+    fn toy_increment_result_edge_id(scope: &NodeId, result: &NodeId) -> crate::EdgeId {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"test.toy-counter.increment.result.edge");
+        hasher.update(scope.as_bytes());
+        hasher.update(result.as_bytes());
+        crate::EdgeId(hasher.finalize().into())
+    }
+
+    fn toy_increment_matches(view: GraphView<'_>, scope: &NodeId) -> bool {
+        crate::contract_host::eint_vars_for_op(view, scope, TOY_INCREMENT_OP_ID)
+            == Some(TOY_INCREMENT_VARS)
+    }
+
+    fn toy_increment_executor(view: GraphView<'_>, scope: &NodeId, delta: &mut crate::TickDelta) {
+        let Some(vars) = crate::contract_host::eint_vars_for_op(view, scope, TOY_INCREMENT_OP_ID)
+        else {
+            return;
+        };
+        if vars != TOY_INCREMENT_VARS {
+            return;
+        }
+
+        let warp_id = view.warp_id();
+        let result = toy_increment_result_node_id(scope);
+        let result_edge = toy_increment_result_edge_id(scope, &result);
+        delta.push(crate::tick_patch::WarpOp::UpsertNode {
+            node: crate::NodeKey {
+                warp_id,
+                local_id: result,
+            },
+            record: NodeRecord {
+                ty: make_type_id(TOY_INCREMENT_RESULT_TYPE),
+            },
+        });
+        delta.push(crate::tick_patch::WarpOp::UpsertEdge {
+            warp_id,
+            record: crate::record::EdgeRecord {
+                id: result_edge,
+                from: *scope,
+                to: result,
+                ty: make_type_id(TOY_INCREMENT_RESULT_EDGE_TYPE),
+            },
+        });
+        delta.push(crate::tick_patch::WarpOp::SetAttachment {
+            key: crate::AttachmentKey::node_alpha(crate::NodeKey {
+                warp_id,
+                local_id: result,
+            }),
+            value: Some(crate::AttachmentValue::Atom(crate::AtomPayload::new(
+                make_type_id(TOY_INCREMENT_RESULT_TYPE),
+                bytes::Bytes::copy_from_slice(TOY_INCREMENT_RESULT_BYTES),
+            ))),
+        });
+    }
+
+    fn toy_increment_footprint(view: GraphView<'_>, scope: &NodeId) -> crate::Footprint {
+        let mut footprint = crate::contract_host::runtime_ingress_eint_read_footprint(view, scope);
+        let warp_id = view.warp_id();
+        let result = toy_increment_result_node_id(scope);
+        let result_edge = toy_increment_result_edge_id(scope, &result);
+        footprint.n_write.insert_with_warp(warp_id, *scope);
+        footprint.n_write.insert_with_warp(warp_id, result);
+        footprint.e_write.insert_with_warp(warp_id, result_edge);
+        footprint
+            .a_write
+            .insert(crate::AttachmentKey::node_alpha(crate::NodeKey {
+                warp_id,
+                local_id: result,
+            }));
+        footprint
+    }
+
+    fn toy_increment_contract_rule() -> RewriteRule {
+        RewriteRule {
+            id: make_type_id("rule:cmd/contract/toy-counter/increment").0,
+            name: "cmd/contract/toy-counter/increment",
+            left: PatternGraph { nodes: vec![] },
+            matcher: toy_increment_matches,
+            executor: toy_increment_executor,
+            compute_footprint: toy_increment_footprint,
+            factor_mask: 0,
+            conflict_policy: ConflictPolicy::Abort,
+            join_fn: None,
+        }
+    }
+
+    fn toy_increment_intent(vars: &[u8]) -> Vec<u8> {
+        echo_wasm_abi::pack_intent_v1(TOY_INCREMENT_OP_ID, vars).unwrap()
+    }
+
+    fn toy_contract_runtime() -> (WorldlineRuntime, Engine, WorldlineId) {
+        let mut runtime = WorldlineRuntime::new();
+        let mut engine = empty_engine();
+        engine.register_rule(toy_increment_contract_rule()).unwrap();
+        let worldline_id = wl(1);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        (runtime, engine, worldline_id)
+    }
+
+    #[test]
+    fn installed_contract_handler_runs_only_during_scheduler_owned_tick() {
+        let (mut runtime, mut engine, worldline_id) = toy_contract_runtime();
+
+        let envelope = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("echo.intent/eint-v1"),
+            toy_increment_intent(TOY_INCREMENT_VARS),
+        );
+        let event_id = NodeId(envelope.ingress_id());
+        let result_id = toy_increment_result_node_id(&event_id);
+        let dispatch = runtime.ingest(envelope).unwrap();
+        assert!(matches!(dispatch, IngressDisposition::Accepted { .. }));
+        assert!(
+            runtime_store(&runtime, worldline_id)
+                .node(&result_id)
+                .is_none(),
+            "application dispatch must not call installed contract handlers synchronously"
+        );
+
+        let mut provenance = mirrored_provenance(&runtime);
+        let records =
+            SchedulerCoordinator::super_tick(&mut runtime, &mut provenance, &mut engine).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].admitted_count, 1);
+
+        let store = runtime_store(&runtime, worldline_id);
+        assert!(store.node(&event_id).is_some());
+        assert_eq!(
+            store.node(&result_id).map(|node| node.ty),
+            Some(make_type_id(TOY_INCREMENT_RESULT_TYPE))
+        );
+        assert!(matches!(
+            store.node_attachment(&result_id),
+            Some(crate::AttachmentValue::Atom(payload))
+                if payload.type_id == make_type_id(TOY_INCREMENT_RESULT_TYPE)
+                    && payload.bytes.as_ref() == TOY_INCREMENT_RESULT_BYTES
+        ));
+        assert_eq!(provenance.len(worldline_id).unwrap(), 1);
+    }
+
+    #[test]
+    fn installed_contract_handler_ignores_nonmatching_eint_operation() {
+        let (mut runtime, mut engine, worldline_id) = toy_contract_runtime();
+        let other_intent =
+            echo_wasm_abi::pack_intent_v1(TOY_INCREMENT_OP_ID + 1, TOY_INCREMENT_VARS).unwrap();
+        let envelope = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("echo.intent/eint-v1"),
+            other_intent,
+        );
+        let event_id = NodeId(envelope.ingress_id());
+        let result_id = toy_increment_result_node_id(&event_id);
+        runtime.ingest(envelope).unwrap();
+
+        let mut provenance = mirrored_provenance(&runtime);
+        let records =
+            SchedulerCoordinator::super_tick(&mut runtime, &mut provenance, &mut engine).unwrap();
+        assert_eq!(records.len(), 1);
+
+        let store = runtime_store(&runtime, worldline_id);
+        assert!(store.node(&event_id).is_some());
+        assert!(
+            store.node(&result_id).is_none(),
+            "installed contract handlers must only run for their generated op id"
+        );
+        assert_eq!(provenance.len(worldline_id).unwrap(), 1);
+    }
+
     #[test]
     fn fork_strand_registers_child_frontier_and_strand_relation() {
         let mut runtime = WorldlineRuntime::new();

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -38,6 +38,7 @@ mod causal_facts;
 mod clock;
 mod cmd;
 mod constants;
+mod contract_host;
 /// Domain separation prefixes for hashing.
 pub mod domain;
 mod dynamic_binding;
@@ -178,6 +179,9 @@ pub use cmd::{
     IMPORT_SUFFIX_RESULT_EDGE_TYPE, IMPORT_SUFFIX_RESULT_NODE_TYPE,
 };
 pub use constants::{blake3_empty, digest_len0_u64, POLICY_ID_NO_POLICY_V0};
+pub use contract_host::{
+    eint_op_id, eint_vars_for_op, matches_eint_op, runtime_ingress_eint_read_footprint,
+};
 pub use dynamic_binding::{
     BoundNodeRef, ClosureMemberBinding, DirectSlotBinding, DynamicBindingError,
     DynamicBindingRuntimeError, RangeClosureBindingRequest, RelationSlotBinding,

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -32,6 +32,9 @@ scheduler-owned tick outcome without giving application code tick authority.
   ingress records, admission ticket digests, and witnessed submission ids.
 - Core can observe a witnessed submission as unknown, pending, or decided by a
   scheduler-owned tick receipt.
+- Core exposes scheduler-owned EINT contract-host helpers so installed
+  `cmd/*` handlers can match operation ids, borrow canonical vars bytes for
+  generated decoding, and declare the standard runtime-ingress read footprint.
 - Footprint conflicts are explicit receipt rejections, not hidden retries.
 - Failed `SuperTick` attempts are failure-atomic: uncommitted runtime,
   provenance, and receipt-correlation writes are rolled back before any fault
@@ -48,7 +51,8 @@ scheduler-owned tick outcome without giving application code tick authority.
 - Accepted submissions are not yet complete witnessed ingress history.
 - Clients cannot yet observe per-intent applied/rejected application semantics
   by id.
-- Installed Wesley handler dispatch is not wired into scheduler-owned execution.
+- Wesley does not yet generate installed handler rules for the core
+  contract-host seam.
 - Generic QueryView remains unsupported in core.
 
 ## Doctrine
@@ -131,9 +135,10 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 ## Immediate Next Slice
 
-InstalledContractHostDispatch should connect installed Wesley contract handlers
-to scheduler-owned runtime execution without letting application dispatch call
-handlers synchronously.
+The next slice should either emit generated installed handler rules from Wesley
+or start QueryViewObserverBridge against the same contract-host boundary. Keep
+the write-side invariant intact: application dispatch submits EINT bytes only;
+handlers execute during scheduler-owned ticks.
 
 This slice must not implement QueryView, streaming subscriptions, automatic
 retry, execution outside scheduler-owned ticks, or wall-clock cadence semantics.

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -35,6 +35,10 @@ scheduler-owned tick outcome without giving application code tick authority.
 - Core exposes scheduler-owned EINT contract-host helpers so installed
   `cmd/*` handlers can match operation ids, borrow canonical vars bytes for
   generated decoding, and declare the standard runtime-ingress read footprint.
+- `echo-wesley-gen --contract-host` emits std-only mutation helper rules for
+  that seam: stable command-rule names, op-id matchers, typed vars decoders,
+  base runtime-ingress read footprints, and rule constructors that accept
+  host-supplied executor and footprint functions.
 - Footprint conflicts are explicit receipt rejections, not hidden retries.
 - Failed `SuperTick` attempts are failure-atomic: uncommitted runtime,
   provenance, and receipt-correlation writes are rolled back before any fault
@@ -51,8 +55,8 @@ scheduler-owned tick outcome without giving application code tick authority.
 - Accepted submissions are not yet complete witnessed ingress history.
 - Clients cannot yet observe per-intent applied/rejected application semantics
   by id.
-- Wesley does not yet generate installed handler rules for the core
-  contract-host seam.
+- Contract-host packaging does not yet reject unsupported contract operations at
+  an installed registry boundary.
 - Generic QueryView remains unsupported in core.
 
 ## Doctrine
@@ -135,10 +139,10 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 ## Immediate Next Slice
 
-The next slice should either emit generated installed handler rules from Wesley
-or start QueryViewObserverBridge against the same contract-host boundary. Keep
+QueryViewObserverBridge should route generated query observations through an
+installed observer boundary and return QueryBytes with a ReadingEnvelope. Keep
 the write-side invariant intact: application dispatch submits EINT bytes only;
 handlers execute during scheduler-owned ticks.
 
-This slice must not implement QueryView, streaming subscriptions, automatic
-retry, execution outside scheduler-owned ticks, or wall-clock cadence semantics.
+This slice must not implement streaming subscriptions, automatic retry,
+execution outside scheduler-owned ticks, or wall-clock cadence semantics.

--- a/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
+++ b/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
@@ -3,7 +3,8 @@
 
 # Installed Wesley Contract Host Dispatch
 
-Status: core contract-host seam checkpoint; generated handler emission remains.
+Status: core contract-host seam and generated handler-rule helpers exist;
+installed registry packaging remains.
 
 Depends on:
 
@@ -29,9 +30,18 @@ by installed `cmd/*` rules:
 - prove handlers run during `SchedulerCoordinator::super_tick(...)`, not during
   application dispatch.
 
-Remaining work is generator/packaging integration: Wesley does not yet emit the
-installed handler rules or package an installed contract registry that rejects
-unsupported contract operations at the contract-host boundary.
+`echo-wesley-gen --contract-host` now emits std-only generated mutation helper
+rules for that seam:
+
+- stable command-rule names bound to schema hash, op id, and operation name;
+- op-id matchers for scheduler-materialized EINT runtime ingress events;
+- typed vars decoders using the generated CBOR shape;
+- base runtime-ingress read footprint helpers;
+- rule constructors that accept host-supplied executor and footprint functions.
+
+Remaining work is packaging integration: Echo does not yet have an installed
+contract registry boundary that rejects unsupported contract operations before
+they become scheduler-visible work.
 
 ## RED
 

--- a/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
+++ b/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
@@ -3,7 +3,7 @@
 
 # Installed Wesley Contract Host Dispatch
 
-Status: RED/GREEN implementation slice.
+Status: core contract-host seam checkpoint; generated handler emission remains.
 
 Depends on:
 
@@ -16,6 +16,22 @@ Depends on:
 Echo can accept EINT bytes, but it does not yet route a validated generated
 contract operation to an installed contract handler inside the normal witnessed
 admission, scheduling, and provenance path.
+
+## Current Checkpoint
+
+`warp-core` now exposes the scheduler-owned EINT contract-host helper seam used
+by installed `cmd/*` rules:
+
+- match a scheduler-materialized EINT runtime ingress event by generated op id;
+- borrow canonical vars bytes for generated decoding;
+- declare the standard runtime-ingress read footprint and extend it with
+  handler-specific writes;
+- prove handlers run during `SchedulerCoordinator::super_tick(...)`, not during
+  application dispatch.
+
+Remaining work is generator/packaging integration: Wesley does not yet emit the
+installed handler rules or package an installed contract registry that rejects
+unsupported contract operations at the contract-host boundary.
 
 ## RED
 


### PR DESCRIPTION
## Summary

- add `warp-core` contract-host helpers for scheduler-materialized EINT runtime ingress
- prove installed `cmd/*` contract handlers match op ids and run only during scheduler-owned ticks
- update BEARING, CHANGELOG, and the installed Wesley host-dispatch backlog checkpoint

## Validation

- `cargo test -p warp-core installed_contract_handler`
- `cargo check -p warp-core`
- `cargo fmt --check`
- `git diff --check`
- push hook: `fmt`, `guards`, `clippy-core`, `tests-warp-core`

## Non-goals

- no QueryView implementation
- no Wesley handler generation yet
- no dynamic plugin loading
- no application tick authority
