### PR TITLE
feat(core): add installed contract registry boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
   query observers before the handlers or observers are installed into
   `Engine`. The boundary verifies the generated `RegistryProvider` with
   `echo-registry-api`, rejects unknown operation ids, rejects mutation/query kind
-  mismatches, rejects duplicate package operation ids, and preflights rule and
+  mismatches, rejects mutation rules whose generated rule name does not bind the
+  declared mutation op id, rejects duplicate package operation ids, and
+  preflights package-internal rule name/id conflicts plus engine-level rule and
   observer conflicts before mutating engine state. This does not add dynamic
   plugin loading, application-controlled ticks, streaming subscriptions, or
   domain nouns to `warp-core`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 ### Added
 
+- `warp-core` now exposes an installed contract package registry boundary for
+  runtime-owner host adapters. An installed package binds generated registry
+  metadata, schema hash, codec identity, package artifact identity, supported
+  mutation op ids, mutation handler rules, supported query op ids, and read-only
+  query observers before the handlers or observers are installed into
+  `Engine`. The boundary verifies the generated `RegistryProvider` with
+  `echo-registry-api`, rejects unknown operation ids, rejects mutation/query kind
+  mismatches, rejects duplicate package operation ids, and preflights rule and
+  observer conflicts before mutating engine state. This does not add dynamic
+  plugin loading, application-controlled ticks, streaming subscriptions, or
+  domain nouns to `warp-core`.
 - `echo-wesley-gen --contract-host` now emits std-only query observer host
   helpers against `warp-core`'s `ContractQueryObserver` boundary. Generated
   query helpers include deterministic authored observer plan identity, typed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "bytes",
  "ciborium",
  "echo-dry-tests",
+ "echo-registry-api",
  "echo-runtime-schema",
  "echo-wasm-abi",
  "hex",

--- a/crates/warp-core/Cargo.toml
+++ b/crates/warp-core/Cargo.toml
@@ -24,6 +24,7 @@ rustc-hash = "2.1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 echo-wasm-abi = { workspace = true }
 echo-runtime-schema = { workspace = true }
+echo-registry-api = { workspace = true }
 warp-math = { workspace = true }
 
 [dev-dependencies]
@@ -84,6 +85,10 @@ required-features = ["host_test"]
 [[test]]
 name = "scheduler_fault_recovery_authority"
 required-features = ["trusted_runtime"]
+
+[[test]]
+name = "installed_contract_registry_tests"
+required-features = ["native_rule_bootstrap"]
 
 [build-dependencies]
 blake3 = "1.0"

