### PR TITLE
feat(wesley): emit query observer host helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 ### Added
 
+- `echo-wesley-gen --contract-host` now emits std-only query observer host
+  helpers against `warp-core`'s `ContractQueryObserver` boundary. Generated
+  query helpers include deterministic authored observer plan identity, typed
+  context-vars decoders that return `Result` on malformed canonical vars, and
+  typed observer constructors that install read-only host closures through
+  `Engine::register_contract_query_observer`. The core observer function
+  boundary now returns a typed `Result`, so decode failures and host observer
+  failures are explicit observation errors. The generated smoke crate proves
+  mutation host helpers and query observer helpers install together without
+  giving query observers write authority, tick authority, or application nouns
+  in core.
 - `warp-core` now routes `QueryView`/`Query` observations to installed
   contract query observers. Installed observers are keyed by generated query op
   id, receive canonical vars bytes plus the resolved causal basis, return

--- a/crates/echo-wesley-gen/README.md
+++ b/crates/echo-wesley-gen/README.md
@@ -27,6 +27,7 @@ cat ir.json | cargo run -p echo-wesley-gen --
 cat ir.json | cargo run -p echo-wesley-gen -- --out generated.rs
 
 # Emit std-only warp-core contract-host helpers for installed mutation handlers
+# and query observers
 cat ir.json | cargo run -p echo-wesley-gen -- --contract-host --out generated.rs
 ```
 
@@ -53,6 +54,13 @@ cat ir.json | cargo run -p echo-wesley-gen -- --contract-host --out generated.rs
   `RewriteRule` from host-supplied executor and footprint functions. It does
   not generate the application mutation body or grant application code tick
   authority.
+- `--contract-host` also emits std-only query observer helpers for installing
+  generated queries as read-only `warp-core::ContractQueryObserver` instances.
+  The generated surface stamps deterministic authored observer plan identity,
+  decodes typed vars from observer context with `Result`, and accepts a host
+  closure that returns `ContractQueryObserverResult` or
+  `ContractQueryObserverError`. Query observers cannot tick the runtime or write
+  through this generated boundary.
 - Optional fields become `Option<T>`; lists become `Vec<T>` (wrapped in Option when not required).
 - Unknown scalar names are emitted as identifiers as-is (so ensure upstream IR types are valid Rust idents).
 - Runtime optic artifact imports preserve Wesley-owned canonical admission

--- a/crates/echo-wesley-gen/src/main.rs
+++ b/crates/echo-wesley-gen/src/main.rs
@@ -8,6 +8,7 @@ use clap::Parser;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
@@ -727,6 +728,13 @@ fn generate_rust(ir: &WesleyIR, args: &Args) -> Result<String> {
                     let optic_fn_name = format_ident!("{}_observe_optic_request", helper_name);
                     let optic_raw_fn_name =
                         format_ident!("{}_observe_optic_request_raw_vars", helper_name);
+                    let observer_plan_label_const =
+                        format_ident!("{}_OBSERVER_PLAN_ID_LABEL", const_name);
+                    let observer_artifact_hash_const =
+                        format_ident!("{}_OBSERVER_ARTIFACT_HASH", const_name);
+                    let observer_plan_fn_name = format_ident!("{}_observer_plan", helper_name);
+                    let observer_vars_fn_name = format_ident!("{}_observer_vars", helper_name);
+                    let query_observer_fn_name = format_ident!("{}_query_observer", helper_name);
                     helper_exports.push(fn_name.clone());
                     helper_exports.push(raw_fn_name.clone());
                     helper_exports.push(optic_fn_name.clone());
@@ -809,6 +817,85 @@ fn generate_rust(ir: &WesleyIR, args: &Args) -> Result<String> {
                             }
                         }
                     });
+                    if args.contract_host {
+                        helper_exports.push(observer_plan_label_const.clone());
+                        helper_exports.push(observer_artifact_hash_const.clone());
+                        helper_exports.push(observer_plan_fn_name.clone());
+                        helper_exports.push(observer_vars_fn_name.clone());
+                        helper_exports.push(query_observer_fn_name.clone());
+                        let observer_plan_label =
+                            format!("observer:query/{schema_sha}/{}/{}", op.op_id, op.name);
+                        let observer_identity =
+                            observer_identity_hashes(ir, op, &generated_rust_artifact_hash)?;
+                        let observer_plan_id = byte_array_literal(observer_identity.plan_id);
+                        let observer_artifact_hash =
+                            byte_array_literal(observer_identity.artifact_hash);
+                        let observer_schema_hash =
+                            byte_array_literal(observer_identity.schema_hash);
+                        let observer_state_schema_hash =
+                            byte_array_literal(observer_identity.state_schema_hash);
+                        let observer_update_law_hash =
+                            byte_array_literal(observer_identity.update_law_hash);
+                        let observer_emission_law_hash =
+                            byte_array_literal(observer_identity.emission_law_hash);
+                        let observer_artifact_hash_hex = hash_hex(observer_identity.artifact_hash);
+                        helper_tokens.extend(quote! {
+                            /// Stable authored observer plan-id label for this generated query.
+                            pub const #observer_plan_label_const: &str = #observer_plan_label;
+
+                            /// Stable artifact hash for this generated query observer helper.
+                            pub const #observer_artifact_hash_const: &str = #observer_artifact_hash_hex;
+
+                            /// Build the authored observer plan stamped onto readings emitted
+                            /// by this generated query observer.
+                            pub fn #observer_plan_fn_name() -> warp_core::AuthoredObserverPlan {
+                                warp_core::AuthoredObserverPlan {
+                                    plan_id: warp_core::ObserverPlanId::from_bytes(#observer_plan_id),
+                                    artifact_hash: #observer_artifact_hash,
+                                    schema_hash: #observer_schema_hash,
+                                    state_schema_hash: #observer_state_schema_hash,
+                                    update_law_hash: #observer_update_law_hash,
+                                    emission_law_hash: #observer_emission_law_hash,
+                                }
+                            }
+
+                            /// Decode this query's generated vars from read-only observer context.
+                            pub fn #observer_vars_fn_name(
+                                context: &warp_core::ContractQueryObserverContext<'_>,
+                            ) -> Result<#vars_name, echo_wasm_abi::CanonError> {
+                                echo_wasm_abi::decode_cbor(context.vars_bytes)
+                            }
+
+                            /// Build a read-only `warp-core` query observer for this generated query.
+                            pub fn #query_observer_fn_name<F>(observe: F) -> warp_core::ContractQueryObserver
+                            where
+                                F: for<'a> Fn(
+                                        &warp_core::ContractQueryObserverContext<'a>,
+                                        #vars_name,
+                                    ) -> Result<
+                                        warp_core::ContractQueryObserverResult,
+                                        warp_core::ContractQueryObserverError,
+                                    >
+                                    + Send
+                                    + Sync
+                                    + 'static,
+                            {
+                                warp_core::ContractQueryObserver::new(
+                                    super::#const_name,
+                                    #observer_plan_fn_name(),
+                                    move |context| {
+                                        let vars = #observer_vars_fn_name(&context).map_err(|error| {
+                                            warp_core::ContractQueryObserverError::invalid_vars(
+                                                context.query_id,
+                                                error.to_string(),
+                                            )
+                                        })?;
+                                        observe(&context, vars)
+                                    },
+                                )
+                            }
+                        });
+                    }
                 }
             }
         }
@@ -993,6 +1080,88 @@ struct GeneratedFootprintCertificate {
     certificate_hash_hex: String,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct GeneratedObserverIdentity {
+    plan_id: [u8; 32],
+    artifact_hash: [u8; 32],
+    schema_hash: [u8; 32],
+    state_schema_hash: [u8; 32],
+    update_law_hash: [u8; 32],
+    emission_law_hash: [u8; 32],
+}
+
+fn observer_identity_hashes(
+    ir: &WesleyIR,
+    op: &ir::OpDefinition,
+    generated_rust_artifact_hash: &str,
+) -> Result<GeneratedObserverIdentity> {
+    let args_json = serde_json::to_string(&op.args)?;
+    let directives_json = op_directives_json(op)?;
+    let schema_sha = ir.schema_sha256.as_deref().unwrap_or("");
+    let codec_id = ir.codec_id.as_deref().unwrap_or(DEFAULT_CODEC_ID);
+    let registry_version = ir.registry_version.unwrap_or(DEFAULT_REGISTRY_VERSION);
+    let observer_plan_label = format!("observer:query/{schema_sha}/{}/{}", op.op_id, op.name);
+    let observer_preimage = format!(
+        concat!(
+            "echo-wesley-query-observer-artifact/v1\n",
+            "schema_sha256={schema_sha}\n",
+            "codec_id={codec_id}\n",
+            "registry_version={registry_version}\n",
+            "op_id={op_id}\n",
+            "op_name={op_name}\n",
+            "result_type={result_type}\n",
+            "args={args_json}\n",
+            "directives_json={directives_json}\n",
+            "generated_rust_artifact_hash={generated_rust_artifact_hash}\n",
+        ),
+        schema_sha = schema_sha,
+        codec_id = codec_id,
+        registry_version = registry_version,
+        op_id = op.op_id,
+        op_name = op.name,
+        result_type = op.result_type,
+        args_json = args_json,
+        directives_json = directives_json,
+        generated_rust_artifact_hash = generated_rust_artifact_hash,
+    );
+    let artifact_hash = blake3_hash(observer_preimage.as_bytes());
+    let artifact_hash_hex = hash_hex(artifact_hash);
+    Ok(GeneratedObserverIdentity {
+        plan_id: blake3_hash(
+            format!("echo-wesley-query-observer-plan-id/v1\n{observer_plan_label}\n").as_bytes(),
+        ),
+        artifact_hash,
+        schema_hash: schema_hash_bytes(schema_sha),
+        state_schema_hash: blake3_hash(
+            format!(
+                "echo-wesley-query-observer-state-schema/v1\n{}\n{}\n{}",
+                schema_sha,
+                op.op_id,
+                artifact_hash_hex.as_str()
+            )
+            .as_bytes(),
+        ),
+        update_law_hash: blake3_hash(
+            format!(
+                "echo-wesley-query-observer-update-law/v1\n{}\n{}\n{}",
+                schema_sha,
+                op.op_id,
+                artifact_hash_hex.as_str()
+            )
+            .as_bytes(),
+        ),
+        emission_law_hash: blake3_hash(
+            format!(
+                "echo-wesley-query-observer-emission-law/v1\n{}\n{}\n{}",
+                schema_sha,
+                op.op_id,
+                artifact_hash_hex.as_str()
+            )
+            .as_bytes(),
+        ),
+    })
+}
+
 fn op_footprint_certificate(
     ir: &WesleyIR,
     op: &ir::OpDefinition,
@@ -1103,6 +1272,41 @@ fn footprint_argument_value<'a>(
 
 fn blake3_hex(input: &[u8]) -> String {
     blake3::hash(input).to_hex().to_string()
+}
+
+fn blake3_hash(input: &[u8]) -> [u8; 32] {
+    blake3::hash(input).into()
+}
+
+fn schema_hash_bytes(schema_sha: &str) -> [u8; 32] {
+    parse_hex_hash(schema_sha).unwrap_or_else(|| {
+        blake3_hash(format!("echo-wesley-schema-hash-fallback/v1\n{schema_sha}\n").as_bytes())
+    })
+}
+
+fn parse_hex_hash(hex: &str) -> Option<[u8; 32]> {
+    if hex.len() != 64 {
+        return None;
+    }
+    let mut bytes = [0_u8; 32];
+    for (index, chunk) in hex.as_bytes().chunks_exact(2).enumerate() {
+        let text = std::str::from_utf8(chunk).ok()?;
+        bytes[index] = u8::from_str_radix(text, 16).ok()?;
+    }
+    Some(bytes)
+}
+
+fn hash_hex(hash: [u8; 32]) -> String {
+    let mut output = String::with_capacity(64);
+    for byte in hash {
+        let _ = write!(&mut output, "{byte:02x}");
+    }
+    output
+}
+
+fn byte_array_literal(bytes: [u8; 32]) -> TokenStream {
+    let elements = bytes.iter().copied();
+    quote! { [#(#elements),*] }
 }
 
 fn op_const_name(name: &str, op_id: u32) -> String {

--- a/crates/echo-wesley-gen/tests/generation.rs
+++ b/crates/echo-wesley-gen/tests/generation.rs
@@ -638,17 +638,22 @@ mod generated;
 mod tests {
     use super::generated::{
         __echo_wesley_generated::{
+            counter_value_observer_plan, counter_value_observer_vars, counter_value_query_observer,
             increment_contract_rule, increment_contract_runtime_ingress_footprint,
-            increment_contract_vars, IncrementVars,
+            increment_contract_vars, CounterValueVars, IncrementVars,
         },
-        pack_increment_intent, IncrementInput,
+        encode_counter_value_vars, pack_increment_intent, IncrementInput, OP_COUNTER_VALUE,
     };
     use warp_core::{
         make_edge_id, make_head_id, make_intent_kind, make_node_id, make_type_id, AttachmentKey,
-        AttachmentValue, AtomPayload, EdgeRecord, EngineBuilder, GraphStore, GraphView,
-        InboxPolicy, IngressEnvelope, IngressTarget, NodeId, NodeKey, NodeRecord, PlaybackMode,
-        ProvenanceService, SchedulerCoordinator, TickDelta, WarpOp, WorldlineId, WorldlineRuntime,
-        WorldlineState, WriterHead, WriterHeadKey,
+        AttachmentValue, AtomPayload, ContractQueryObserverContext, ContractQueryObserverError,
+        ContractQueryObserverResult, EdgeRecord, EngineBuilder, GraphStore, GraphView,
+        InboxPolicy, IngressEnvelope, IngressTarget, NodeId, NodeKey, NodeRecord,
+        ObservationAt, ObservationCoordinate, ObservationFrame, ObservationPayload,
+        ObservationProjection, ObservationService, PlaybackMode, ProvenanceService,
+        ReadingObserverBasis, ReadingObserverPlan, ReadingResidualPosture, SchedulerCoordinator,
+        TickDelta, WarpOp, WorldlineId, WorldlineRuntime, WorldlineState, WriterHead,
+        WriterHeadKey,
     };
 
     const RESULT_BYTES: &[u8] = b"value=42";
@@ -723,6 +728,124 @@ mod tests {
             .warp_state()
             .store(&frontier.state().root().warp_id)
             .unwrap()
+    }
+
+    fn counter_value_observe(
+        context: &ContractQueryObserverContext<'_>,
+        vars: CounterValueVars,
+    ) -> Result<ContractQueryObserverResult, ContractQueryObserverError> {
+        assert_eq!(context.query_id, OP_COUNTER_VALUE);
+        assert_eq!(counter_value_observer_vars(context).unwrap(), vars);
+        Ok(ContractQueryObserverResult::complete(b"value=42".to_vec()))
+    }
+
+    fn runtime_with_worldline() -> (WorldlineRuntime, ProvenanceService, WorldlineId) {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = WorldlineId::from_bytes([1; 32]);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let mut provenance = ProvenanceService::new();
+        provenance
+            .register_worldline(
+                worldline_id,
+                runtime.worldlines().get(&worldline_id).unwrap().state(),
+            )
+            .unwrap();
+        (runtime, provenance, worldline_id)
+    }
+
+    fn query_request(
+        worldline_id: WorldlineId,
+        vars_bytes: Vec<u8>,
+    ) -> warp_core::ObservationRequest {
+        warp_core::ObservationRequest::builtin_one_shot(
+            ObservationCoordinate {
+                worldline_id,
+                at: ObservationAt::Frontier,
+            },
+            ObservationFrame::QueryView,
+            ObservationProjection::Query {
+                query_id: OP_COUNTER_VALUE,
+                vars_bytes,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn generated_query_observer_installs_and_returns_query_bytes() {
+        let mut store = GraphStore::default();
+        let root = make_node_id("root");
+        store.insert_node(
+            root,
+            NodeRecord {
+                ty: make_type_id("world"),
+            },
+        );
+        let mut engine = EngineBuilder::new(store, root).workers(1).build();
+        engine
+            .register_contract_query_observer(counter_value_query_observer(counter_value_observe))
+            .unwrap();
+        let (runtime, provenance, worldline_id) = runtime_with_worldline();
+        let vars = CounterValueVars {};
+        let request = query_request(worldline_id, encode_counter_value_vars(&vars).unwrap());
+
+        let artifact =
+            ObservationService::observe(&runtime, &provenance, &engine, request).unwrap();
+
+        assert_eq!(artifact.frame, ObservationFrame::QueryView);
+        assert!(matches!(
+            artifact.projection,
+            ObservationProjection::Query { query_id: OP_COUNTER_VALUE, .. }
+        ));
+        assert_eq!(
+            artifact.payload,
+            ObservationPayload::QueryBytes(b"value=42".to_vec())
+        );
+        assert_eq!(
+            artifact.reading.observer_basis,
+            ReadingObserverBasis::QueryView
+        );
+        assert_eq!(
+            artifact.reading.residual_posture,
+            ReadingResidualPosture::Complete
+        );
+        assert_eq!(
+            artifact.reading.observer_plan,
+            ReadingObserverPlan::Authored {
+                plan: Box::new(counter_value_observer_plan())
+            }
+        );
+    }
+
+    #[test]
+    fn generated_query_observer_decode_failure_returns_typed_error() {
+        let mut store = GraphStore::default();
+        let root = make_node_id("root");
+        store.insert_node(
+            root,
+            NodeRecord {
+                ty: make_type_id("world"),
+            },
+        );
+        let mut engine = EngineBuilder::new(store, root).workers(1).build();
+        engine
+            .register_contract_query_observer(counter_value_query_observer(counter_value_observe))
+            .unwrap();
+        let (runtime, provenance, worldline_id) = runtime_with_worldline();
+        let request = query_request(worldline_id, b"not cbor".to_vec());
+
+        let err = ObservationService::observe(&runtime, &provenance, &engine, request)
+            .expect_err("invalid query vars must fail as observer error");
+
+        assert!(matches!(
+            err,
+            warp_core::ObservationError::ContractQueryObserverFailed {
+                query_id: OP_COUNTER_VALUE,
+                source: ContractQueryObserverError::InvalidVars { .. },
+            }
+        ));
     }
 
     #[test]
@@ -1367,6 +1490,33 @@ fn test_toy_contract_generates_eint_and_observation_helpers() {
 }
 
 #[test]
+fn test_toy_contract_generated_contract_host_helpers_emit_query_observer_helpers() {
+    let output = run_wesley_gen_with_args(TOY_COUNTER_IR, &["--contract-host"]);
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    for required in [
+        "pub const OP_COUNTER_VALUE_OBSERVER_PLAN_ID_LABEL",
+        "pub const OP_COUNTER_VALUE_OBSERVER_ARTIFACT_HASH",
+        "pub fn counter_value_observer_plan",
+        "pub fn counter_value_observer_vars",
+        "pub fn counter_value_query_observer",
+        "ContractQueryObserverContext",
+        "ContractQueryObserverError",
+        "ContractQueryObserverResult",
+    ] {
+        assert!(
+            stdout.contains(required),
+            "generated contract-host output is missing query observer helper: {required}"
+        );
+    }
+}
+
+#[test]
 fn test_footprint_artifact_hash_changes_when_generated_args_change() {
     let without_arg = r#"{
         "ir_version": "echo-ir/v1",
@@ -1602,7 +1752,7 @@ fn test_toy_contract_generated_output_compiles_in_consumer_crate() {
 }
 
 #[test]
-fn test_toy_contract_generated_contract_host_helpers_compile_in_consumer_crate() {
+fn test_toy_contract_generated_contract_host_query_observer_compiles_in_consumer_crate() {
     let output = run_wesley_gen_with_args(TOY_COUNTER_IR, &["--contract-host"]);
     assert!(
         output.status.success(),
@@ -1613,6 +1763,8 @@ fn test_toy_contract_generated_contract_host_helpers_compile_in_consumer_crate()
     assert!(generated.contains("pub fn increment_contract_rule"));
     assert!(generated.contains("pub fn increment_contract_vars"));
     assert!(generated.contains("pub fn increment_contract_runtime_ingress_footprint"));
+    assert!(generated.contains("pub fn counter_value_query_observer"));
+    assert!(generated.contains("pub fn counter_value_observer_vars"));
     let crate_dir = write_contract_host_smoke_crate(&generated);
     let output = Command::new("cargo")
         .args(["test", "--manifest-path"])

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -244,11 +244,11 @@ pub use neighborhood::{
 };
 pub use observation::{
     AuthoredObserverPlan, BuiltinObserverPlan, ContractQueryObserveFn, ContractQueryObserver,
-    ContractQueryObserverContext, ContractQueryObserverResult, HeadObservation,
-    ObservationArtifact, ObservationAt, ObservationBasisPosture, ObservationCoordinate,
-    ObservationError, ObservationFrame, ObservationPayload, ObservationProjection,
-    ObservationProjectionKind, ObservationReadBudget, ObservationRequest, ObservationRights,
-    ObservationService, ObserverInstanceId, ObserverInstanceRef, ObserverPlanId,
+    ContractQueryObserverContext, ContractQueryObserverError, ContractQueryObserverResult,
+    HeadObservation, ObservationArtifact, ObservationAt, ObservationBasisPosture,
+    ObservationCoordinate, ObservationError, ObservationFrame, ObservationPayload,
+    ObservationProjection, ObservationProjectionKind, ObservationReadBudget, ObservationRequest,
+    ObservationRights, ObservationService, ObserverInstanceId, ObserverInstanceRef, ObserverPlanId,
     ReadingBudgetPosture, ReadingEnvelope, ReadingObserverBasis, ReadingObserverPlan,
     ReadingResidualPosture, ReadingRightsPosture, ReadingWitnessRef, ResolvedObservationCoordinate,
     WorldlineSnapshot,

--- a/crates/warp-core/src/observation.rs
+++ b/crates/warp-core/src/observation.rs
@@ -13,6 +13,8 @@
 //! Observation is strictly read-only. It never advances runtime state, drains
 //! inboxes, rewrites provenance, or mutates compatibility mirrors.
 
+use std::sync::Arc;
+
 use blake3::Hasher;
 use echo_wasm_abi::kernel_port as abi;
 use thiserror::Error;
@@ -470,6 +472,26 @@ pub struct ContractQueryObserver {
 }
 
 impl ContractQueryObserver {
+    /// Builds an installed contract query observer from a read-only host
+    /// closure. The closure receives immutable observation context and cannot
+    /// tick or mutate the runtime through this boundary.
+    pub fn new<F>(query_id: u32, observer_plan: AuthoredObserverPlan, observe: F) -> Self
+    where
+        F: for<'a> Fn(
+                ContractQueryObserverContext<'a>,
+            )
+                -> Result<ContractQueryObserverResult, ContractQueryObserverError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self {
+            query_id,
+            observer_plan,
+            observe: Arc::new(observe),
+        }
+    }
+
     fn observer_plan(&self) -> ReadingObserverPlan {
         ReadingObserverPlan::Authored {
             plan: Box::new(self.observer_plan.clone()),
@@ -478,8 +500,14 @@ impl ContractQueryObserver {
 }
 
 /// Read-only installed contract query observer function.
-pub type ContractQueryObserveFn =
-    for<'a> fn(ContractQueryObserverContext<'a>) -> ContractQueryObserverResult;
+pub type ContractQueryObserveFn = Arc<
+    dyn for<'a> Fn(
+            ContractQueryObserverContext<'a>,
+        ) -> Result<ContractQueryObserverResult, ContractQueryObserverError>
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// Read-only context passed to an installed contract query observer.
 pub struct ContractQueryObserverContext<'a> {
@@ -522,6 +550,47 @@ impl ContractQueryObserverResult {
         Self {
             bytes,
             residual_posture: ReadingResidualPosture::Residual,
+        }
+    }
+}
+
+/// Error emitted by a hosted query observer while producing query bytes.
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum ContractQueryObserverError {
+    /// Canonical query vars could not be decoded for the generated query id.
+    #[error("invalid query vars for query id {query_id}: {message}")]
+    InvalidVars {
+        /// Generated query operation id.
+        query_id: u32,
+        /// Deterministic decode error description.
+        message: String,
+    },
+    /// The hosted observer failed after vars were decoded.
+    #[error("query observer failed for query id {query_id}: {message}")]
+    Failed {
+        /// Generated query operation id.
+        query_id: u32,
+        /// Deterministic failure description.
+        message: String,
+    },
+}
+
+impl ContractQueryObserverError {
+    /// Builds a typed invalid-vars observer error.
+    #[must_use]
+    pub fn invalid_vars(query_id: u32, message: impl Into<String>) -> Self {
+        Self::InvalidVars {
+            query_id,
+            message: message.into(),
+        }
+    }
+
+    /// Builds a typed observer failure.
+    #[must_use]
+    pub fn failed(query_id: u32, message: impl Into<String>) -> Self {
+        Self::Failed {
+            query_id,
+            message: message.into(),
         }
     }
 }
@@ -963,6 +1032,14 @@ pub enum ObservationError {
         /// Stable generated query operation id.
         query_id: u32,
     },
+    /// An installed contract query observer rejected or failed the request.
+    #[error("contract query observer failed for query id {query_id}: {source}")]
+    ContractQueryObserverFailed {
+        /// Stable generated query operation id.
+        query_id: u32,
+        /// Observer-emitted failure.
+        source: ContractQueryObserverError,
+    },
     /// The requested observer plan is not installed or executable.
     #[error("unsupported observer plan: {0:?}")]
     UnsupportedObserverPlan(ReadingObserverPlan),
@@ -1094,7 +1171,13 @@ impl ObservationService {
                     resolved: &resolved,
                     runtime,
                     provenance,
-                });
+                })
+                .map_err(|source| {
+                    ObservationError::ContractQueryObserverFailed {
+                        query_id: *query_id,
+                        source,
+                    }
+                })?;
                 (
                     ObservationPayload::QueryBytes(result.bytes),
                     observer.observer_plan(),
@@ -1405,6 +1488,12 @@ impl ObservationService {
                 OpticObstructionKind::UnsupportedProjectionLaw,
                 None,
                 "contract QueryView optics are not installed yet",
+            ),
+            ObservationError::ContractQueryObserverFailed { .. } => Self::optic_obstruction(
+                request,
+                OpticObstructionKind::UnsupportedProjectionLaw,
+                None,
+                "contract QueryView observer failed to emit a reading",
             ),
             ObservationError::UnsupportedRights(_) => Self::optic_obstruction(
                 request,
@@ -2259,7 +2348,7 @@ mod tests {
 
     fn complete_query_observer(
         context: ContractQueryObserverContext<'_>,
-    ) -> ContractQueryObserverResult {
+    ) -> Result<ContractQueryObserverResult, ContractQueryObserverError> {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&context.query_id.to_le_bytes());
         bytes.extend_from_slice(context.vars_bytes);
@@ -2270,15 +2359,15 @@ mod tests {
                 .as_u64()
                 .to_le_bytes(),
         );
-        ContractQueryObserverResult::complete(bytes)
+        Ok(ContractQueryObserverResult::complete(bytes))
     }
 
     fn residual_query_observer(
         context: ContractQueryObserverContext<'_>,
-    ) -> ContractQueryObserverResult {
+    ) -> Result<ContractQueryObserverResult, ContractQueryObserverError> {
         let mut bytes = b"residual:".to_vec();
         bytes.extend_from_slice(context.vars_bytes);
-        ContractQueryObserverResult::residual(bytes)
+        Ok(ContractQueryObserverResult::residual(bytes))
     }
 
     fn empty_runtime_fixture() -> (Engine, WorldlineRuntime, ProvenanceService, WorldlineId) {
@@ -3047,11 +3136,11 @@ mod tests {
         let (mut engine, runtime, provenance, worldline_id) = one_commit_fixture();
         let plan = authored_query_plan(90, 91);
         engine
-            .register_contract_query_observer(ContractQueryObserver {
-                query_id: 9_001,
-                observer_plan: plan.clone(),
-                observe: complete_query_observer,
-            })
+            .register_contract_query_observer(ContractQueryObserver::new(
+                9_001,
+                plan.clone(),
+                complete_query_observer,
+            ))
             .unwrap();
         let request = query_request(
             worldline_id,
@@ -3102,18 +3191,18 @@ mod tests {
     fn contract_query_identity_changes_when_plan_query_vars_or_basis_change() {
         let (mut engine, runtime, provenance, worldline_id) = one_commit_fixture();
         engine
-            .register_contract_query_observer(ContractQueryObserver {
-                query_id: 9_001,
-                observer_plan: authored_query_plan(90, 91),
-                observe: complete_query_observer,
-            })
+            .register_contract_query_observer(ContractQueryObserver::new(
+                9_001,
+                authored_query_plan(90, 91),
+                complete_query_observer,
+            ))
             .unwrap();
         engine
-            .register_contract_query_observer(ContractQueryObserver {
-                query_id: 9_002,
-                observer_plan: authored_query_plan(92, 93),
-                observe: complete_query_observer,
-            })
+            .register_contract_query_observer(ContractQueryObserver::new(
+                9_002,
+                authored_query_plan(92, 93),
+                complete_query_observer,
+            ))
             .unwrap();
 
         let baseline = ObservationService::observe(
@@ -3168,11 +3257,11 @@ mod tests {
         let (mut other_engine, other_runtime, other_provenance, other_worldline_id) =
             one_commit_fixture();
         other_engine
-            .register_contract_query_observer(ContractQueryObserver {
-                query_id: 9_001,
-                observer_plan: authored_query_plan(90, 99),
-                observe: complete_query_observer,
-            })
+            .register_contract_query_observer(ContractQueryObserver::new(
+                9_001,
+                authored_query_plan(90, 99),
+                complete_query_observer,
+            ))
             .unwrap();
         let different_schema = ObservationService::observe(
             &other_runtime,
@@ -3197,11 +3286,11 @@ mod tests {
     fn bounded_contract_query_observer_reports_residual_posture() -> Result<(), String> {
         let (mut engine, runtime, provenance, worldline_id) = one_commit_fixture();
         engine
-            .register_contract_query_observer(ContractQueryObserver {
-                query_id: 9_003,
-                observer_plan: authored_query_plan(94, 95),
-                observe: residual_query_observer,
-            })
+            .register_contract_query_observer(ContractQueryObserver::new(
+                9_003,
+                authored_query_plan(94, 95),
+                residual_query_observer,
+            ))
             .map_err(|err| err.to_string())?;
         let mut request = query_request(
             worldline_id,

--- a/crates/warp-wasm/src/warp_kernel.rs
+++ b/crates/warp-wasm/src/warp_kernel.rs
@@ -42,15 +42,15 @@ use echo_wasm_abi::{
 };
 use warp_core::{
     make_head_id, make_intent_kind, make_node_id, make_type_id, AttachmentDescentPolicy,
-    AttachmentKey, AttachmentOwner, AttachmentPlane, AuthoredObserverPlan, BraidId, CoordinateAt,
-    EchoCoordinate, EdgeKey, Engine, EngineBuilder, EngineError, GlobalTick, GraphStore,
-    HeadEligibility, HeadId, HistoryError, IngressDisposition, IngressEnvelope, IngressTarget,
-    NeighborhoodError, NeighborhoodSiteService, NodeKey, NodeRecord, ObservationAt,
-    ObservationCoordinate, ObservationError, ObservationFrame, ObservationPayload,
-    ObservationProjection, ObservationReadBudget, ObservationRequest, ObservationRights,
-    ObservationService, ObserveOpticRequest, ObserverInstanceId, ObserverInstanceRef,
-    ObserverPlanId, OpticAperture, OpticApertureShape, OpticCapabilityId, OpticFocus,
-    OpticReadBudget, PlaybackMode, ProjectionVersion, ProvenanceRef, ProvenanceService,
+    AttachmentKey, AttachmentOwner, AttachmentPlane, AuthoredObserverPlan, BraidId,
+    ContractQueryObserverError, CoordinateAt, EchoCoordinate, EdgeKey, Engine, EngineBuilder,
+    EngineError, GlobalTick, GraphStore, HeadEligibility, HeadId, HistoryError, IngressDisposition,
+    IngressEnvelope, IngressTarget, NeighborhoodError, NeighborhoodSiteService, NodeKey,
+    NodeRecord, ObservationAt, ObservationCoordinate, ObservationError, ObservationFrame,
+    ObservationPayload, ObservationProjection, ObservationReadBudget, ObservationRequest,
+    ObservationRights, ObservationService, ObserveOpticRequest, ObserverInstanceId,
+    ObserverInstanceRef, ObserverPlanId, OpticAperture, OpticApertureShape, OpticCapabilityId,
+    OpticFocus, OpticReadBudget, PlaybackMode, ProjectionVersion, ProvenanceRef, ProvenanceService,
     ReadingObserverPlan, ReducerVersion, RetainedReadingKey, RunId, RuntimeError,
     SchedulerCoordinator, SchedulerKind, SettlementError, SettlementService, StrandId, TypeId,
     WorldlineId, WorldlineRuntime, WorldlineState, WorldlineStateError, WorldlineTick, WriterHead,
@@ -320,6 +320,20 @@ impl WarpKernel {
                 code: error_codes::UNSUPPORTED_QUERY,
                 message: format!("query observation is not installed for query id {query_id}"),
             },
+            ObservationError::ContractQueryObserverFailed { query_id, source } => {
+                let code = match &source {
+                    ContractQueryObserverError::InvalidVars { .. } => error_codes::CODEC_ERROR,
+                    ContractQueryObserverError::Failed { .. } => {
+                        error_codes::OBSERVATION_UNAVAILABLE
+                    }
+                };
+                AbiError {
+                    code,
+                    message: format!(
+                        "contract query observer failed for query id {query_id}: {source}"
+                    ),
+                }
+            }
             ObservationError::UnsupportedObserverPlan(plan) => AbiError {
                 code: error_codes::UNSUPPORTED_OBSERVER_PLAN,
                 message: format!("unsupported observer plan: {plan:?}"),

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -3,7 +3,7 @@
 
 # BEARING
 
-Last updated: 2026-05-20.
+Last updated: 2026-05-21.
 
 This signpost summarizes current direction. It does not create commitments or
 replace backlog items, design docs, retros, or CLI status. If it disagrees with
@@ -43,6 +43,10 @@ scheduler-owned tick outcome without giving application code tick authority.
   observers keyed by generated query op id. Observers receive canonical vars
   bytes and the resolved causal basis, emit `QueryBytes`, and stamp the
   `ReadingEnvelope` with authored observer plan identity.
+- `echo-wesley-gen --contract-host` emits std-only query observer helpers for
+  that seam: deterministic authored observer plan identity, typed context-vars
+  decoders, and read-only observer constructors that install host closures into
+  `warp-core`.
 - Footprint conflicts are explicit receipt rejections, not hidden retries.
 - Failed `SuperTick` attempts are failure-atomic: uncommitted runtime,
   provenance, and receipt-correlation writes are rolled back before any fault
@@ -61,8 +65,6 @@ scheduler-owned tick outcome without giving application code tick authority.
   by id.
 - Contract-host packaging does not yet reject unsupported contract operations at
   an installed registry boundary.
-- `echo-wesley-gen` does not yet emit generated query observer installation
-  helpers for the core contract query observer boundary.
 
 ## Doctrine
 
@@ -145,10 +147,12 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 ## Immediate Next Slice
 
-The next slice should emit generated query observer helpers from Wesley against
-the core contract query observer boundary. Keep the write-side invariant intact:
-application dispatch submits EINT bytes only; handlers execute during
-scheduler-owned ticks.
+The next slice should add an installed contract registry boundary. Wesley now
+emits both write-side mutation host helpers and read-side query observer host
+helpers; Echo needs a single installed package surface that binds schema hash,
+artifact hash, codec identity, supported operation ids, mutation handlers, and
+query observers before contract operations become runtime-visible work or
+reads.
 
-This slice must not implement streaming subscriptions, automatic retry,
+That slice must not implement streaming subscriptions, automatic retry,
 execution outside scheduler-owned ticks, or wall-clock cadence semantics.

--- a/docs/method/backlog/asap/PLATFORM_contract-queryview-observer-bridge.md
+++ b/docs/method/backlog/asap/PLATFORM_contract-queryview-observer-bridge.md
@@ -3,8 +3,8 @@
 
 # Contract QueryView Observer Bridge
 
-Status: core observer bridge checkpoint; generated query helper emission
-remains.
+Status: core observer bridge and generated query helper checkpoint complete;
+installed contract registry boundary remains.
 
 Depends on:
 
@@ -25,6 +25,11 @@ bounded bytes and residual posture; Echo wraps the bytes in
 `ObservationPayload::QueryBytes` and stamps the `ReadingEnvelope` with the
 authored observer plan identity.
 
+`echo-wesley-gen --contract-host` now emits std-only query observer helpers for
+that boundary: deterministic authored observer plan identity, typed
+context-vars decoders that return `Result`, and read-only observer constructors
+that install host closures through `warp-core`.
+
 ## RED
 
 Added failing tests that prove:
@@ -36,6 +41,11 @@ Added failing tests that prove:
 - changing schema/plan identity, op id, vars, or basis changes artifact
   identity;
 - bounded observers can report residual posture.
+- generated contract-host output includes query observer helper constructors;
+- generated query observers decode typed vars from observer context and return
+  typed observer errors for malformed canonical vars;
+- generated mutation host helpers and query observer helpers compile and install
+  together in a consumer smoke crate.
 
 ## GREEN
 
@@ -50,17 +60,22 @@ ObservationPayload::QueryBytes(bytes)
 
 and a ReadingEnvelope that names contract/query identity.
 
+`echo-wesley-gen --contract-host` emits generated query observer helpers that
+bind Wesley query definitions to this read-only observer boundary without
+adding application nouns to core.
+
 ## Acceptance criteria
 
 - Unsupported query op returns typed obstruction/error, not fake empty success.
 - Same query, basis, and vars produce stable reading identity.
 - Changing schema hash, op id, vars, or basis changes identity.
 - Bounded observers can report budget/residual posture.
+- Generated query observer helpers install through
+  `Engine::register_contract_query_observer`.
+- Malformed generated query vars become typed observer errors, not `None`.
 
 ## Remaining work
 
-- `echo-wesley-gen` should emit query observer helper constructors against this
-  core boundary.
 - Contract-host packaging still needs an installed registry boundary that
   rejects unsupported contract operations before they become runtime-visible
   work or reads.


### PR DESCRIPTION
## Summary

- emit std-only `--contract-host` query observer helpers from `echo-wesley-gen`
- add typed `ContractQueryObserver` closure construction and observer error propagation in `warp-core`
- prove generated mutation host helpers and query observer helpers install together in the contract-host smoke crate
- update BEARING, CHANGELOG, generator README, and the QueryView observer backlog card

## Tests

- `cargo test -p echo-wesley-gen test_toy_contract_generated_contract_host_helpers_emit_query_observer_helpers -- --nocapture`
- `cargo test -p echo-wesley-gen test_toy_contract_generated_contract_host_query_observer_compiles_in_consumer_crate -- --nocapture`
- `cargo test -p echo-wesley-gen test_contract_host_generation_rejects_no_std -- --nocapture`
- `cargo test -p echo-wesley-gen -- --nocapture`
- `cargo test -p warp-core contract_query -- --nocapture`
- `cargo check -p warp-core`
- `cargo check -p warp-wasm --features engine`
- `cargo fmt --all -- --check`
- `git diff --check`
- `npx markdownlint-cli2 CHANGELOG.md crates/echo-wesley-gen/README.md docs/BEARING.md docs/method/backlog/asap/PLATFORM_contract-queryview-observer-bridge.md`
- pre-push targeted suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `echo-wesley-gen --contract-host` now generates complete query observer helpers, including deterministic observer plan identity, typed context-variable decoders with explicit error handling, and read-only observer constructors for runtime installation.

* **Documentation**
  * Updated README, changelog, and architecture documentation to reflect new query observer generation capabilities and integration with the contract registry boundary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/echo/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->