--- a/crates/warp-core/src/contract_registry.rs
+++ b/crates/warp-core/src/contract_registry.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Installed contract package boundary.
+//!
+//! This module binds generated registry metadata to installed mutation handlers
+//! and read-only query observers without importing application nouns into core.
+
+#[cfg(feature = "native_rule_bootstrap")]
+use std::collections::BTreeSet;
+
+use echo_registry_api::{
+    ContractArtifactRejection, ContractArtifactTrustPosture, ContractArtifactVerificationPolicy,
+    OpKind, RegistryInfo, RegistryProvider,
+};
+use thiserror::Error;
+
+#[cfg(feature = "native_rule_bootstrap")]
+use blake3::Hasher;
+#[cfg(feature = "native_rule_bootstrap")]
+use echo_registry_api::verify_contract_artifact;
+
+use crate::ident::Hash;
+use crate::observation::ContractQueryObserver;
+use crate::rule::RewriteRule;
+
+#[cfg(feature = "native_rule_bootstrap")]
+const INSTALLED_CONTRACT_PACKAGE_ID_DOMAIN: &[u8] = b"echo:installed-contract-package-id:v1\0";
+
+/// Deterministic identity for an installed generated contract package.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct InstalledContractPackageId(Hash);
+
+impl InstalledContractPackageId {
+    /// Reconstructs the id from canonical bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the canonical byte representation.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash {
+        &self.0
+    }
+}
+
+/// Host-owned package identity supplied when installing generated contract code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContractPackageIdentity<'a> {
+    /// Runtime package name chosen by the host.
+    pub package_name: &'a str,
+    /// Runtime package version chosen by the host.
+    pub package_version: &'a str,
+    /// Hex-encoded generated package artifact hash.
+    pub artifact_hash_hex: &'a str,
+}
+
+/// Generated mutation handler bound to a registry operation id.
+pub struct ContractMutationHandler {
+    /// Generated mutation operation id this handler supports.
+    pub op_id: u32,
+    /// Scheduler-owned rewrite rule that handles materialized runtime ingress.
+    pub rule: RewriteRule,
+}
+
+/// Generated contract package ready for runtime-owner installation.
+pub struct InstalledContractPackage<'a> {
+    /// Host-owned package identity.
+    pub identity: ContractPackageIdentity<'a>,
+    /// Generated registry provider compiled by Wesley.
+    pub registry: &'a dyn RegistryProvider,
+    /// Host verification policy for the generated registry artifact.
+    pub verification_policy: ContractArtifactVerificationPolicy<'a>,
+    /// Generated mutation handlers to install.
+    pub mutation_handlers: Vec<ContractMutationHandler>,
+    /// Generated read-only query observers to install.
+    pub query_observers: Vec<ContractQueryObserver>,
+}
+
+/// Installed package metadata retained by Echo core.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InstalledContractPackageRecord {
+    /// Deterministic package identity.
+    pub package_id: InstalledContractPackageId,
+    /// Runtime package name.
+    pub package_name: String,
+    /// Runtime package version.
+    pub package_version: String,
+    /// Hex-encoded generated package artifact hash.
+    pub artifact_hash_hex: String,
+    /// Verified generated registry metadata.
+    pub registry_info: RegistryInfo,
+    /// Verified artifact trust posture.
+    pub trust_posture: ContractArtifactTrustPosture,
+    /// Installed mutation operation ids.
+    pub mutation_op_ids: Vec<u32>,
+    /// Installed query operation ids.
+    pub query_op_ids: Vec<u32>,
+}
+
+/// Error returned when installing a generated contract package fails.
+#[derive(Debug, Error)]
+pub enum InstalledContractPackageError<'a> {
+    /// Package name was empty.
+    #[error("installed contract package name is empty")]
+    EmptyPackageName,
+    /// Package version was empty.
+    #[error("installed contract package version is empty")]
+    EmptyPackageVersion,
+    /// Package artifact hash was empty.
+    #[error("installed contract package artifact hash is empty")]
+    EmptyArtifactHash,
+    /// Generated registry failed host verification.
+    #[error("contract artifact verification failed: {0:?}")]
+    ArtifactRejected(ContractArtifactRejection<'a>),
+    /// Mutation handler named an operation not present in the generated registry.
+    #[error("unknown mutation operation id: {op_id}")]
+    UnknownMutationOperation {
+        /// Unsupported operation id.
+        op_id: u32,
+    },
+    /// Mutation handler named a non-mutation registry operation.
+    #[error("operation id {op_id} is not a mutation: {actual:?}")]
+    MutationOperationKindMismatch {
+        /// Operation id.
+        op_id: u32,
+        /// Actual registry operation kind.
+        actual: OpKind,
+    },
+    /// Query observer named an operation not present in the generated registry.
+    #[error("unknown query operation id: {op_id}")]
+    UnknownQueryOperation {
+        /// Unsupported operation id.
+        op_id: u32,
+    },
+    /// Query observer named a non-query registry operation.
+    #[error("operation id {op_id} is not a query: {actual:?}")]
+    QueryOperationKindMismatch {
+        /// Operation id.
+        op_id: u32,
+        /// Actual registry operation kind.
+        actual: OpKind,
+    },
+    /// Package repeated a mutation handler operation id.
+    #[error("duplicate mutation handler operation id in package: {op_id}")]
+    DuplicateMutationHandlerInPackage {
+        /// Duplicated operation id.
+        op_id: u32,
+    },
+    /// Package repeated a query observer operation id.
+    #[error("duplicate query observer operation id in package: {op_id}")]
+    DuplicateQueryObserverInPackage {
+        /// Duplicated operation id.
+        op_id: u32,
+    },
+    /// Package id is already installed.
+    #[error("installed contract package already exists: {package_id:?}")]
+    DuplicatePackage {
+        /// Duplicated package id.
+        package_id: InstalledContractPackageId,
+    },
+    /// Mutation operation id is already installed by another package.
+    #[error("contract mutation operation id already installed: {op_id}")]
+    DuplicateInstalledMutationOperation {
+        /// Duplicated operation id.
+        op_id: u32,
+    },
+    /// Query operation id is already installed by another package.
+    #[error("contract query operation id already installed: {op_id}")]
+    DuplicateInstalledQueryOperation {
+        /// Duplicated operation id.
+        op_id: u32,
+    },
+    /// Rewrite rule name is already installed.
+    #[error("duplicate rewrite rule name: {name}")]
+    DuplicateRuleName {
+        /// Duplicated rule name.
+        name: &'static str,
+    },
+    /// Rewrite rule id is already installed.
+    #[error("duplicate rewrite rule id: {rule_id:?}")]
+    DuplicateRuleId {
+        /// Duplicated rule id.
+        rule_id: Hash,
+    },
+    /// Rule requested Join conflict policy without a join function.
+    #[error("missing join function for installed contract rule")]
+    MissingJoinFn,
+    /// Engine registration failed after package preflight.
+    #[error("internal installed contract registration failure: {reason}")]
+    InternalRegistrationFailure {
+        /// Static failure reason.
+        reason: &'static str,
+    },
+}
+
+/// Validated package installation plan.
+#[cfg(feature = "native_rule_bootstrap")]
+pub(crate) struct PreparedInstalledContractPackage {
+    pub(crate) record: InstalledContractPackageRecord,
+    pub(crate) mutation_handlers: Vec<ContractMutationHandler>,
+    pub(crate) query_observers: Vec<ContractQueryObserver>,
+}
+
+#[cfg(feature = "native_rule_bootstrap")]
+pub(crate) fn prepare_installed_contract_package(
+    package: InstalledContractPackage<'_>,
+) -> Result<PreparedInstalledContractPackage, InstalledContractPackageError<'_>> {
+    validate_identity(package.identity)?;
+    let verified = verify_contract_artifact(package.registry, &package.verification_policy)
+        .map_err(InstalledContractPackageError::ArtifactRejected)?;
+
+    let mut mutation_op_ids = Vec::with_capacity(package.mutation_handlers.len());
+    let mut seen_mutations = BTreeSet::new();
+    for handler in &package.mutation_handlers {
+        if !seen_mutations.insert(handler.op_id) {
+            return Err(
+                InstalledContractPackageError::DuplicateMutationHandlerInPackage {
+                    op_id: handler.op_id,
+                },
+            );
+        }
+        let Some(op) = package.registry.op_by_id(handler.op_id) else {
+            return Err(InstalledContractPackageError::UnknownMutationOperation {
+                op_id: handler.op_id,
+            });
+        };
+        if op.kind != OpKind::Mutation {
+            return Err(
+                InstalledContractPackageError::MutationOperationKindMismatch {
+                    op_id: handler.op_id,
+                    actual: op.kind,
+                },
+            );
+        }
+        mutation_op_ids.push(handler.op_id);
+    }
+
+    let mut query_op_ids = Vec::with_capacity(package.query_observers.len());
+    let mut seen_queries = BTreeSet::new();
+    for observer in &package.query_observers {
+        if !seen_queries.insert(observer.query_id) {
+            return Err(
+                InstalledContractPackageError::DuplicateQueryObserverInPackage {
+                    op_id: observer.query_id,
+                },
+            );
+        }
+        let Some(op) = package.registry.op_by_id(observer.query_id) else {
+            return Err(InstalledContractPackageError::UnknownQueryOperation {
+                op_id: observer.query_id,
+            });
+        };
+        if op.kind != OpKind::Query {
+            return Err(InstalledContractPackageError::QueryOperationKindMismatch {
+                op_id: observer.query_id,
+                actual: op.kind,
+            });
+        }
+        query_op_ids.push(observer.query_id);
+    }
+
+    mutation_op_ids.sort_unstable();
+    query_op_ids.sort_unstable();
+
+    let package_id = installed_contract_package_id(package.identity, verified.info);
+    let record = InstalledContractPackageRecord {
+        package_id,
+        package_name: package.identity.package_name.to_owned(),
+        package_version: package.identity.package_version.to_owned(),
+        artifact_hash_hex: package.identity.artifact_hash_hex.to_owned(),
+        registry_info: verified.info,
+        trust_posture: verified.posture,
+        mutation_op_ids,
+        query_op_ids,
+    };
+
+    Ok(PreparedInstalledContractPackage {
+        record,
+        mutation_handlers: package.mutation_handlers,
+        query_observers: package.query_observers,
+    })
+}
+
+#[cfg(feature = "native_rule_bootstrap")]
+fn validate_identity(
+    identity: ContractPackageIdentity<'_>,
+) -> Result<(), InstalledContractPackageError<'_>> {
+    if identity.package_name.is_empty() {
+        return Err(InstalledContractPackageError::EmptyPackageName);
+    }
+    if identity.package_version.is_empty() {
+        return Err(InstalledContractPackageError::EmptyPackageVersion);
+    }
+    if identity.artifact_hash_hex.is_empty() {
+        return Err(InstalledContractPackageError::EmptyArtifactHash);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "native_rule_bootstrap")]
+fn installed_contract_package_id(
+    identity: ContractPackageIdentity<'_>,
+    registry_info: RegistryInfo,
+) -> InstalledContractPackageId {
+    let mut hasher = Hasher::new();
+    hasher.update(INSTALLED_CONTRACT_PACKAGE_ID_DOMAIN);
+    push_len_prefixed(&mut hasher, identity.package_name.as_bytes());
+    push_len_prefixed(&mut hasher, identity.package_version.as_bytes());
+    push_len_prefixed(&mut hasher, identity.artifact_hash_hex.as_bytes());
+    push_len_prefixed(&mut hasher, registry_info.codec_id.as_bytes());
+    hasher.update(&registry_info.registry_version.to_le_bytes());
+    push_len_prefixed(&mut hasher, registry_info.schema_sha256_hex.as_bytes());
+    InstalledContractPackageId::from_bytes(hasher.finalize().into())
+}
+
+#[cfg(feature = "native_rule_bootstrap")]
+fn push_len_prefixed(hasher: &mut Hasher, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}

--- a/crates/warp-core/src/contract_registry.rs
+++ b/crates/warp-core/src/contract_registry.rs
@@ -129,6 +129,18 @@ pub enum InstalledContractPackageError<'a> {
         /// Actual registry operation kind.
         actual: OpKind,
     },
+    /// Mutation handler declared one operation id while its generated rule names another.
+    #[error(
+        "mutation handler declared operation id {declared_op_id} but rule {rule_name} names operation id {rule_op_id:?}"
+    )]
+    MutationRuleOperationMismatch {
+        /// Operation id declared by the installed package handler.
+        declared_op_id: u32,
+        /// Operation id encoded in the generated rule name, when parseable.
+        rule_op_id: Option<u32>,
+        /// Rule name that failed the generated naming contract.
+        rule_name: &'static str,
+    },
     /// Query observer named an operation not present in the generated registry.
     #[error("unknown query operation id: {op_id}")]
     UnknownQueryOperation {
@@ -214,6 +226,8 @@ pub(crate) fn prepare_installed_contract_package(
 
     let mut mutation_op_ids = Vec::with_capacity(package.mutation_handlers.len());
     let mut seen_mutations = BTreeSet::new();
+    let mut seen_rule_names = BTreeSet::new();
+    let mut seen_rule_ids = BTreeSet::new();
     for handler in &package.mutation_handlers {
         if !seen_mutations.insert(handler.op_id) {
             return Err(
@@ -234,6 +248,31 @@ pub(crate) fn prepare_installed_contract_package(
                     actual: op.kind,
                 },
             );
+        }
+        let rule_op_id = generated_contract_rule_op_id(handler.rule.name);
+        if rule_op_id != Some(handler.op_id) {
+            return Err(
+                InstalledContractPackageError::MutationRuleOperationMismatch {
+                    declared_op_id: handler.op_id,
+                    rule_op_id,
+                    rule_name: handler.rule.name,
+                },
+            );
+        }
+        if !seen_rule_names.insert(handler.rule.name) {
+            return Err(InstalledContractPackageError::DuplicateRuleName {
+                name: handler.rule.name,
+            });
+        }
+        if !seen_rule_ids.insert(handler.rule.id) {
+            return Err(InstalledContractPackageError::DuplicateRuleId {
+                rule_id: handler.rule.id,
+            });
+        }
+        if matches!(handler.rule.conflict_policy, crate::ConflictPolicy::Join)
+            && handler.rule.join_fn.is_none()
+        {
+            return Err(InstalledContractPackageError::MissingJoinFn);
         }
         mutation_op_ids.push(handler.op_id);
     }
@@ -298,6 +337,24 @@ fn validate_identity(
         return Err(InstalledContractPackageError::EmptyArtifactHash);
     }
     Ok(())
+}
+
+#[cfg(feature = "native_rule_bootstrap")]
+fn generated_contract_rule_op_id(rule_name: &str) -> Option<u32> {
+    let mut parts = rule_name.split('/');
+    if parts.next()? != "cmd" {
+        return None;
+    }
+    if parts.next()? != "contract" {
+        return None;
+    }
+    let _schema_hash = parts.next()?;
+    let op_id = parts.next()?.parse().ok()?;
+    let _operation_name = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(op_id)
 }
 
 #[cfg(feature = "native_rule_bootstrap")]

--- a/crates/warp-core/src/engine_impl.rs
+++ b/crates/warp-core/src/engine_impl.rs
@@ -7,6 +7,12 @@ use blake3::Hasher;
 use thiserror::Error;
 
 use crate::attachment::{AttachmentKey, AttachmentValue};
+#[cfg(feature = "native_rule_bootstrap")]
+use crate::contract_registry::{
+    prepare_installed_contract_package, ContractMutationHandler, InstalledContractPackage,
+    InstalledContractPackageError,
+};
+use crate::contract_registry::{InstalledContractPackageId, InstalledContractPackageRecord};
 use crate::graph::GraphStore;
 use crate::graph_view::GraphView;
 use crate::head_inbox::{IngressEnvelope, IngressPayload, IntentKind};
@@ -432,6 +438,13 @@ pub struct Engine {
     compact_rule_ids: HashMap<Hash, CompactRuleId>,
     rules_by_compact: HashMap<CompactRuleId, &'static str>,
     canonical_cmd_rules: Vec<(Hash, &'static str)>,
+    #[cfg_attr(not(feature = "native_rule_bootstrap"), allow(dead_code))]
+    installed_contract_packages:
+        BTreeMap<InstalledContractPackageId, InstalledContractPackageRecord>,
+    #[cfg_attr(not(feature = "native_rule_bootstrap"), allow(dead_code))]
+    contract_mutation_handlers: BTreeMap<u32, InstalledContractPackageId>,
+    #[cfg_attr(not(feature = "native_rule_bootstrap"), allow(dead_code))]
+    contract_query_observer_packages: BTreeMap<u32, InstalledContractPackageId>,
     contract_query_observers: BTreeMap<u32, ContractQueryObserver>,
     scheduler: DeterministicScheduler,
     scheduler_kind: SchedulerKind,
@@ -859,6 +872,9 @@ impl Engine {
             compact_rule_ids: HashMap::new(),
             rules_by_compact: HashMap::new(),
             canonical_cmd_rules: Vec::new(),
+            installed_contract_packages: BTreeMap::new(),
+            contract_mutation_handlers: BTreeMap::new(),
+            contract_query_observer_packages: BTreeMap::new(),
             contract_query_observers: BTreeMap::new(),
             scheduler: DeterministicScheduler::new(kind, Arc::clone(&telemetry)),
             scheduler_kind: kind,
@@ -1049,6 +1065,9 @@ impl Engine {
             compact_rule_ids: HashMap::new(),
             rules_by_compact: HashMap::new(),
             canonical_cmd_rules: Vec::new(),
+            installed_contract_packages: BTreeMap::new(),
+            contract_mutation_handlers: BTreeMap::new(),
+            contract_query_observer_packages: BTreeMap::new(),
             contract_query_observers: BTreeMap::new(),
             scheduler: DeterministicScheduler::new(kind, Arc::clone(&telemetry)),
             scheduler_kind: kind,
@@ -1172,6 +1191,142 @@ impl Engine {
 
     pub(crate) fn contract_query_observer(&self, query_id: u32) -> Option<&ContractQueryObserver> {
         self.contract_query_observers.get(&query_id)
+    }
+
+    /// Installs a generated contract package through the package registry
+    /// boundary.
+    ///
+    /// This runtime-owner bootstrap surface verifies the generated registry,
+    /// confirms that mutation handlers and query observers correspond to
+    /// supported operations, and only then registers scheduler-owned rules and
+    /// read-only observers. Application dispatch does not call this method and
+    /// does not gain tick authority through it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstalledContractPackageError`] if registry verification fails,
+    /// any handler/observer names an unsupported operation, or the package would
+    /// conflict with an already-installed package, rule, mutation op, or query op.
+    #[cfg(feature = "native_rule_bootstrap")]
+    #[doc(hidden)]
+    pub fn install_contract_package<'a>(
+        &mut self,
+        package: InstalledContractPackage<'a>,
+    ) -> Result<InstalledContractPackageRecord, InstalledContractPackageError<'a>> {
+        let prepared = prepare_installed_contract_package(package)?;
+        self.preflight_installed_contract_package(&prepared.record, &prepared.mutation_handlers)?;
+
+        for handler in prepared.mutation_handlers {
+            self.register_rule_impl(handler.rule)
+                .map_err(Self::installed_contract_registration_error)?;
+            self.contract_mutation_handlers
+                .insert(handler.op_id, prepared.record.package_id);
+        }
+        for observer in prepared.query_observers {
+            let query_id = observer.query_id;
+            self.register_contract_query_observer_impl(observer)
+                .map_err(Self::installed_contract_registration_error)?;
+            self.contract_query_observer_packages
+                .insert(query_id, prepared.record.package_id);
+        }
+        self.installed_contract_packages
+            .insert(prepared.record.package_id, prepared.record.clone());
+        Ok(prepared.record)
+    }
+
+    #[cfg(feature = "native_rule_bootstrap")]
+    fn installed_contract_registration_error<'a>(
+        error: EngineError,
+    ) -> InstalledContractPackageError<'a> {
+        match error {
+            EngineError::DuplicateRuleName(name) => {
+                InstalledContractPackageError::DuplicateRuleName { name }
+            }
+            EngineError::DuplicateRuleId(rule_id) => {
+                InstalledContractPackageError::DuplicateRuleId { rule_id }
+            }
+            EngineError::DuplicateContractQueryObserver(op_id) => {
+                InstalledContractPackageError::DuplicateInstalledQueryOperation { op_id }
+            }
+            EngineError::MissingJoinFn => InstalledContractPackageError::MissingJoinFn,
+            _ => InstalledContractPackageError::InternalRegistrationFailure {
+                reason: "unexpected engine registration error after package preflight",
+            },
+        }
+    }
+
+    #[cfg(feature = "native_rule_bootstrap")]
+    fn preflight_installed_contract_package<'a>(
+        &self,
+        record: &InstalledContractPackageRecord,
+        mutation_handlers: &[ContractMutationHandler],
+    ) -> Result<(), InstalledContractPackageError<'a>> {
+        if self
+            .installed_contract_packages
+            .contains_key(&record.package_id)
+        {
+            return Err(InstalledContractPackageError::DuplicatePackage {
+                package_id: record.package_id,
+            });
+        }
+        for op_id in &record.mutation_op_ids {
+            if self.contract_mutation_handlers.contains_key(op_id) {
+                return Err(
+                    InstalledContractPackageError::DuplicateInstalledMutationOperation {
+                        op_id: *op_id,
+                    },
+                );
+            }
+        }
+        for op_id in &record.query_op_ids {
+            if self.contract_query_observers.contains_key(op_id)
+                || self.contract_query_observer_packages.contains_key(op_id)
+            {
+                return Err(
+                    InstalledContractPackageError::DuplicateInstalledQueryOperation {
+                        op_id: *op_id,
+                    },
+                );
+            }
+        }
+        for handler in mutation_handlers {
+            if self.rules.contains_key(handler.rule.name) {
+                return Err(InstalledContractPackageError::DuplicateRuleName {
+                    name: handler.rule.name,
+                });
+            }
+            if self.rules_by_id.contains_key(&handler.rule.id) {
+                return Err(InstalledContractPackageError::DuplicateRuleId {
+                    rule_id: handler.rule.id,
+                });
+            }
+            if matches!(handler.rule.conflict_policy, ConflictPolicy::Join)
+                && handler.rule.join_fn.is_none()
+            {
+                return Err(InstalledContractPackageError::MissingJoinFn);
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the package id that installed a mutation operation id.
+    #[cfg(feature = "native_rule_bootstrap")]
+    #[must_use]
+    pub fn installed_contract_mutation_package_id(
+        &self,
+        op_id: u32,
+    ) -> Option<&InstalledContractPackageId> {
+        self.contract_mutation_handlers.get(&op_id)
+    }
+
+    /// Returns the package id that installed a query operation id.
+    #[cfg(feature = "native_rule_bootstrap")]
+    #[must_use]
+    pub fn installed_contract_query_package_id(
+        &self,
+        op_id: u32,
+    ) -> Option<&InstalledContractPackageId> {
+        self.contract_query_observer_packages.get(&op_id)
     }
 
     /// Begins a new transaction and returns its identifier.

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -46,6 +46,7 @@ mod clock;
 mod cmd;
 mod constants;
 mod contract_host;
+mod contract_registry;
 /// Domain separation prefixes for hashing.
 pub mod domain;
 mod dynamic_binding;
@@ -188,6 +189,10 @@ pub use cmd::{
 pub use constants::{blake3_empty, digest_len0_u64, POLICY_ID_NO_POLICY_V0};
 pub use contract_host::{
     eint_op_id, eint_vars_for_op, matches_eint_op, runtime_ingress_eint_read_footprint,
+};
+pub use contract_registry::{
+    ContractMutationHandler, ContractPackageIdentity, InstalledContractPackage,
+    InstalledContractPackageError, InstalledContractPackageId, InstalledContractPackageRecord,
 };
 pub use dynamic_binding::{
     BoundNodeRef, ClosureMemberBinding, DirectSlotBinding, DynamicBindingError,

--- a/crates/warp-core/tests/installed_contract_registry_tests.rs
+++ b/crates/warp-core/tests/installed_contract_registry_tests.rs
@@ -20,7 +20,16 @@ use warp_core::{
 const SCHEMA_SHA256_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const MUTATION_OP_ID: u32 = 1001;
 const QUERY_OP_ID: u32 = 1002;
+const SECOND_MUTATION_OP_ID: u32 = 1003;
 const UNKNOWN_OP_ID: u32 = 9999;
+const MUTATION_RULE_NAME: &str =
+    "cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/1001/increment";
+const SECOND_MUTATION_RULE_NAME: &str =
+    "cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/1003/decrement";
+const UNKNOWN_MUTATION_RULE_NAME: &str =
+    "cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/9999/unknown";
+const ALT_INCREMENT_RULE_NAME: &str =
+    "cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/1001/incrementAlt";
 
 static INCREMENT_ARGS: &[ArgDef] = &[ArgDef {
     name: "input",
@@ -44,6 +53,15 @@ static OPS: &[OpDef] = &[
         name: "counterValue",
         op_id: QUERY_OP_ID,
         args: &[],
+        result_ty: "CounterValue",
+        directives_json: "{}",
+        footprint_certificate: None,
+    },
+    OpDef {
+        kind: OpKind::Mutation,
+        name: "decrement",
+        op_id: SECOND_MUTATION_OP_ID,
+        args: INCREMENT_ARGS,
         result_ty: "CounterValue",
         directives_json: "{}",
         footprint_certificate: None,
@@ -108,6 +126,25 @@ fn verification_policy() -> ContractArtifactVerificationPolicy<'static> {
     }
 }
 
+fn mismatched_verification_policy() -> ContractArtifactVerificationPolicy<'static> {
+    ContractArtifactVerificationPolicy {
+        codec_id: "cbor-canon-v1",
+        registry_version: 1,
+        schema_sha256_hex: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        footprint_certificates: &[],
+        require_mutation_footprint_certificates: false,
+    }
+}
+
+fn rule_name_for_op_id(op_id: u32) -> &'static str {
+    match op_id {
+        MUTATION_OP_ID => MUTATION_RULE_NAME,
+        SECOND_MUTATION_OP_ID => SECOND_MUTATION_RULE_NAME,
+        UNKNOWN_OP_ID => UNKNOWN_MUTATION_RULE_NAME,
+        _ => "cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/4242/other",
+    }
+}
+
 fn mutation_rule(name: &'static str) -> RewriteRule {
     fn matches(_: GraphView<'_>, _: &NodeId) -> bool {
         false
@@ -130,6 +167,17 @@ fn mutation_rule(name: &'static str) -> RewriteRule {
     }
 }
 
+fn mutation_handler(op_id: u32) -> ContractMutationHandler {
+    ContractMutationHandler {
+        op_id,
+        rule: mutation_rule(rule_name_for_op_id(op_id)),
+    }
+}
+
+fn mutation_handler_with_rule(op_id: u32, rule: RewriteRule) -> ContractMutationHandler {
+    ContractMutationHandler { op_id, rule }
+}
+
 fn query_observer(query_id: u32) -> ContractQueryObserver {
     ContractQueryObserver::new(query_id, observer_plan(), |_context| {
         Ok(ContractQueryObserverResult::complete(b"value=42".to_vec()))
@@ -148,16 +196,35 @@ fn observer_plan() -> AuthoredObserverPlan {
 }
 
 fn package_with_ops(mutation_op_id: u32, query_op_id: u32) -> InstalledContractPackage<'static> {
+    package_with_identity_ops(package_identity(), mutation_op_id, query_op_id)
+}
+
+fn package_with_identity_ops(
+    identity: ContractPackageIdentity<'static>,
+    mutation_op_id: u32,
+    query_op_id: u32,
+) -> InstalledContractPackage<'static> {
+    package_with_handlers(
+        identity,
+        verification_policy(),
+        vec![mutation_handler(mutation_op_id)],
+        vec![query_observer(query_op_id)],
+    )
+}
+
+fn package_with_handlers(
+    identity: ContractPackageIdentity<'static>,
+    verification_policy: ContractArtifactVerificationPolicy<'static>,
+    mutation_handlers: Vec<ContractMutationHandler>,
+    query_observers: Vec<ContractQueryObserver>,
+) -> InstalledContractPackage<'static> {
     static REGISTRY: StaticRegistry = StaticRegistry;
     InstalledContractPackage {
-        identity: package_identity(),
+        identity,
         registry: &REGISTRY,
-        verification_policy: verification_policy(),
-        mutation_handlers: vec![ContractMutationHandler {
-            op_id: mutation_op_id,
-            rule: mutation_rule("cmd/contract/toy-counter/increment"),
-        }],
-        query_observers: vec![query_observer(query_op_id)],
+        verification_policy,
+        mutation_handlers,
+        query_observers,
     }
 }
 
@@ -276,6 +343,10 @@ fn installed_contract_package_rejects_query_kind_mismatch_before_observer_instal
             actual: OpKind::Mutation,
         }
     ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
 
     let (runtime, provenance, worldline_id) = runtime_with_worldline()?;
     let Err(err) = ObservationService::observe(
@@ -293,5 +364,283 @@ fn installed_contract_package_rejects_query_kind_mismatch_before_observer_instal
             query_id: MUTATION_OP_ID
         }
     ));
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_duplicate_mutation_op_id_before_registration(
+) -> Result<(), String> {
+    let mut engine = engine();
+    let package = package_with_handlers(
+        package_identity(),
+        verification_policy(),
+        vec![
+            mutation_handler(MUTATION_OP_ID),
+            mutation_handler_with_rule(MUTATION_OP_ID, mutation_rule(ALT_INCREMENT_RULE_NAME)),
+        ],
+        vec![query_observer(QUERY_OP_ID)],
+    );
+
+    let Err(err) = engine.install_contract_package(package) else {
+        return Err("duplicate mutation op id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::DuplicateMutationHandlerInPackage {
+            op_id: MUTATION_OP_ID
+        }
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_duplicate_query_op_id_before_registration(
+) -> Result<(), String> {
+    let mut engine = engine();
+    let package = package_with_handlers(
+        package_identity(),
+        verification_policy(),
+        vec![mutation_handler(MUTATION_OP_ID)],
+        vec![query_observer(QUERY_OP_ID), query_observer(QUERY_OP_ID)],
+    );
+
+    let Err(err) = engine.install_contract_package(package) else {
+        return Err("duplicate query op id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::DuplicateQueryObserverInPackage { op_id: QUERY_OP_ID }
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_duplicate_rule_id_without_partial_install(
+) -> Result<(), String> {
+    let mut engine = engine();
+    let first = mutation_rule(MUTATION_RULE_NAME);
+    let mut second = mutation_rule(SECOND_MUTATION_RULE_NAME);
+    second.id = first.id;
+    let package = package_with_handlers(
+        package_identity(),
+        verification_policy(),
+        vec![
+            mutation_handler_with_rule(MUTATION_OP_ID, first),
+            mutation_handler_with_rule(SECOND_MUTATION_OP_ID, second),
+        ],
+        vec![query_observer(QUERY_OP_ID)],
+    );
+
+    let Err(err) = engine.install_contract_package(package) else {
+        return Err("duplicate rule id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::DuplicateRuleId { .. }
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(SECOND_MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+
+    engine
+        .install_contract_package(package_with_ops(MUTATION_OP_ID, QUERY_OP_ID))
+        .map_err(|err| format!("failed install must not leave registered rule behind: {err:?}"))?;
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_rule_operation_mismatch_before_registration(
+) -> Result<(), String> {
+    let mut engine = engine();
+    let package = package_with_handlers(
+        package_identity(),
+        verification_policy(),
+        vec![mutation_handler_with_rule(
+            MUTATION_OP_ID,
+            mutation_rule(SECOND_MUTATION_RULE_NAME),
+        )],
+        vec![query_observer(QUERY_OP_ID)],
+    );
+
+    let Err(err) = engine.install_contract_package(package) else {
+        return Err("mismatched mutation rule op id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::MutationRuleOperationMismatch {
+            declared_op_id: MUTATION_OP_ID,
+            rule_op_id: Some(SECOND_MUTATION_OP_ID),
+            rule_name: SECOND_MUTATION_RULE_NAME,
+        }
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_artifact_verification_without_registration(
+) -> Result<(), String> {
+    let mut engine = engine();
+    let package = package_with_handlers(
+        package_identity(),
+        mismatched_verification_policy(),
+        vec![mutation_handler(MUTATION_OP_ID)],
+        vec![query_observer(QUERY_OP_ID)],
+    );
+
+    let Err(err) = engine.install_contract_package(package) else {
+        return Err("artifact verification mismatch must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::ArtifactRejected(_)
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_missing_join_fn_without_registration() -> Result<(), String> {
+    let mut engine = engine();
+    let mut rule = mutation_rule(MUTATION_RULE_NAME);
+    rule.conflict_policy = warp_core::ConflictPolicy::Join;
+    let package = package_with_handlers(
+        package_identity(),
+        verification_policy(),
+        vec![mutation_handler_with_rule(MUTATION_OP_ID, rule)],
+        vec![query_observer(QUERY_OP_ID)],
+    );
+
+    let Err(err) = engine.install_contract_package(package) else {
+        return Err("join policy without join fn must be rejected".to_owned());
+    };
+
+    assert!(matches!(err, InstalledContractPackageError::MissingJoinFn));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_duplicate_package() -> Result<(), String> {
+    let mut engine = engine();
+    let record = engine
+        .install_contract_package(package_with_ops(MUTATION_OP_ID, QUERY_OP_ID))
+        .map_err(|err| format!("initial package install failed: {err:?}"))?;
+
+    let Err(err) = engine.install_contract_package(package_with_ops(MUTATION_OP_ID, QUERY_OP_ID))
+    else {
+        return Err("duplicate package id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::DuplicatePackage { package_id }
+            if package_id == record.package_id
+    ));
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_duplicate_installed_operation_ids() -> Result<(), String> {
+    let mut engine = engine();
+    engine
+        .install_contract_package(package_with_ops(MUTATION_OP_ID, QUERY_OP_ID))
+        .map_err(|err| format!("initial package install failed: {err:?}"))?;
+
+    let mut identity = package_identity();
+    identity.package_version = "0.2.0";
+    let Err(err) = engine.install_contract_package(package_with_identity_ops(
+        identity,
+        MUTATION_OP_ID,
+        QUERY_OP_ID,
+    )) else {
+        return Err("duplicate installed mutation op id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::DuplicateInstalledMutationOperation {
+            op_id: MUTATION_OP_ID
+        }
+    ));
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_duplicate_installed_query_id() -> Result<(), String> {
+    let mut engine = engine();
+    engine
+        .install_contract_package(package_with_ops(MUTATION_OP_ID, QUERY_OP_ID))
+        .map_err(|err| format!("initial package install failed: {err:?}"))?;
+
+    let mut identity = package_identity();
+    identity.package_version = "0.2.0";
+    let Err(err) = engine.install_contract_package(package_with_identity_ops(
+        identity,
+        SECOND_MUTATION_OP_ID,
+        QUERY_OP_ID,
+    )) else {
+        return Err("duplicate installed query op id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::DuplicateInstalledQueryOperation { op_id: QUERY_OP_ID }
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(SECOND_MUTATION_OP_ID),
+        None
+    );
     Ok(())
 }

--- a/crates/warp-core/tests/installed_contract_registry_tests.rs
+++ b/crates/warp-core/tests/installed_contract_registry_tests.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Installed contract package registry boundary tests.
+#![cfg(feature = "native_rule_bootstrap")]
+
+use echo_registry_api::{
+    ArgDef, ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, RegistryInfo,
+    RegistryProvider,
+};
+use warp_core::{
+    make_node_id, make_type_id, AuthoredObserverPlan, ContractMutationHandler,
+    ContractPackageIdentity, ContractQueryObserver, ContractQueryObserverResult, EngineBuilder,
+    GraphStore, GraphView, InstalledContractPackage, InstalledContractPackageError, NodeId,
+    NodeRecord, ObservationAt, ObservationCoordinate, ObservationError, ObservationFrame,
+    ObservationPayload, ObservationProjection, ObservationRequest, ObservationService,
+    ObserverPlanId, PatternGraph, ProvenanceService, RewriteRule, TickDelta, WorldlineId,
+    WorldlineRuntime, WorldlineState,
+};
+
+const SCHEMA_SHA256_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const MUTATION_OP_ID: u32 = 1001;
+const QUERY_OP_ID: u32 = 1002;
+const UNKNOWN_OP_ID: u32 = 9999;
+
+static INCREMENT_ARGS: &[ArgDef] = &[ArgDef {
+    name: "input",
+    ty: "IncrementInput",
+    required: true,
+    list: false,
+}];
+
+static OPS: &[OpDef] = &[
+    OpDef {
+        kind: OpKind::Mutation,
+        name: "increment",
+        op_id: MUTATION_OP_ID,
+        args: INCREMENT_ARGS,
+        result_ty: "CounterValue",
+        directives_json: "{}",
+        footprint_certificate: None,
+    },
+    OpDef {
+        kind: OpKind::Query,
+        name: "counterValue",
+        op_id: QUERY_OP_ID,
+        args: &[],
+        result_ty: "CounterValue",
+        directives_json: "{}",
+        footprint_certificate: None,
+    },
+];
+
+struct StaticRegistry;
+
+impl RegistryProvider for StaticRegistry {
+    fn info(&self) -> RegistryInfo {
+        RegistryInfo {
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+        }
+    }
+
+    fn op_by_id(&self, op_id: u32) -> Option<&'static OpDef> {
+        OPS.iter().find(|op| op.op_id == op_id)
+    }
+
+    fn all_ops(&self) -> &'static [OpDef] {
+        OPS
+    }
+
+    fn all_enums(&self) -> &'static [echo_registry_api::EnumDef] {
+        &[]
+    }
+
+    fn all_objects(&self) -> &'static [ObjectDef] {
+        &[]
+    }
+}
+
+fn engine() -> warp_core::Engine {
+    let mut store = GraphStore::default();
+    let root = make_node_id("root");
+    store.insert_node(
+        root,
+        NodeRecord {
+            ty: make_type_id("world"),
+        },
+    );
+    EngineBuilder::new(store, root).workers(1).build()
+}
+
+fn package_identity() -> ContractPackageIdentity<'static> {
+    ContractPackageIdentity {
+        package_name: "toy-counter",
+        package_version: "0.1.0",
+        artifact_hash_hex: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }
+}
+
+fn verification_policy() -> ContractArtifactVerificationPolicy<'static> {
+    ContractArtifactVerificationPolicy {
+        codec_id: "cbor-canon-v1",
+        registry_version: 1,
+        schema_sha256_hex: SCHEMA_SHA256_HEX,
+        footprint_certificates: &[],
+        require_mutation_footprint_certificates: false,
+    }
+}
+
+fn mutation_rule(name: &'static str) -> RewriteRule {
+    fn matches(_: GraphView<'_>, _: &NodeId) -> bool {
+        false
+    }
+    fn execute(_: GraphView<'_>, _: &NodeId, _: &mut TickDelta) {}
+    fn footprint(_: GraphView<'_>, _: &NodeId) -> warp_core::Footprint {
+        warp_core::Footprint::default()
+    }
+
+    RewriteRule {
+        id: make_type_id(name).0,
+        name,
+        left: PatternGraph { nodes: vec![] },
+        matcher: matches,
+        executor: execute,
+        compute_footprint: footprint,
+        factor_mask: 0,
+        conflict_policy: warp_core::ConflictPolicy::Abort,
+        join_fn: None,
+    }
+}
+
+fn query_observer(query_id: u32) -> ContractQueryObserver {
+    ContractQueryObserver::new(query_id, observer_plan(), |_context| {
+        Ok(ContractQueryObserverResult::complete(b"value=42".to_vec()))
+    })
+}
+
+fn observer_plan() -> AuthoredObserverPlan {
+    AuthoredObserverPlan {
+        plan_id: ObserverPlanId::from_bytes([1; 32]),
+        artifact_hash: [2; 32],
+        schema_hash: [3; 32],
+        state_schema_hash: [4; 32],
+        update_law_hash: [5; 32],
+        emission_law_hash: [6; 32],
+    }
+}
+
+fn package_with_ops(mutation_op_id: u32, query_op_id: u32) -> InstalledContractPackage<'static> {
+    static REGISTRY: StaticRegistry = StaticRegistry;
+    InstalledContractPackage {
+        identity: package_identity(),
+        registry: &REGISTRY,
+        verification_policy: verification_policy(),
+        mutation_handlers: vec![ContractMutationHandler {
+            op_id: mutation_op_id,
+            rule: mutation_rule("cmd/contract/toy-counter/increment"),
+        }],
+        query_observers: vec![query_observer(query_op_id)],
+    }
+}
+
+fn runtime_with_worldline() -> Result<(WorldlineRuntime, ProvenanceService, WorldlineId), String> {
+    let mut runtime = WorldlineRuntime::new();
+    let worldline_id = WorldlineId::from_bytes([1; 32]);
+    runtime
+        .register_worldline(worldline_id, WorldlineState::empty())
+        .map_err(|err| format!("worldline registration failed: {err:?}"))?;
+    let state = runtime
+        .worldlines()
+        .get(&worldline_id)
+        .ok_or("registered worldline missing")?
+        .state()
+        .clone();
+    let mut provenance = ProvenanceService::new();
+    provenance
+        .register_worldline(worldline_id, &state)
+        .map_err(|err| format!("provenance registration failed: {err:?}"))?;
+    Ok((runtime, provenance, worldline_id))
+}
+
+fn query_request(worldline_id: WorldlineId, query_id: u32) -> Result<ObservationRequest, String> {
+    ObservationRequest::builtin_one_shot(
+        ObservationCoordinate {
+            worldline_id,
+            at: ObservationAt::Frontier,
+        },
+        ObservationFrame::QueryView,
+        ObservationProjection::Query {
+            query_id,
+            vars_bytes: Vec::new(),
+        },
+    )
+    .map_err(|err| format!("query request construction failed: {err:?}"))
+}
+
+#[test]
+fn installed_contract_package_binds_supported_mutation_and_query() -> Result<(), String> {
+    let mut engine = engine();
+    let record = engine
+        .install_contract_package(package_with_ops(MUTATION_OP_ID, QUERY_OP_ID))
+        .map_err(|err| format!("supported package should install: {err:?}"))?;
+
+    assert_eq!(record.package_name, "toy-counter");
+    assert_eq!(record.package_version, "0.1.0");
+    assert_eq!(record.registry_info.schema_sha256_hex, SCHEMA_SHA256_HEX);
+    assert_eq!(record.mutation_op_ids, vec![MUTATION_OP_ID]);
+    assert_eq!(record.query_op_ids, vec![QUERY_OP_ID]);
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        Some(&record.package_id)
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        Some(&record.package_id)
+    );
+
+    let (runtime, provenance, worldline_id) = runtime_with_worldline()?;
+    let observed = ObservationService::observe(
+        &runtime,
+        &provenance,
+        &engine,
+        query_request(worldline_id, QUERY_OP_ID)?,
+    )
+    .map_err(|err| format!("installed query observer should serve supported query: {err:?}"))?;
+
+    assert_eq!(
+        observed.payload,
+        ObservationPayload::QueryBytes(b"value=42".to_vec())
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_unknown_mutation_before_registration() -> Result<(), String> {
+    let mut engine = engine();
+
+    let Err(err) = engine.install_contract_package(package_with_ops(UNKNOWN_OP_ID, QUERY_OP_ID))
+    else {
+        return Err("unknown mutation op id must be rejected before install".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::UnknownMutationOperation {
+            op_id: UNKNOWN_OP_ID
+        }
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(UNKNOWN_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_query_kind_mismatch_before_observer_install(
+) -> Result<(), String> {
+    let mut engine = engine();
+
+    let Err(err) =
+        engine.install_contract_package(package_with_ops(MUTATION_OP_ID, MUTATION_OP_ID))
+    else {
+        return Err("query observer for mutation op id must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::QueryOperationKindMismatch {
+            op_id: MUTATION_OP_ID,
+            actual: OpKind::Mutation,
+        }
+    ));
+
+    let (runtime, provenance, worldline_id) = runtime_with_worldline()?;
+    let Err(err) = ObservationService::observe(
+        &runtime,
+        &provenance,
+        &engine,
+        query_request(worldline_id, MUTATION_OP_ID)?,
+    ) else {
+        return Err("rejected observer must not be installed".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        ObservationError::UnsupportedQuery {
+            query_id: MUTATION_OP_ID
+        }
+    ));
+    Ok(())
+}

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -194,9 +194,14 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 The next slice should prove installed contract mutation dispatch through the
 normal witnessed intent and scheduler-owned tick path. Echo now has a single
-installed package surface that binds schema hash, artifact hash, codec identity,
-supported operation ids, mutation handlers, and query observers before those
-handlers or observers install into `Engine`.
+registry-verified installed package surface that binds schema hash, artifact
+hash, codec identity, supported operation ids, mutation handlers, and query
+observers before those handlers or observers install into `Engine`.
+
+Direct `native_rule_bootstrap` registration remains an internal fixture and
+transitional engine-test path. It does not provide package identity, registry
+verification, or generated operation/package binding guarantees. Contract-host
+proofs that need those guarantees should install through the package boundary.
 
 The next proof should start from canonical generated EINT bytes, pass through
 witnessed ingress and package-supported operation lookup, stage through the

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -175,7 +175,7 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 | TicketedRuntimeIngress         | Complete | Ticketed ingress stages admitted submissions through runtime-owner authority without ticking.              |
 | ReceiptCorrelation             | Complete | Scheduler-owned tick receipts correlate back to ticketed ingress, tickets, and submissions.                |
 | IntentOutcomeObservation       | Partial  | Core exposes zero-write pending/decided observation; domain-level applied/rejected semantics remain later. |
-| InstalledContractHostDispatch  | Partial  | Core and Wesley helper seams exist; installed package/registry gating is next.                             |
+| InstalledContractHostDispatch  | Partial  | Installed package registry gating exists; full normal intent/tick dispatch proof remains next.             |
 | ConflictPolicy / ExplicitRetry | Partial  | Conflict rejection is explicit; user-facing retry policy is still future work.                             |
 | QueryViewObserverBridge        | Complete | Core routes QueryView/Query to installed observers, and Wesley emits host helper constructors.             |
 | Replay/DIND proof              | Later    | End-to-end replay proof for the full intent/admission/tick pipeline remains future work.                   |
@@ -192,12 +192,16 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 ## Immediate Next Slice
 
-The next slice should add an installed contract registry boundary. Wesley now
-emits both write-side mutation host helpers and read-side query observer host
-helpers; Echo needs a single installed package surface that binds schema hash,
-artifact hash, codec identity, supported operation ids, mutation handlers, and
-query observers before contract operations become runtime-visible work or
-reads.
+The next slice should prove installed contract mutation dispatch through the
+normal witnessed intent and scheduler-owned tick path. Echo now has a single
+installed package surface that binds schema hash, artifact hash, codec identity,
+supported operation ids, mutation handlers, and query observers before those
+handlers or observers install into `Engine`.
+
+The next proof should start from canonical generated EINT bytes, pass through
+witnessed ingress and package-supported operation lookup, stage through the
+existing ticketed runtime path, and run the installed mutation rule only during a
+scheduler-owned tick.
 
 That slice must not implement streaming subscriptions, automatic retry,
 execution outside scheduler-owned ticks, or wall-clock cadence semantics.

--- a/docs/architecture/application-contract-hosting.md
+++ b/docs/architecture/application-contract-hosting.md
@@ -148,6 +148,12 @@ surface.
 **ObservationRequest** is the generic read request. Generated query helpers map
 contract query operations onto this request shape when possible.
 
+**Installed contract package** is the runtime-owner installation unit that binds
+generated registry metadata, schema hash, package artifact hash, codec identity,
+supported operation ids, mutation handler rules, and read-only query observers
+before those handlers or observers are installed into `Engine`. Unsupported
+operation ids and mutation/query kind mismatches fail at this package boundary.
+
 **ReadingEnvelope** is the read-side evidence envelope. It carries observer
 plan, basis, witness refs, budget posture, rights posture, and residual,
 plural, or obstructed posture. The current family boundary is named in

--- a/docs/architecture/application-contract-hosting.md
+++ b/docs/architecture/application-contract-hosting.md
@@ -148,11 +148,17 @@ surface.
 **ObservationRequest** is the generic read request. Generated query helpers map
 contract query operations onto this request shape when possible.
 
-**Installed contract package** is the runtime-owner installation unit that binds
-generated registry metadata, schema hash, package artifact hash, codec identity,
-supported operation ids, mutation handler rules, and read-only query observers
-before those handlers or observers are installed into `Engine`. Unsupported
-operation ids and mutation/query kind mismatches fail at this package boundary.
+**Installed contract package** is the registry-verified runtime-owner
+installation unit that binds generated registry metadata, schema hash, package
+artifact hash, codec identity, supported operation ids, mutation handler rules,
+and read-only query observers before those handlers or observers are installed
+into `Engine`. Unsupported operation ids, mutation/query kind mismatches,
+mutation rule/op-id mismatches, and duplicate package rule identities fail at
+this package boundary before the engine mutates.
+
+Direct `native_rule_bootstrap` rule or observer registration remains an internal
+fixture and transitional engine-test path. It does not provide package identity,
+registry verification, or generated operation/package binding guarantees.
 
 **ReadingEnvelope** is the read-side evidence envelope. It carries observer
 plan, basis, witness refs, budget posture, rights posture, and residual,

--- a/docs/design/warp-optic-implementation-map.md
+++ b/docs/design/warp-optic-implementation-map.md
@@ -223,7 +223,7 @@ Implementation improvements over the paper examples that must be preserved:
 
 ## Next Code Slice
 
-The next code slice is the Installed Contract Registry Boundary:
+The installed contract package registry boundary now exists:
 
 ```text
 schema identity
@@ -237,5 +237,11 @@ schema identity
 -> one installed contract package boundary
 ```
 
-Unsupported operations should be rejected at this package boundary before they
-become runtime-visible work or accepted reads.
+Unsupported operations are rejected at this package boundary before handlers or
+observers are installed into `Engine`.
+
+The next code slice is installed contract mutation dispatch through the normal
+intent/ticket/runtime/scheduler path. That slice should prove generated EINT
+bytes can reach an installed package-supported mutation handler during
+scheduler-owned execution without turning application dispatch into a tick or a
+synchronous domain RPC.

--- a/docs/design/warp-optic-implementation-map.md
+++ b/docs/design/warp-optic-implementation-map.md
@@ -240,6 +240,12 @@ schema identity
 Unsupported operations are rejected at this package boundary before handlers or
 observers are installed into `Engine`.
 
+The package boundary also rejects mutation rules whose generated command-rule
+name does not bind the declared mutation op id, and it preflights duplicate
+package rule identities before mutating engine state. Direct
+`native_rule_bootstrap` registration remains an internal fixture path without
+registry/package identity guarantees.
+
 The next code slice is installed contract mutation dispatch through the normal
 intent/ticket/runtime/scheduler path. That slice should prove generated EINT
 bytes can reach an installed package-supported mutation handler during

--- a/docs/method/backlog/asap/PLATFORM_contract-queryview-observer-bridge.md
+++ b/docs/method/backlog/asap/PLATFORM_contract-queryview-observer-bridge.md
@@ -3,8 +3,8 @@
 
 # Contract QueryView Observer Bridge
 
-Status: core observer bridge and generated query helper checkpoint complete;
-installed contract registry boundary remains.
+Status: core observer bridge, generated query helper checkpoint, and installed
+contract package registry boundary complete.
 
 Depends on:
 
@@ -76,9 +76,8 @@ adding application nouns to core.
 
 ## Remaining work
 
-- Contract-host packaging still needs an installed registry boundary that
-  rejects unsupported contract operations before they become runtime-visible
-  work or reads.
+- Contract-aware readings still need package identity carried through the
+  evidence surface used by product-facing consumers.
 
 ## Non-goals
 

--- a/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
+++ b/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
@@ -3,14 +3,14 @@
 
 # Installed Wesley Contract Host Dispatch
 
-Status: core contract-host seam and generated handler-rule helpers exist;
-installed registry packaging remains.
+Status: installed package registry boundary exists; full normal intent/tick
+dispatch proof remains.
 
 Depends on:
 
 - [0018 - Contract-Hosted File History Substrate](../../../design/0018-contract-hosted-file-history-substrate/design.md)
 - [0017 - Authenticated Wesley Intent Admission Posture](../../../design/0017-authenticated-wesley-intent-admission-posture/design.md)
-- [Wesley to Echo toy contract proof](../up-next/PLATFORM_wesley-to-echo-toy-contract-proof.md)
+- [0016 - Wesley To Echo Toy Contract Proof](../../../design/0016-wesley-to-echo-toy-contract-proof/design.md)
 
 ## Why now
 
@@ -39,9 +39,14 @@ rules for that seam:
 - base runtime-ingress read footprint helpers;
 - rule constructors that accept host-supplied executor and footprint functions.
 
-Remaining work is packaging integration: Echo does not yet have an installed
-contract registry boundary that rejects unsupported contract operations before
-they become scheduler-visible work.
+`warp-core` now has an installed contract package boundary that verifies a
+generated `RegistryProvider`, binds package identity, mutation handler rules,
+and query observers, and rejects unsupported operations before handlers or
+observers install into `Engine`.
+
+Remaining work is dispatch integration: prove a generated EINT submitted through
+normal Echo ingress reaches the installed mutation handler only through the
+witnessed/ticketed/scheduler-owned path.
 
 ## RED
 
@@ -58,10 +63,8 @@ Add the minimal generic installed-contract host seam needed to pass the test.
 
 Candidate surface:
 
-- installed contract registry;
-- op-id lookup;
+- package-supported op-id lookup during ingress/admission/runtime handoff;
 - generated vars decode;
-- generic mutation handler trait;
 - artifact/schema identity attached to receipt or ingress metadata.
 
 ## Acceptance criteria

--- a/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
+++ b/docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md
@@ -39,10 +39,15 @@ rules for that seam:
 - base runtime-ingress read footprint helpers;
 - rule constructors that accept host-supplied executor and footprint functions.
 
-`warp-core` now has an installed contract package boundary that verifies a
-generated `RegistryProvider`, binds package identity, mutation handler rules,
-and query observers, and rejects unsupported operations before handlers or
-observers install into `Engine`.
+`warp-core` now has a registry-verified installed contract package boundary that
+verifies a generated `RegistryProvider`, binds package identity, mutation
+handler rules, and query observers, and rejects unsupported operations,
+mutation rule/op-id mismatches, duplicate package operation ids, and duplicate
+package rule identities before handlers or observers install into `Engine`.
+
+Direct `native_rule_bootstrap` registration remains available only as an
+internal fixture and transitional engine-test path. It is not the registry
+package boundary and does not provide package identity guarantees.
 
 Remaining work is dispatch integration: prove a generated EINT submitted through
 normal Echo ingress reaches the installed mutation handler only through the

--- a/docs/method/backlog/asap/PLATFORM_wesley-compiled-contract-hosting-doctrine.md
+++ b/docs/method/backlog/asap/PLATFORM_wesley-compiled-contract-hosting-doctrine.md
@@ -4,8 +4,9 @@
 # Wesley Compiled Contract Hosting Doctrine
 
 Status: design packet accepted; implementation advanced through contract-host
-mutation helpers and query observer helpers. Current blocker is the installed
-contract registry boundary.
+mutation helpers, query observer helpers, and the installed contract package
+registry boundary. Current blocker is normal installed mutation dispatch through
+witnessed ingress and scheduler-owned ticks.
 
 Depends on:
 
@@ -47,8 +48,7 @@ card was created, Echo has also landed:
 - core QueryView/Query observer routing;
 - `echo-wesley-gen --contract-host` query observer helper constructors.
 
-The active implementation gap is now one installed package/registry boundary
-that binds:
+Echo now has one installed package/registry boundary that binds:
 
 - EINT v1
 - `RegistryInfo`
@@ -63,7 +63,7 @@ that binds:
 - authored observer plan identities
 - contract package/version identity
 
-before contract operations become runtime-visible work or accepted reads.
+before handlers or observers install into `Engine`.
 
 The current WARP/Echo noun map lives in
 `docs/design/warp-optic-implementation-map.md`. The current optic admission
@@ -78,8 +78,9 @@ slice -> lower -> witness -> retain
 ## Done looks like
 
 - The accepted design doc remains linked from this card.
-- The current next implementation card is the installed contract registry
-  boundary, not more Wesley generation or another doctrine packet.
+- The current next implementation card is installed contract mutation dispatch
+  through the normal witnessed intent and scheduler-owned tick path, not more
+  Wesley generation or another doctrine packet.
 - Echo still must not add text-editor APIs, Graft APIs, or consumer-specific
   ABI methods.
 - Built-in substrate/debug observers remain distinct from contract-defined

--- a/docs/method/backlog/asap/PLATFORM_wesley-compiled-contract-hosting-doctrine.md
+++ b/docs/method/backlog/asap/PLATFORM_wesley-compiled-contract-hosting-doctrine.md
@@ -63,7 +63,10 @@ Echo now has one installed package/registry boundary that binds:
 - authored observer plan identities
 - contract package/version identity
 
-before handlers or observers install into `Engine`.
+before handlers or observers install into `Engine`. Direct
+`native_rule_bootstrap` registration remains an internal fixture and
+transitional engine-test path; it does not provide registry/package identity
+guarantees.
 
 The current WARP/Echo noun map lives in
 `docs/design/warp-optic-implementation-map.md`. The current optic admission


### PR DESCRIPTION
## Summary

- Add a `warp-core` installed contract package boundary that verifies generated `RegistryProvider` metadata with `echo-registry-api` before installing host code.
- Bind package identity, schema/codec/artifact metadata, supported mutation operation ids, mutation handler rules, supported query operation ids, and read-only query observers as one installed package surface.
- Reject unknown operation ids, mutation/query kind mismatches, duplicate package op ids, duplicate installed op ids, and rule/observer conflicts before mutating `Engine` install state.
- Update BEARING, contract-hosting docs, backlog cards, and changelog so the next slice moves to normal installed mutation dispatch through witnessed ingress and scheduler-owned ticks.

## Non-goals

- No dynamic plugin loading.
- No application tick authority.
- No streaming subscriptions.
- No application/domain nouns in `warp-core`.
- No synchronous application dispatch execution.

## Validation

- RED witness before implementation: `cargo test -p warp-core --features native_rule_bootstrap --test installed_contract_registry_tests` failed because the boundary and dependency did not exist.
- `cargo test -p warp-core --features native_rule_bootstrap --test installed_contract_registry_tests`
- `cargo check -p warp-core`
- `cargo check -p warp-core --features native_rule_bootstrap`
- `cargo clippy -p warp-core --features native_rule_bootstrap --test installed_contract_registry_tests -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p warp-core --no-deps --features native_rule_bootstrap`
- `cargo fmt --check`
- `git diff --check`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/architecture/application-contract-hosting.md docs/design/warp-optic-implementation-map.md docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md docs/method/backlog/asap/PLATFORM_contract-queryview-observer-bridge.md docs/method/backlog/asap/PLATFORM_wesley-compiled-contract-hosting-doctrine.md`
- `cargo xtask lint-dead-refs --file docs/BEARING.md --file docs/architecture/application-contract-hosting.md --file docs/design/warp-optic-implementation-map.md --file docs/method/backlog/asap/PLATFORM_installed-wesley-contract-host-dispatch.md --file docs/method/backlog/asap/PLATFORM_contract-queryview-observer-bridge.md --file docs/method/backlog/asap/PLATFORM_wesley-compiled-contract-hosting-doctrine.md`
- Pre-push hook passed, including affected `warp-core` library tests and `installed_contract_registry_tests`.
