### PR TITLE
feat(core): advance v0.1 local contract host release bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   pipeline replay tests, reference trusted host loop test, and serious external
   consumer fixture without requiring developers to run the full DIND suite for
   normal local iteration.
+- The docs now include an executable local contract-host quickstart and a
+  v0.1.0 authority-boundary audit. The quickstart points developers at
+  `cargo xtask test-slice contract-path-release`, names the app-facing and
+  trusted-host APIs, and documents compatibility and retention boundaries. The
+  audit records current evidence that application code cannot tick, stage
+  ingress, install packages, or recover scheduler faults through the app
+  surface.
 - `echo-cas` semantic retention now supports bounded byte-range lookup through
   `RetainedBlobIndex::load_range(...)`. Range lookup requires the exact
   semantic coordinate, enforces the caller's byte budget, and returns typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   package install; and installed contract receipt/reading evidence cites the
   verified compatibility metadata without granting execution or query
   authority.
+- `warp-core` now exposes a reference trusted runtime host loop for the local
+  contract-host path. `TrustedRuntimeHost` owns generated package installation,
+  ticketed ingress staging, scheduler passes, until-idle policy, and read-only
+  observation service access, while `TrustedRuntimeApp` exposes app-facing
+  submit/observe/query methods without tick, package-install, ingress-staging,
+  or fault-recovery authority.
 - `warp-core` now has an external contract proof fixture for the v0.1.0 local
   contract-host path. The fixture installs a generated-style package with a
   mutation, conflict-capable mutation, and QueryView query; submits non-trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,6 +559,9 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
 
 ### Fixed
 
+- `warp-core` witnessed-submission persistence snapshots now fail closed when
+  a submission lacks retained canonical envelope material instead of silently
+  dropping replayed submissions from the host-persistable image.
 - Local pre-push verification now includes the changed-file fingerprint in its
   cache key, skips nested integration-test helper modules instead of inventing
   fake `--test mod` targets, and only emits `<module>::tests` filters for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   missing retention, stale basis, residual readings, and budget limits without
   importing application-domain failure names into core or treating runtime
   faults as lawful domain rejections.
+- `warp-core` now exposes retained evidence references and
+  missing-retention posture for contract-hosted evidence. `RetainedEvidenceRef`
+  binds installed contract identity, retained role, semantic digest, content
+  hash, and byte length; `RetainedEvidencePosture` returns either available
+  evidence or typed `MissingRetention` obstruction. CAS hashes remain byte
+  identities only and cannot stand in for semantic reading or evidence
+  coordinates.
 - `warp-core` now has an external contract proof fixture for the v0.1.0 local
   contract-host path. The fixture installs a generated-style package with a
   mutation, conflict-capable mutation, and QueryView query; submits non-trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   evidence or typed `MissingRetention` obstruction. CAS hashes remain byte
   identities only and cannot stand in for semantic reading or evidence
   coordinates.
+- `warp-core` now exposes a local witnessed-submission persistence shell.
+  `WitnessedSubmissionPersistenceSnapshot` pairs accepted submission records
+  with canonical ingress envelopes so hosts can persist accepted-but-not-yet-
+  ticked work and restore duplicate detection plus envelope material without
+  staging scheduler-visible inbox work, ticking, dispatching handlers, or
+  executing contracts.
 - `warp-core` now has an external contract proof fixture for the v0.1.0 local
   contract-host path. The fixture installs a generated-style package with a
   mutation, conflict-capable mutation, and QueryView query; submits non-trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
   ticked work and restore duplicate detection plus envelope material without
   staging scheduler-visible inbox work, ticking, dispatching handlers, or
   executing contracts.
+- `warp-core` now exposes a local product-facing intent outcome surface.
+  `submit_app_intent(...)` returns an `IntentSubmissionHandle` without ticking
+  or staging runtime ingress, and `observe_app_intent_outcome(...)` maps
+  internal scheduler correlation into `IntentOutcome::{Unknown, Pending,
+Applied, Rejected, Obstructed}` with receipt evidence and typed contract
+  obstruction posture.
 - `warp-core` now has an external contract proof fixture for the v0.1.0 local
   contract-host path. The fixture installs a generated-style package with a
   mutation, conflict-capable mutation, and QueryView query; submits non-trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@
   internal scheduler correlation into `IntentOutcome::{Unknown, Pending,
 Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   obstruction posture.
+- `echo-registry-api`, `echo-wesley-gen`, and `warp-core` now enforce local
+  contract/API compatibility at the installed package boundary. Generated
+  registries carry Echo contract ABI, Wesley generator, and contract-host
+  helper API versions; host verification policy rejects version drift before
+  package install; and installed contract receipt/reading evidence cites the
+  verified compatibility metadata without granting execution or query
+  authority.
 - `warp-core` now has an external contract proof fixture for the v0.1.0 local
   contract-host path. The fixture installs a generated-style package with a
   mutation, conflict-capable mutation, and QueryView query; submits non-trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   through `echo-cas` semantic coordinates; and replays witnessed submission
   history to the same observed intent outcome. The fixture keeps application
   nouns inside the test package and generated payload shape, not in Echo core.
+- `warp-core` now has a serious external-consumer-shaped contract fixture for
+  the local contract-host path. The fixture uses hot-text-style document edit
+  names only in test code, installs through the generic package boundary,
+  submits through the app-facing host handle, produces a footprint-conflict
+  rejection for overlapping edits, observes a bounded QueryView reading, and
+  retains both reading payload and receipt evidence through semantic
+  coordinates.
 - `echo-cas` semantic retention now supports bounded byte-range lookup through
   `RetainedBlobIndex::load_range(...)`. Range lookup requires the exact
   semantic coordinate, enforces the caller's byte budget, and returns typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Added
 
+- `warp-core` now exposes a generic contract obstruction taxonomy for
+  product-facing contract-host surfaces. `ContractObstructionKind`,
+  `ContractObstructionSubject`, and `ContractObstruction` classify unsupported
+  operations, unsupported queries, admission obstructions, runtime faults,
+  missing retention, stale basis, residual readings, and budget limits without
+  importing application-domain failure names into core or treating runtime
+  faults as lawful domain rejections.
 - `warp-core` now has an external contract proof fixture for the v0.1.0 local
   contract-host path. The fixture installs a generated-style package with a
   mutation, conflict-capable mutation, and QueryView query; submits non-trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   rejection for overlapping edits, observes a bounded QueryView reading, and
   retains both reading payload and receipt evidence through semantic
   coordinates.
+- `xtask test-slice` now includes `contract-path-release`, a narrow local
+  v0.1 contract-host release witness. The slice runs the installed contract
+  pipeline replay tests, reference trusted host loop test, and serious external
+  consumer fixture without requiring developers to run the full DIND suite for
+  normal local iteration.
 - `echo-cas` semantic retention now supports bounded byte-range lookup through
   `RetainedBlobIndex::load_range(...)`. Range lookup requires the exact
   semantic coordinate, enforces the caller's byte budget, and returns typed

--- a/crates/echo-registry-api/README.md
+++ b/crates/echo-registry-api/README.md
@@ -18,6 +18,9 @@ Hosts can call `verify_contract_artifact(...)` against a generated
 `RegistryProvider` before deciding how much trust to assign to a
 Wesley-generated artifact. The verification policy compares:
 
+- Echo contract ABI version;
+- Wesley generator version;
+- contract-host helper API version;
 - codec id;
 - registry layout version;
 - schema hash;
@@ -34,3 +37,7 @@ posture, not merely on successful metadata verification.
 The verifier returns a typed `ContractArtifactRejection` on mismatch. It does
 not validate application payload semantics or execute an operation; generated
 application adapters still own domain validation before packing EINT bytes.
+
+Generated compatibility metadata is install-time evidence only. It does not
+grant execution authority, query rights, or scheduler control, and it does not
+replace semantic reading identity.

--- a/crates/echo-registry-api/src/lib.rs
+++ b/crates/echo-registry-api/src/lib.rs
@@ -8,15 +8,26 @@
 
 #![no_std]
 
+/// Local contract ABI version supported by this registry API.
+pub const ECHO_CONTRACT_ABI_VERSION: u32 = 1;
+/// Generated contract-host helper API version supported by Echo.
+pub const CONTRACT_HOST_HELPER_API_VERSION: u32 = 1;
+
 /// Codec identifier used by the registry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RegistryInfo {
+    /// Echo contract ABI version targeted by the generated artifact.
+    pub echo_abi_version: u32,
     /// Canonical codec identifier (e.g., "cbor-canon-v1").
     pub codec_id: &'static str,
     /// Registry schema version for breaking changes in layout.
     pub registry_version: u32,
     /// Hex-encoded schema hash (lowercase, 64 chars).
     pub schema_sha256_hex: &'static str,
+    /// Wesley generator version that emitted this registry.
+    pub wesley_generator_version: &'static str,
+    /// Generated contract-host helper API version.
+    pub helper_api_version: u32,
 }
 
 /// Trust posture assigned after a generated contract artifact has been verified.
@@ -45,12 +56,18 @@ pub struct ExpectedFootprintCertificate<'a> {
 /// Host policy for verifying a generated contract artifact before admission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContractArtifactVerificationPolicy<'a> {
+    /// Expected Echo contract ABI version.
+    pub echo_abi_version: u32,
     /// Expected codec identifier for the generated artifact.
     pub codec_id: &'a str,
     /// Expected registry layout version for the generated artifact.
     pub registry_version: u32,
     /// Expected schema hash for the generated artifact.
     pub schema_sha256_hex: &'a str,
+    /// Expected Wesley generator version.
+    pub wesley_generator_version: &'a str,
+    /// Expected contract-host helper API version.
+    pub helper_api_version: u32,
     /// Expected footprint certificates keyed by operation id.
     pub footprint_certificates: &'a [ExpectedFootprintCertificate<'a>],
     /// Require every mutation op to carry a footprint certificate named by this policy.
@@ -69,6 +86,13 @@ pub struct VerifiedContractArtifact {
 /// Rejection returned when a generated contract artifact fails verification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContractArtifactRejection<'a> {
+    /// The generated artifact targets a different Echo ABI version.
+    EchoAbiVersionMismatch {
+        /// Expected Echo ABI version.
+        expected: u32,
+        /// Actual Echo ABI version from the registry.
+        actual: u32,
+    },
     /// The registry codec id did not match host policy.
     CodecIdMismatch {
         /// Expected codec id.
@@ -89,6 +113,20 @@ pub enum ContractArtifactRejection<'a> {
         expected: &'a str,
         /// Actual schema hash from the registry.
         actual: &'static str,
+    },
+    /// The generated artifact came from an unsupported Wesley generator version.
+    WesleyGeneratorVersionMismatch {
+        /// Expected Wesley generator version.
+        expected: &'a str,
+        /// Actual Wesley generator version from the registry.
+        actual: &'static str,
+    },
+    /// The generated helper API version does not match Echo's contract-host API.
+    HelperApiVersionMismatch {
+        /// Expected helper API version.
+        expected: u32,
+        /// Actual helper API version from the registry.
+        actual: u32,
     },
     /// Host policy named an operation id that the registry does not contain.
     MissingOperation {
@@ -328,6 +366,12 @@ pub fn verify_contract_artifact<'a>(
     policy: &ContractArtifactVerificationPolicy<'a>,
 ) -> Result<VerifiedContractArtifact, ContractArtifactRejection<'a>> {
     let info = registry.info();
+    if info.echo_abi_version != policy.echo_abi_version {
+        return Err(ContractArtifactRejection::EchoAbiVersionMismatch {
+            expected: policy.echo_abi_version,
+            actual: info.echo_abi_version,
+        });
+    }
     if info.codec_id != policy.codec_id {
         return Err(ContractArtifactRejection::CodecIdMismatch {
             expected: policy.codec_id,
@@ -344,6 +388,18 @@ pub fn verify_contract_artifact<'a>(
         return Err(ContractArtifactRejection::SchemaHashMismatch {
             expected: policy.schema_sha256_hex,
             actual: info.schema_sha256_hex,
+        });
+    }
+    if info.wesley_generator_version != policy.wesley_generator_version {
+        return Err(ContractArtifactRejection::WesleyGeneratorVersionMismatch {
+            expected: policy.wesley_generator_version,
+            actual: info.wesley_generator_version,
+        });
+    }
+    if info.helper_api_version != policy.helper_api_version {
+        return Err(ContractArtifactRejection::HelperApiVersionMismatch {
+            expected: policy.helper_api_version,
+            actual: info.helper_api_version,
         });
     }
 
@@ -523,9 +579,12 @@ mod tests {
     impl RegistryProvider for StaticRegistry {
         fn info(&self) -> RegistryInfo {
             RegistryInfo {
+                echo_abi_version: 1,
                 codec_id: "cbor-canon-v1",
                 registry_version: 1,
                 schema_sha256_hex: SCHEMA_SHA256_HEX,
+                wesley_generator_version: "echo-wesley-gen/0.1.0",
+                helper_api_version: 1,
             }
         }
 
@@ -557,9 +616,12 @@ mod tests {
             artifact_hash_hex: Some(ARTIFACT_HASH_HEX),
         }];
         let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
             footprint_certificates: &expected_certificates,
             require_mutation_footprint_certificates: true,
         };
@@ -586,9 +648,12 @@ mod tests {
             artifact_hash_hex: Some(ARTIFACT_HASH_HEX),
         }];
         let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
             footprint_certificates: &expected_certificates,
             require_mutation_footprint_certificates: true,
         };
@@ -608,14 +673,92 @@ mod tests {
     }
 
     #[test]
+    fn verifier_rejects_echo_abi_version_mismatch() {
+        let registry = StaticRegistry {
+            ops: OPS_WITH_CERTIFICATE,
+        };
+        let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 2,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
+            footprint_certificates: &[],
+            require_mutation_footprint_certificates: false,
+        };
+
+        assert_eq!(
+            verify_contract_artifact(&registry, &policy),
+            Err(ContractArtifactRejection::EchoAbiVersionMismatch {
+                expected: 2,
+                actual: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_wesley_generator_version_mismatch() {
+        let registry = StaticRegistry {
+            ops: OPS_WITH_CERTIFICATE,
+        };
+        let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/9.9.9",
+            helper_api_version: 1,
+            footprint_certificates: &[],
+            require_mutation_footprint_certificates: false,
+        };
+
+        assert_eq!(
+            verify_contract_artifact(&registry, &policy),
+            Err(ContractArtifactRejection::WesleyGeneratorVersionMismatch {
+                expected: "echo-wesley-gen/9.9.9",
+                actual: "echo-wesley-gen/0.1.0",
+            })
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_helper_api_version_mismatch() {
+        let registry = StaticRegistry {
+            ops: OPS_WITH_CERTIFICATE,
+        };
+        let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 2,
+            footprint_certificates: &[],
+            require_mutation_footprint_certificates: false,
+        };
+
+        assert_eq!(
+            verify_contract_artifact(&registry, &policy),
+            Err(ContractArtifactRejection::HelperApiVersionMismatch {
+                expected: 2,
+                actual: 1,
+            })
+        );
+    }
+
+    #[test]
     fn verifier_does_not_compile_time_certify_empty_policy() {
         let registry = StaticRegistry {
             ops: OPS_QUERY_ONLY,
         };
         let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
             footprint_certificates: &[],
             require_mutation_footprint_certificates: false,
         };
@@ -635,9 +778,12 @@ mod tests {
             ops: OPS_WITH_CERTIFICATE,
         };
         let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
             footprint_certificates: &[],
             require_mutation_footprint_certificates: false,
         };
@@ -657,9 +803,12 @@ mod tests {
             ops: OPS_WITHOUT_CERTIFICATE,
         };
         let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
             footprint_certificates: &[],
             require_mutation_footprint_certificates: true,
         };
@@ -681,9 +830,12 @@ mod tests {
             ops: OPS_WITH_CERTIFICATE,
         };
         let policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
             footprint_certificates: &[],
             require_mutation_footprint_certificates: true,
         };

--- a/crates/echo-wasm-abi/src/kernel_port.rs
+++ b/crates/echo-wasm-abi/src/kernel_port.rs
@@ -1642,6 +1642,8 @@ pub enum ContractOperationKind {
 pub struct ContractEvidenceIdentity {
     /// Deterministic installed package id.
     pub package_id: Vec<u8>,
+    /// Echo contract ABI version verified at install time.
+    pub echo_abi_version: u32,
     /// Runtime package name chosen by the host.
     pub package_name: String,
     /// Runtime package version chosen by the host.
@@ -1652,6 +1654,10 @@ pub struct ContractEvidenceIdentity {
     pub codec_id: String,
     /// Registry version verified at install time.
     pub registry_version: u32,
+    /// Wesley generator version verified at install time.
+    pub wesley_generator_version: String,
+    /// Contract-host helper API version verified at install time.
+    pub helper_api_version: u32,
     /// Hex-encoded authored schema hash verified at install time.
     pub schema_sha256_hex: String,
     /// Generated operation/query id handled by this package.

--- a/crates/echo-wesley-gen/src/main.rs
+++ b/crates/echo-wesley-gen/src/main.rs
@@ -258,11 +258,15 @@ fn generate_rust(ir: &WesleyIR, args: &Args) -> Result<String> {
     let codec_id = ir.codec_id.as_deref().unwrap_or("cbor-canon-v1");
     let registry_version = ir.registry_version.unwrap_or(1);
     let generated_rust_artifact_hash = generated_rust_artifact_hash(ir, args)?;
+    let wesley_generator_version = format!("echo-wesley-gen/{}", env!("CARGO_PKG_VERSION"));
 
     tokens.extend(quote! {
         pub const SCHEMA_SHA256: &str = #schema_sha;
+        pub const ECHO_CONTRACT_ABI_VERSION: u32 = 1;
         pub const CODEC_ID: &str = #codec_id;
         pub const REGISTRY_VERSION: u32 = #registry_version;
+        pub const WESLEY_GENERATOR_VERSION: &str = #wesley_generator_version;
+        pub const CONTRACT_HOST_HELPER_API_VERSION: u32 = 1;
         pub const GENERATED_RUST_ARTIFACT_HASH: &str = #generated_rust_artifact_hash;
     });
 
@@ -975,9 +979,12 @@ fn generate_rust(ir: &WesleyIR, args: &Args) -> Result<String> {
             impl RegistryProvider for GeneratedRegistry {
                 fn info(&self) -> RegistryInfo {
                     RegistryInfo {
+                        echo_abi_version: ECHO_CONTRACT_ABI_VERSION,
                         codec_id: CODEC_ID,
                         registry_version: REGISTRY_VERSION,
                         schema_sha256_hex: SCHEMA_SHA256,
+                        wesley_generator_version: WESLEY_GENERATOR_VERSION,
+                        helper_api_version: CONTRACT_HOST_HELPER_API_VERSION,
                     }
                 }
 
@@ -1412,6 +1419,11 @@ fn validate_generated_item_names(ir: &WesleyIR) -> Result<()> {
     )?;
     record_generated_item(
         &mut top_level_items,
+        "ECHO_CONTRACT_ABI_VERSION",
+        "generated Echo contract ABI version constant",
+    )?;
+    record_generated_item(
+        &mut top_level_items,
         "CODEC_ID",
         "generated codec id constant",
     )?;
@@ -1419,6 +1431,16 @@ fn validate_generated_item_names(ir: &WesleyIR) -> Result<()> {
         &mut top_level_items,
         "REGISTRY_VERSION",
         "generated registry version constant",
+    )?;
+    record_generated_item(
+        &mut top_level_items,
+        "WESLEY_GENERATOR_VERSION",
+        "generated Wesley generator version constant",
+    )?;
+    record_generated_item(
+        &mut top_level_items,
+        "CONTRACT_HOST_HELPER_API_VERSION",
+        "generated contract-host helper API version constant",
     )?;
 
     for type_def in &ir.types {

--- a/crates/echo-wesley-gen/tests/generation.rs
+++ b/crates/echo-wesley-gen/tests/generation.rs
@@ -108,8 +108,11 @@ type Mutation {
 
     assert!(stdout.contains("pub struct CounterValue"));
     assert!(stdout.contains("pub struct IncrementInput"));
+    assert!(stdout.contains("pub const ECHO_CONTRACT_ABI_VERSION: u32 = 1"));
     assert!(stdout.contains("pub const CODEC_ID: &str = \"cbor-canon-v1\""));
     assert!(stdout.contains("pub const REGISTRY_VERSION: u32 = 1"));
+    assert!(stdout.contains("pub const WESLEY_GENERATOR_VERSION: &str = \"echo-wesley-gen/0.1.0\""));
+    assert!(stdout.contains("pub const CONTRACT_HOST_HELPER_API_VERSION: u32 = 1"));
     assert!(stdout.contains("pub const OP_COUNTER_VALUE: u32 ="));
     assert!(stdout.contains("pub const OP_INCREMENT: u32 ="));
     assert!(stdout.contains("pub struct CounterValueVars"));
@@ -213,9 +216,10 @@ mod tests {
         counter_value_observation_request, counter_value_observation_request_raw_vars,
         counter_value_observe_optic_request, counter_value_observe_optic_request_raw_vars,
         encode_counter_value_vars, increment_dispatch_optic_intent_request, pack_increment_intent,
-        IncrementInput, CODEC_ID, OP_COUNTER_VALUE, OP_INCREMENT,
-        OP_INCREMENT_FOOTPRINT_ARTIFACT_HASH, OP_INCREMENT_FOOTPRINT_CERTIFICATE_HASH, REGISTRY,
-        REGISTRY_VERSION, SCHEMA_SHA256,
+        CONTRACT_HOST_HELPER_API_VERSION, ECHO_CONTRACT_ABI_VERSION, IncrementInput, CODEC_ID,
+        OP_COUNTER_VALUE, OP_INCREMENT, OP_INCREMENT_FOOTPRINT_ARTIFACT_HASH,
+        OP_INCREMENT_FOOTPRINT_CERTIFICATE_HASH, REGISTRY, REGISTRY_VERSION, SCHEMA_SHA256,
+        WESLEY_GENERATOR_VERSION,
     };
     use echo_registry_api::{
         verify_contract_artifact, ContractArtifactTrustPosture, ContractArtifactVerificationPolicy,
@@ -393,9 +397,12 @@ mod tests {
             artifact_hash_hex: Some(OP_INCREMENT_FOOTPRINT_ARTIFACT_HASH),
         }];
         let artifact_policy = ContractArtifactVerificationPolicy {
+            echo_abi_version: ECHO_CONTRACT_ABI_VERSION,
             codec_id: CODEC_ID,
             registry_version: REGISTRY_VERSION,
             schema_sha256_hex: SCHEMA_SHA256,
+            wesley_generator_version: WESLEY_GENERATOR_VERSION,
+            helper_api_version: CONTRACT_HOST_HELPER_API_VERSION,
             footprint_certificates: &expected_certificates,
             require_mutation_footprint_certificates: true,
         };

--- a/crates/warp-core/Cargo.toml
+++ b/crates/warp-core/Cargo.toml
@@ -95,14 +95,6 @@ required-features = ["native_rule_bootstrap"]
 name = "installed_contract_intent_pipeline_tests"
 required-features = ["native_rule_bootstrap", "host_test"]
 
-[[test]]
-name = "trusted_runtime_host_loop_tests"
-required-features = ["native_rule_bootstrap", "trusted_runtime"]
-
-[[test]]
-name = "external_consumer_contract_fixture_tests"
-required-features = ["native_rule_bootstrap", "trusted_runtime"]
-
 [build-dependencies]
 blake3 = "1.0"
 

--- a/crates/warp-core/Cargo.toml
+++ b/crates/warp-core/Cargo.toml
@@ -99,6 +99,10 @@ required-features = ["native_rule_bootstrap", "host_test"]
 name = "trusted_runtime_host_loop_tests"
 required-features = ["native_rule_bootstrap", "trusted_runtime"]
 
+[[test]]
+name = "external_consumer_contract_fixture_tests"
+required-features = ["native_rule_bootstrap", "trusted_runtime"]
+
 [build-dependencies]
 blake3 = "1.0"
 

--- a/crates/warp-core/Cargo.toml
+++ b/crates/warp-core/Cargo.toml
@@ -95,6 +95,10 @@ required-features = ["native_rule_bootstrap"]
 name = "installed_contract_intent_pipeline_tests"
 required-features = ["native_rule_bootstrap", "host_test"]
 
+[[test]]
+name = "trusted_runtime_host_loop_tests"
+required-features = ["native_rule_bootstrap", "trusted_runtime"]
+
 [build-dependencies]
 blake3 = "1.0"
 

--- a/crates/warp-core/src/contract_obstruction.rs
+++ b/crates/warp-core/src/contract_obstruction.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Contract-hosted obstruction taxonomy.
+//!
+//! This module names generic obstruction posture for contract-hosted
+//! applications. It does not replace domain errors, does not invent
+//! application-specific failure names, and does not turn runtime faults into
+//! lawful domain rejections.
+
+use crate::coordinator::RuntimeError;
+use crate::ident::Hash;
+use crate::observation::{ObservationError, ReadingResidualPosture};
+use crate::{ContractEvidenceIdentity, SchedulerFaultId};
+
+/// Generic contract-hosted obstruction kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ContractObstructionKind {
+    /// No installed contract package supports the requested mutation operation.
+    UnsupportedOperation,
+    /// No installed contract query observer supports the requested query.
+    UnsupportedQuery,
+    /// Admission or request posture prevented contract work or reading.
+    AdmissionObstruction,
+    /// Runtime safety posture or an internal failure prevented progress.
+    RuntimeFault,
+    /// Required retained material was unavailable.
+    MissingRetention,
+    /// The requested basis is stale, invalid, or unavailable.
+    StaleBasis,
+    /// The observer emitted an explicit residual reading.
+    ResidualReading,
+    /// The requested read exceeded its declared budget.
+    BudgetExceeded,
+}
+
+/// Generic subject named by a contract obstruction.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum ContractObstructionSubject {
+    /// No narrower subject is available yet.
+    #[default]
+    Unspecified,
+    /// Generated mutation operation id.
+    Operation {
+        /// Generated mutation operation id.
+        op_id: u32,
+    },
+    /// Generated query operation id.
+    Query {
+        /// Generated query operation id.
+        query_id: u32,
+    },
+    /// Witnessed submission id.
+    Submission {
+        /// Witnessed submission id.
+        submission_id: Hash,
+    },
+    /// Admission ticket digest.
+    Ticket {
+        /// Admission ticket digest.
+        ticket_digest: Hash,
+    },
+    /// Query reading identity.
+    Reading {
+        /// Query reading identity.
+        reading_id: Hash,
+    },
+    /// Retained material coordinate or digest.
+    Retention {
+        /// Retained material coordinate or digest.
+        retention_id: Hash,
+    },
+    /// Scheduler fault evidence.
+    SchedulerFault {
+        /// Scheduler fault evidence id.
+        fault_id: SchedulerFaultId,
+    },
+}
+
+/// Product-facing contract obstruction posture.
+///
+/// The optional contract evidence names the installed package boundary when the
+/// caller already has it. It is evidence metadata only; it does not authorize
+/// execution and does not grant query rights.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContractObstruction {
+    /// Stable generic obstruction kind.
+    pub kind: ContractObstructionKind,
+    /// Generic subject associated with the obstruction.
+    pub subject: ContractObstructionSubject,
+    /// Installed package evidence, when known.
+    pub contract: Option<ContractEvidenceIdentity>,
+}
+
+impl ContractObstruction {
+    /// Builds an obstruction with no installed package evidence.
+    #[must_use]
+    pub fn new(kind: ContractObstructionKind, subject: ContractObstructionSubject) -> Self {
+        Self {
+            kind,
+            subject,
+            contract: None,
+        }
+    }
+
+    /// Attaches installed package evidence to the obstruction.
+    #[must_use]
+    pub fn with_contract(mut self, contract: ContractEvidenceIdentity) -> Self {
+        self.contract = Some(contract);
+        self
+    }
+
+    /// No installed package supports the mutation operation id.
+    #[must_use]
+    pub fn unsupported_operation(op_id: u32) -> Self {
+        Self::new(
+            ContractObstructionKind::UnsupportedOperation,
+            ContractObstructionSubject::Operation { op_id },
+        )
+    }
+
+    /// No installed query observer supports the query id.
+    #[must_use]
+    pub fn unsupported_query(query_id: u32) -> Self {
+        Self::new(
+            ContractObstructionKind::UnsupportedQuery,
+            ContractObstructionSubject::Query { query_id },
+        )
+    }
+
+    /// Contract admission or request posture obstructed the work.
+    #[must_use]
+    pub fn admission_obstruction(subject: ContractObstructionSubject) -> Self {
+        Self::new(ContractObstructionKind::AdmissionObstruction, subject)
+    }
+
+    /// Runtime safety posture obstructed progress.
+    #[must_use]
+    pub fn runtime_fault(subject: ContractObstructionSubject) -> Self {
+        Self::new(ContractObstructionKind::RuntimeFault, subject)
+    }
+
+    /// Required retained material was unavailable.
+    #[must_use]
+    pub fn missing_retention(retention_id: Hash) -> Self {
+        Self::new(
+            ContractObstructionKind::MissingRetention,
+            ContractObstructionSubject::Retention { retention_id },
+        )
+    }
+
+    /// The requested causal basis is stale, invalid, or unavailable.
+    #[must_use]
+    pub fn stale_basis() -> Self {
+        Self::new(
+            ContractObstructionKind::StaleBasis,
+            ContractObstructionSubject::Unspecified,
+        )
+    }
+
+    /// The reading completed only as an explicit residual.
+    #[must_use]
+    pub fn residual_reading(reading_id: Hash) -> Self {
+        Self::new(
+            ContractObstructionKind::ResidualReading,
+            ContractObstructionSubject::Reading { reading_id },
+        )
+    }
+
+    /// The read exceeded its declared budget.
+    #[must_use]
+    pub fn budget_exceeded() -> Self {
+        Self::new(
+            ContractObstructionKind::BudgetExceeded,
+            ContractObstructionSubject::Unspecified,
+        )
+    }
+
+    /// Classifies an observation error without importing application-domain
+    /// failure names into core.
+    #[must_use]
+    pub fn from_observation_error(error: &ObservationError) -> Self {
+        match error {
+            ObservationError::UnsupportedQuery { query_id } => Self::unsupported_query(*query_id),
+            ObservationError::BudgetExceeded { .. } => Self::budget_exceeded(),
+            ObservationError::InvalidWorldline(_)
+            | ObservationError::InvalidTick { .. }
+            | ObservationError::ObservationUnavailable { .. } => Self::stale_basis(),
+            ObservationError::UnsupportedFrameProjection { .. }
+            | ObservationError::UnsupportedObserverPlan(_)
+            | ObservationError::UnsupportedObserverInstance(_)
+            | ObservationError::UnsupportedRights(_)
+            | ObservationError::ContractQueryObserverFailed { .. } => {
+                Self::admission_obstruction(ContractObstructionSubject::Unspecified)
+            }
+            ObservationError::CodecFailure(_) => {
+                Self::runtime_fault(ContractObstructionSubject::Unspecified)
+            }
+        }
+    }
+
+    /// Classifies a runtime error for contract-hosted product surfaces.
+    #[must_use]
+    pub fn from_runtime_error(error: &RuntimeError) -> Self {
+        match error {
+            RuntimeError::UnsupportedInstalledContractMutation { op_id } => {
+                Self::unsupported_operation(*op_id)
+            }
+            RuntimeError::SchedulerRuntimeFaultActive(fault_id)
+            | RuntimeError::UnknownSchedulerFault(fault_id)
+            | RuntimeError::SchedulerFaultAlreadyResolved(fault_id) => {
+                Self::runtime_fault(ContractObstructionSubject::SchedulerFault {
+                    fault_id: *fault_id,
+                })
+            }
+            RuntimeError::MalformedInstalledContractIntent
+            | RuntimeError::UnknownIntentSubmission(_)
+            | RuntimeError::TicketedIngressSubmissionMismatch(_)
+            | RuntimeError::TicketedIngressAlreadyStaged(_)
+            | RuntimeError::TicketedIngressDuplicateRuntimeIngress { .. } => {
+                Self::admission_obstruction(ContractObstructionSubject::Unspecified)
+            }
+            RuntimeError::SchedulerFaultGenerationOverflow
+            | RuntimeError::DuplicateWorldline(_)
+            | RuntimeError::DuplicateHead(_)
+            | RuntimeError::UnknownWorldline(_)
+            | RuntimeError::UnknownHead(_)
+            | RuntimeError::DuplicateDefaultWriter(_)
+            | RuntimeError::DuplicateInboxAddress { .. }
+            | RuntimeError::MissingDefaultWriter(_)
+            | RuntimeError::MissingInboxAddress { .. }
+            | RuntimeError::RejectedByPolicy(_)
+            | RuntimeError::Engine(_)
+            | RuntimeError::Provenance(_)
+            | RuntimeError::Replay(_)
+            | RuntimeError::Strand(_)
+            | RuntimeError::FrontierTickOverflow(_)
+            | RuntimeError::GlobalTickOverflow
+            | RuntimeError::IntentSubmissionGenerationOverflow
+            | RuntimeError::IntentSubmissionReplayMismatch(_) => {
+                Self::runtime_fault(ContractObstructionSubject::Unspecified)
+            }
+        }
+    }
+
+    /// Classifies reading residual posture when a product surface needs a
+    /// contract obstruction only for non-complete readings.
+    #[must_use]
+    pub fn from_residual_posture(
+        posture: ReadingResidualPosture,
+        reading_id: Option<Hash>,
+    ) -> Option<Self> {
+        match posture {
+            ReadingResidualPosture::Complete | ReadingResidualPosture::PluralityPreserved => None,
+            ReadingResidualPosture::Residual => {
+                Some(Self::residual_reading(reading_id.unwrap_or([0; 32])))
+            }
+            ReadingResidualPosture::Obstructed => Some(Self::admission_obstruction(
+                ContractObstructionSubject::Reading {
+                    reading_id: reading_id.unwrap_or([0; 32]),
+                },
+            )),
+        }
+    }
+}

--- a/crates/warp-core/src/contract_obstruction.rs
+++ b/crates/warp-core/src/contract_obstruction.rs
@@ -219,6 +219,12 @@ impl ContractObstruction {
             | RuntimeError::TicketedIngressDuplicateRuntimeIngress { .. } => {
                 Self::admission_obstruction(ContractObstructionSubject::Unspecified)
             }
+            RuntimeError::WitnessedSubmissionEnvelopeUnavailable(submission_id) => Self::new(
+                ContractObstructionKind::MissingRetention,
+                ContractObstructionSubject::Submission {
+                    submission_id: *submission_id,
+                },
+            ),
             RuntimeError::SchedulerFaultGenerationOverflow
             | RuntimeError::DuplicateWorldline(_)
             | RuntimeError::DuplicateHead(_)

--- a/crates/warp-core/src/contract_registry.rs
+++ b/crates/warp-core/src/contract_registry.rs
@@ -75,6 +75,8 @@ impl From<ContractOperationKind> for OpKind {
 pub struct ContractEvidenceIdentity {
     /// Deterministic installed package id.
     pub package_id: InstalledContractPackageId,
+    /// Echo contract ABI version verified at install time.
+    pub echo_abi_version: u32,
     /// Runtime package name chosen by the host.
     pub package_name: String,
     /// Runtime package version chosen by the host.
@@ -85,6 +87,10 @@ pub struct ContractEvidenceIdentity {
     pub codec_id: String,
     /// Registry version verified at install time.
     pub registry_version: u32,
+    /// Wesley generator version verified at install time.
+    pub wesley_generator_version: String,
+    /// Contract-host helper API version verified at install time.
+    pub helper_api_version: u32,
     /// Hex-encoded authored schema hash verified at install time.
     pub schema_sha256_hex: String,
     /// Generated operation/query id handled by this package.
@@ -157,11 +163,14 @@ impl InstalledContractPackageRecord {
     ) -> ContractEvidenceIdentity {
         ContractEvidenceIdentity {
             package_id: self.package_id,
+            echo_abi_version: self.registry_info.echo_abi_version,
             package_name: self.package_name.clone(),
             package_version: self.package_version.clone(),
             artifact_hash_hex: self.artifact_hash_hex.clone(),
             codec_id: self.registry_info.codec_id.to_owned(),
             registry_version: self.registry_info.registry_version,
+            wesley_generator_version: self.registry_info.wesley_generator_version.to_owned(),
+            helper_api_version: self.registry_info.helper_api_version,
             schema_sha256_hex: self.registry_info.schema_sha256_hex.to_owned(),
             op_id,
             op_kind,

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -194,6 +194,67 @@ pub struct IntentSubmissionRecord {
     pub submission_generation: IngressSubmissionGeneration,
 }
 
+/// Persistable witnessed submission material.
+///
+/// The submission record is Echo semantic ingress history. The envelope is the
+/// canonical material a trusted host can later use for ticketed runtime ingress.
+/// Restoring this material does not enter scheduler-visible inboxes.
+#[derive(Clone, Debug)]
+pub struct WitnessedSubmissionPersistenceRecord {
+    /// Witnessed Echo submission record.
+    pub submission: IntentSubmissionRecord,
+    /// Canonical ingress envelope accepted by Echo.
+    pub envelope: IngressEnvelope,
+}
+
+/// Deterministic local persistence image for witnessed submissions.
+///
+/// Hosts may write this image to durable storage. Importing it restores
+/// accepted submission identity and envelope material only; it does not tick,
+/// dispatch, stage ticketed ingress, or mutate application state.
+#[derive(Clone, Debug, Default)]
+pub struct WitnessedSubmissionPersistenceSnapshot {
+    records: Vec<WitnessedSubmissionPersistenceRecord>,
+}
+
+impl WitnessedSubmissionPersistenceSnapshot {
+    /// Builds a snapshot from persistence records, sorted into replay order.
+    #[must_use]
+    pub fn new(mut records: Vec<WitnessedSubmissionPersistenceRecord>) -> Self {
+        records.sort_by_key(|record| {
+            (
+                record.submission.submission_generation,
+                record.submission.submission_id,
+            )
+        });
+        Self { records }
+    }
+
+    /// Returns the snapshot records in deterministic replay order.
+    #[must_use]
+    pub fn records(&self) -> &[WitnessedSubmissionPersistenceRecord] {
+        &self.records
+    }
+
+    /// Consumes the snapshot and returns records in deterministic replay order.
+    #[must_use]
+    pub fn into_records(self) -> Vec<WitnessedSubmissionPersistenceRecord> {
+        self.records
+    }
+
+    /// Returns `true` when the snapshot carries no submission material.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Returns the number of persisted witnessed submissions.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+}
+
 /// Explicit authority token for staging ticketed runtime ingress.
 ///
 /// Application-facing code should not hold this token. An admission ticket is
@@ -593,6 +654,8 @@ pub struct WorldlineRuntime {
     next_submission_generation: IngressSubmissionGeneration,
     /// Witnessed submission records keyed by content-addressed submission id.
     witnessed_submissions: BTreeMap<Hash, IntentSubmissionRecord>,
+    /// Canonical envelope material for witnessed submissions.
+    witnessed_submission_envelopes: BTreeMap<Hash, IngressEnvelope>,
     /// Deterministic lookup from resolved semantic target and ingress id to
     /// witnessed submission id.
     submission_by_target: BTreeMap<(WriterHeadKey, Hash), Hash>,
@@ -760,6 +823,16 @@ impl WorldlineRuntime {
         self.witnessed_submissions.get(submission_id)
     }
 
+    /// Returns retained canonical envelope material for a witnessed submission.
+    ///
+    /// This is not scheduler admission. The envelope can be used later by a
+    /// trusted host together with an admission ticket to stage ticketed runtime
+    /// ingress.
+    #[must_use]
+    pub fn witnessed_submission_envelope(&self, submission_id: &Hash) -> Option<&IngressEnvelope> {
+        self.witnessed_submission_envelopes.get(submission_id)
+    }
+
     /// Iterates witnessed submissions in deterministic submission-id order.
     pub fn witnessed_submissions(&self) -> impl Iterator<Item = &IntentSubmissionRecord> {
         self.witnessed_submissions.values()
@@ -780,6 +853,32 @@ impl WorldlineRuntime {
             .collect::<Vec<_>>();
         records.sort_by_key(|record| (record.submission_generation, record.submission_id));
         records
+    }
+
+    /// Returns a deterministic local persistence snapshot for witnessed
+    /// submissions with retained envelope material.
+    ///
+    /// The snapshot is host-persistable semantic ingress material. Restoring it
+    /// does not make application code tick and does not stage scheduler-visible
+    /// runtime ingress.
+    #[must_use]
+    pub fn witnessed_submission_persistence_snapshot(
+        &self,
+    ) -> WitnessedSubmissionPersistenceSnapshot {
+        let records = self
+            .witnessed_submission_replay_records()
+            .into_iter()
+            .filter_map(|submission| {
+                self.witnessed_submission_envelopes
+                    .get(&submission.submission_id)
+                    .cloned()
+                    .map(|envelope| WitnessedSubmissionPersistenceRecord {
+                        submission,
+                        envelope,
+                    })
+            })
+            .collect();
+        WitnessedSubmissionPersistenceSnapshot::new(records)
     }
 
     /// Returns the number of witnessed submission records.
@@ -1382,6 +1481,52 @@ impl WorldlineRuntime {
         Ok(())
     }
 
+    /// Restores persisted witnessed submission records and canonical envelopes.
+    ///
+    /// This restores semantic ingress history and host-retained envelope
+    /// material only. It does not enter the envelopes into head inboxes, stage
+    /// ticketed runtime ingress, advance ticks, dispatch handlers, or execute
+    /// contracts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any snapshot record does not match its canonical
+    /// envelope, targets an unknown head, violates the target inbox policy, or
+    /// conflicts with existing witnessed submission history.
+    pub fn restore_witnessed_submission_persistence(
+        &mut self,
+        snapshot: WitnessedSubmissionPersistenceSnapshot,
+    ) -> Result<(), RuntimeError> {
+        let records = snapshot.into_records();
+        let mut staged_envelopes = BTreeMap::new();
+
+        for record in &records {
+            if record.envelope.ingress_id() != record.submission.ingress_id {
+                return Err(RuntimeError::IntentSubmissionReplayMismatch(
+                    record.submission.submission_id,
+                ));
+            }
+            let head_key = self.resolve_target(record.envelope.target())?;
+            if head_key != record.submission.head_key {
+                return Err(RuntimeError::IntentSubmissionReplayMismatch(
+                    record.submission.submission_id,
+                ));
+            }
+            let head = self
+                .heads
+                .get(&head_key)
+                .ok_or(RuntimeError::UnknownHead(head_key))?;
+            if !head.inbox().would_accept(&record.envelope) {
+                return Err(RuntimeError::RejectedByPolicy(head_key));
+            }
+            staged_envelopes.insert(record.submission.submission_id, record.envelope.clone());
+        }
+
+        self.replay_witnessed_submissions(records.into_iter().map(|record| record.submission))?;
+        self.witnessed_submission_envelopes.extend(staged_envelopes);
+        Ok(())
+    }
+
     /// Records an accepted intent submission without entering runtime ingress.
     ///
     /// This is witnessed Echo ingress history only. It does not store the
@@ -1398,6 +1543,7 @@ impl WorldlineRuntime {
         envelope: IngressEnvelope,
     ) -> Result<IntentSubmissionDisposition, RuntimeError> {
         let ingress_id = envelope.ingress_id();
+        let retained_envelope = envelope.clone();
         let head_key = self.resolve_target(envelope.target())?;
 
         if self
@@ -1440,6 +1586,8 @@ impl WorldlineRuntime {
         }
 
         let record = self.record_witnessed_submission(head_key, ingress_id)?;
+        self.witnessed_submission_envelopes
+            .insert(record.submission_id, retained_envelope);
         Ok(IntentSubmissionDisposition::Accepted {
             ingress_id,
             head_key,
@@ -1573,6 +1721,7 @@ impl WorldlineRuntime {
         envelope: IngressEnvelope,
     ) -> Result<IngressDisposition, RuntimeError> {
         let ingress_id = envelope.ingress_id();
+        let retained_envelope = envelope.clone();
         let head_key = self.resolve_target(envelope.target())?;
 
         if self
@@ -1602,6 +1751,8 @@ impl WorldlineRuntime {
         match outcome {
             InboxIngestResult::Accepted => {
                 let record = self.record_witnessed_submission(head_key, ingress_id)?;
+                self.witnessed_submission_envelopes
+                    .insert(record.submission_id, retained_envelope);
                 Ok(IngressDisposition::Accepted {
                     ingress_id,
                     head_key,
@@ -3794,6 +3945,206 @@ mod tests {
             1
         );
         assert_eq!(runtime.witnessed_submission_count(), 1);
+    }
+
+    #[test]
+    fn witnessed_submission_persistence_restores_envelope_without_ticking() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(1);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let head_key = register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"pending-persisted".to_vec(),
+        );
+        let accepted = runtime.submit_intent(env.clone()).unwrap();
+        let (submission_id, submission_generation) = match accepted {
+            IntentSubmissionDisposition::Accepted {
+                submission_id,
+                submission_generation,
+                ..
+            } => (submission_id, submission_generation),
+            IntentSubmissionDisposition::Duplicate { .. } => {
+                panic!("first submission should be accepted")
+            }
+        };
+
+        let snapshot = runtime.witnessed_submission_persistence_snapshot();
+        assert_eq!(snapshot.len(), 1);
+
+        let mut restored = WorldlineRuntime::new();
+        restored
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let restored_head = register_head(
+            &mut restored,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        restored
+            .restore_witnessed_submission_persistence(snapshot)
+            .unwrap();
+
+        let restored_record = restored
+            .witnessed_submission(&submission_id)
+            .expect("restored runtime should have witnessed submission");
+        assert_eq!(restored_record.submission_generation, submission_generation);
+        assert_eq!(restored_record.head_key, head_key);
+        assert_eq!(
+            restored
+                .witnessed_submission_envelope(&submission_id)
+                .expect("restored runtime should retain canonical envelope")
+                .ingress_id(),
+            env.ingress_id()
+        );
+        assert_eq!(restored.global_tick(), gt(0));
+        assert_eq!(
+            restored
+                .worldlines()
+                .get(&worldline_id)
+                .unwrap()
+                .frontier_tick(),
+            wt(0)
+        );
+        assert_eq!(
+            restored
+                .heads
+                .get(&restored_head)
+                .unwrap()
+                .inbox()
+                .pending_count(),
+            0,
+            "recovery must not stage scheduler-visible inbox work"
+        );
+        assert_eq!(restored.ticketed_runtime_ingress_count(), 0);
+    }
+
+    #[test]
+    fn duplicate_submit_after_persistence_restore_returns_duplicate() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(2);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"duplicate-after-restore".to_vec(),
+        );
+        let accepted = runtime.submit_intent(env.clone()).unwrap();
+        let (submission_id, submission_generation) = match accepted {
+            IntentSubmissionDisposition::Accepted {
+                submission_id,
+                submission_generation,
+                ..
+            } => (submission_id, submission_generation),
+            IntentSubmissionDisposition::Duplicate { .. } => {
+                panic!("first submission should be accepted")
+            }
+        };
+        let snapshot = runtime.witnessed_submission_persistence_snapshot();
+
+        let mut restored = WorldlineRuntime::new();
+        restored
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut restored,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        restored
+            .restore_witnessed_submission_persistence(snapshot)
+            .unwrap();
+
+        assert!(matches!(
+            restored.submit_intent(env).unwrap(),
+            IntentSubmissionDisposition::Duplicate {
+                submission_id: restored_submission,
+                submission_generation: restored_generation,
+                ..
+            } if restored_submission == submission_id && restored_generation == submission_generation
+        ));
+        assert_eq!(restored.witnessed_submission_count(), 1);
+    }
+
+    #[test]
+    fn persistence_restore_rejects_mismatched_envelope_without_partial_import() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(3);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"original".to_vec(),
+        );
+        runtime.submit_intent(env).unwrap();
+        let mut record = runtime
+            .witnessed_submission_persistence_snapshot()
+            .records()[0]
+            .clone();
+        record.envelope = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"different".to_vec(),
+        );
+        let snapshot = WitnessedSubmissionPersistenceSnapshot::new(vec![record]);
+
+        let mut restored = WorldlineRuntime::new();
+        restored
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut restored,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+
+        assert!(matches!(
+            restored.restore_witnessed_submission_persistence(snapshot),
+            Err(RuntimeError::IntentSubmissionReplayMismatch(_))
+        ));
+        assert_eq!(restored.witnessed_submission_count(), 0);
+        assert!(restored
+            .witnessed_submission_persistence_snapshot()
+            .is_empty());
     }
 
     #[test]

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -271,7 +271,7 @@ impl TicketedRuntimeIngressAuthority {
     ///
     /// The caller must prove it is executing inside Echo's trusted runtime
     /// owner, test harness, or equivalent host-controlled boundary.
-    #[cfg(feature = "host_test")]
+    #[cfg(any(test, feature = "host_test", feature = "trusted_runtime"))]
     #[doc(hidden)]
     #[must_use]
     pub fn assume_runtime_owner() -> Self {

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -449,6 +449,56 @@ pub enum IntentSubmissionDisposition {
     },
 }
 
+/// App-facing submission handle returned after Echo accepts or recognizes an
+/// intent submission.
+///
+/// This is not execution evidence and not a tick receipt. It is a stable handle
+/// for polling the scheduler-owned outcome later.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IntentSubmissionHandle {
+    /// Content-addressed canonical ingress id.
+    pub ingress_id: Hash,
+    /// Resolved semantic writer-head target.
+    pub head_key: WriterHeadKey,
+    /// Witnessed Echo submission id.
+    pub submission_id: Hash,
+    /// Echo-owned intake/correlation generation.
+    pub submission_generation: IngressSubmissionGeneration,
+    /// `true` when Echo had already witnessed this semantic submission.
+    pub duplicate: bool,
+}
+
+impl From<IntentSubmissionDisposition> for IntentSubmissionHandle {
+    fn from(disposition: IntentSubmissionDisposition) -> Self {
+        match disposition {
+            IntentSubmissionDisposition::Accepted {
+                ingress_id,
+                head_key,
+                submission_id,
+                submission_generation,
+            } => Self {
+                ingress_id,
+                head_key,
+                submission_id,
+                submission_generation,
+                duplicate: false,
+            },
+            IntentSubmissionDisposition::Duplicate {
+                ingress_id,
+                head_key,
+                submission_id,
+                submission_generation,
+            } => Self {
+                ingress_id,
+                head_key,
+                submission_id,
+                submission_generation,
+                duplicate: true,
+            },
+        }
+    }
+}
+
 /// Result of ingesting an envelope into the runtime.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IngressDisposition {
@@ -598,6 +648,175 @@ pub enum IntentOutcomeObservation {
         /// Applied/rejected decision derived from the retained receipt entry.
         decision: IntentOutcomeDecision,
     },
+}
+
+/// Receipt evidence attached to app-facing applied or rejected outcomes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntentOutcomeReceipt {
+    /// Ticketed ingress correlation event.
+    pub ticketed_ingress_id: Hash,
+    /// Admission ticket digest bound to runtime ingress.
+    pub ticket_digest: Hash,
+    /// Canonical ingress id decided by the tick.
+    pub ingress_id: Hash,
+    /// Writer head that committed the tick.
+    pub head_key: WriterHeadKey,
+    /// Installed contract evidence, when the work came from a generated package.
+    pub contract: Option<crate::ContractEvidenceIdentity>,
+    /// Runtime cycle stamp that produced the receipt.
+    pub commit_global_tick: GlobalTick,
+    /// Worldline tick after the commit.
+    pub worldline_tick_after: WorldlineTick,
+    /// Scheduler-owned tick receipt digest.
+    pub tick_receipt_digest: Hash,
+    /// Commit hash emitted by the scheduler-owned tick.
+    pub commit_hash: Hash,
+    /// Entry index inside the correlated tick receipt.
+    pub receipt_entry_index: u32,
+    /// Scheduler rule that produced the receipt entry.
+    pub rule_id: Hash,
+}
+
+impl IntentOutcomeReceipt {
+    fn from_correlation(
+        correlation: &ReceiptCorrelationRecord,
+        receipt_entry_index: u32,
+        rule_id: Hash,
+    ) -> Self {
+        Self {
+            ticketed_ingress_id: correlation.ticketed_ingress_id,
+            ticket_digest: correlation.ticket_digest,
+            ingress_id: correlation.ingress_id,
+            head_key: correlation.head_key,
+            contract: correlation.contract.clone(),
+            commit_global_tick: correlation.commit_global_tick,
+            worldline_tick_after: correlation.worldline_tick_after,
+            tick_receipt_digest: correlation.tick_receipt_digest,
+            commit_hash: correlation.commit_hash,
+            receipt_entry_index,
+            rule_id,
+        }
+    }
+}
+
+/// App-facing outcome posture for a witnessed intent submission.
+///
+/// This is a read-only polling shape. It does not tick, dispatch handlers,
+/// subscribe to streams, or retry failed work.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IntentOutcome {
+    /// Echo has no witnessed submission for the supplied id.
+    Unknown {
+        /// Submission id the caller asked about.
+        submission_id: Hash,
+    },
+    /// Echo has witnessed the submission, but no tick receipt has decided it.
+    Pending {
+        /// Witnessed Echo submission id.
+        submission_id: Hash,
+        /// Echo-owned intake/correlation generation.
+        submission_generation: IngressSubmissionGeneration,
+        /// Ticketed runtime ingress id, if admission has staged runtime ingress.
+        ticketed_ingress_id: Option<Hash>,
+    },
+    /// The scheduler-owned tick applied this intent.
+    Applied {
+        /// Witnessed Echo submission id.
+        submission_id: Hash,
+        /// Receipt evidence for the applied decision.
+        receipt: Box<IntentOutcomeReceipt>,
+    },
+    /// The scheduler-owned tick rejected this intent as a lawful outcome.
+    Rejected {
+        /// Witnessed Echo submission id.
+        submission_id: Hash,
+        /// Receipt evidence for the rejected decision.
+        receipt: Box<IntentOutcomeReceipt>,
+        /// Deterministic rejection reason emitted by the tick receipt.
+        reason: TickReceiptRejection,
+        /// Receipt entry indices that blocked this candidate.
+        blocked_by: Vec<u32>,
+    },
+    /// Echo could not honestly interpret the outcome evidence.
+    Obstructed {
+        /// Witnessed Echo submission id.
+        submission_id: Hash,
+        /// Typed contract-host obstruction.
+        obstruction: crate::ContractObstruction,
+    },
+}
+
+impl IntentOutcome {
+    /// Converts the internal scheduler observation into the app-facing outcome
+    /// shape.
+    #[must_use]
+    pub fn from_observation(observation: IntentOutcomeObservation) -> Self {
+        match observation {
+            IntentOutcomeObservation::UnknownSubmission { submission_id } => {
+                Self::Unknown { submission_id }
+            }
+            IntentOutcomeObservation::Pending {
+                submission_id,
+                submission_generation,
+                ticketed_ingress_id,
+            } => Self::Pending {
+                submission_id,
+                submission_generation,
+                ticketed_ingress_id,
+            },
+            IntentOutcomeObservation::Decided {
+                correlation,
+                decision:
+                    IntentOutcomeDecision::Applied {
+                        receipt_entry_index,
+                        rule_id,
+                    },
+            } => Self::Applied {
+                submission_id: correlation.submission_id,
+                receipt: Box::new(IntentOutcomeReceipt::from_correlation(
+                    &correlation,
+                    receipt_entry_index,
+                    rule_id,
+                )),
+            },
+            IntentOutcomeObservation::Decided {
+                correlation,
+                decision:
+                    IntentOutcomeDecision::Rejected {
+                        receipt_entry_index,
+                        rule_id,
+                        reason,
+                        blocked_by,
+                    },
+            } => Self::Rejected {
+                submission_id: correlation.submission_id,
+                receipt: Box::new(IntentOutcomeReceipt::from_correlation(
+                    &correlation,
+                    receipt_entry_index,
+                    rule_id,
+                )),
+                reason,
+                blocked_by,
+            },
+            IntentOutcomeObservation::Decided {
+                correlation,
+                decision:
+                    IntentOutcomeDecision::NoMatchingReceiptEntry {
+                        tick_receipt_digest,
+                    },
+            } => {
+                let mut obstruction =
+                    crate::ContractObstruction::missing_retention(tick_receipt_digest);
+                if let Some(contract) = correlation.contract.as_ref() {
+                    obstruction = obstruction.with_contract(contract.clone());
+                }
+                Self::Obstructed {
+                    submission_id: correlation.submission_id,
+                    obstruction,
+                }
+            }
+        }
+    }
 }
 
 /// Request to fork a strand from one precise source-lane coordinate.
@@ -958,6 +1177,17 @@ impl WorldlineRuntime {
         self.receipt_correlations_by_ticketed_ingress.len()
     }
 
+    /// App-facing submission helper.
+    ///
+    /// This records witnessed ingress history only. It does not enter runtime
+    /// ingress, tick, dispatch handlers, or mutate application state.
+    pub fn submit_app_intent(
+        &mut self,
+        envelope: IngressEnvelope,
+    ) -> Result<IntentSubmissionHandle, RuntimeError> {
+        self.submit_intent(envelope).map(Into::into)
+    }
+
     /// Returns scheduler fault evidence by fault id.
     #[must_use]
     pub fn scheduler_fault(&self, fault_id: &SchedulerFaultId) -> Option<&SchedulerFaultRecord> {
@@ -1071,6 +1301,15 @@ impl WorldlineRuntime {
                 .get(submission_id)
                 .copied(),
         }
+    }
+
+    /// App-facing read-only outcome observation.
+    ///
+    /// This wraps the internal scheduler observation in product-facing states
+    /// and uses the contract obstruction taxonomy for missing outcome evidence.
+    #[must_use]
+    pub fn observe_app_intent_outcome(&self, submission_id: &Hash) -> IntentOutcome {
+        IntentOutcome::from_observation(self.observe_intent_outcome(submission_id))
     }
 
     fn intent_outcome_decision(
@@ -2947,6 +3186,10 @@ mod tests {
         GlobalTick::from_raw(raw)
     }
 
+    fn hash(n: u8) -> Hash {
+        [n; 32]
+    }
+
     fn empty_engine() -> Engine {
         let mut store = GraphStore::default();
         let root = make_node_id("root");
@@ -4145,6 +4388,167 @@ mod tests {
         assert!(restored
             .witnessed_submission_persistence_snapshot()
             .is_empty());
+    }
+
+    #[test]
+    fn submit_app_intent_returns_handle_without_ticking() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(4);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        let head_key = register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"app-submit".to_vec(),
+        );
+
+        let handle = runtime.submit_app_intent(env.clone()).unwrap();
+
+        assert_eq!(handle.ingress_id, env.ingress_id());
+        assert_eq!(handle.head_key, head_key);
+        assert_eq!(handle.submission_generation.as_u64(), 1);
+        assert!(!handle.duplicate);
+        assert_eq!(runtime.global_tick(), gt(0));
+        assert_eq!(
+            runtime
+                .worldlines()
+                .get(&worldline_id)
+                .unwrap()
+                .frontier_tick(),
+            wt(0)
+        );
+        assert_eq!(runtime.ticketed_runtime_ingress_count(), 0);
+    }
+
+    #[test]
+    fn observe_app_intent_outcome_reports_unknown_and_pending() {
+        let mut runtime = WorldlineRuntime::new();
+        let unknown_submission = hash(99);
+        assert!(matches!(
+            runtime.observe_app_intent_outcome(&unknown_submission),
+            IntentOutcome::Unknown { submission_id } if submission_id == unknown_submission
+        ));
+
+        let worldline_id = wl(5);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let handle = runtime
+            .submit_app_intent(IngressEnvelope::local_intent(
+                IngressTarget::DefaultWriter { worldline_id },
+                make_intent_kind("test"),
+                b"pending-app".to_vec(),
+            ))
+            .unwrap();
+
+        assert!(matches!(
+            runtime.observe_app_intent_outcome(&handle.submission_id),
+            IntentOutcome::Pending {
+                submission_id,
+                submission_generation,
+                ticketed_ingress_id: None,
+            } if submission_id == handle.submission_id
+                && submission_generation == handle.submission_generation
+        ));
+    }
+
+    #[test]
+    fn app_intent_outcome_maps_decisions_and_missing_receipt_evidence() {
+        let head_key = WriterHeadKey {
+            worldline_id: wl(6),
+            head_id: make_head_id("default"),
+        };
+        let correlation = ReceiptCorrelationRecord {
+            ticketed_ingress_id: hash(1),
+            submission_id: hash(2),
+            ticket_digest: hash(3),
+            ingress_id: hash(4),
+            head_key,
+            contract: None,
+            commit_global_tick: gt(7),
+            worldline_tick_after: wt(8),
+            tick_receipt_digest: hash(9),
+            commit_hash: hash(10),
+        };
+
+        let applied = IntentOutcome::from_observation(IntentOutcomeObservation::Decided {
+            correlation: Box::new(correlation.clone()),
+            decision: IntentOutcomeDecision::Applied {
+                receipt_entry_index: 3,
+                rule_id: hash(11),
+            },
+        });
+        assert!(matches!(
+            applied,
+            IntentOutcome::Applied {
+                submission_id,
+                receipt,
+            } if submission_id == correlation.submission_id
+                && receipt.tick_receipt_digest == correlation.tick_receipt_digest
+                && receipt.receipt_entry_index == 3
+        ));
+
+        let rejected = IntentOutcome::from_observation(IntentOutcomeObservation::Decided {
+            correlation: Box::new(correlation.clone()),
+            decision: IntentOutcomeDecision::Rejected {
+                receipt_entry_index: 4,
+                rule_id: hash(12),
+                reason: TickReceiptRejection::FootprintConflict,
+                blocked_by: vec![1, 2],
+            },
+        });
+        assert!(matches!(
+            rejected,
+            IntentOutcome::Rejected {
+                submission_id,
+                reason: TickReceiptRejection::FootprintConflict,
+                blocked_by,
+                ..
+            } if submission_id == correlation.submission_id && blocked_by == vec![1, 2]
+        ));
+
+        let obstructed = IntentOutcome::from_observation(IntentOutcomeObservation::Decided {
+            correlation: Box::new(correlation.clone()),
+            decision: IntentOutcomeDecision::NoMatchingReceiptEntry {
+                tick_receipt_digest: correlation.tick_receipt_digest,
+            },
+        });
+        match obstructed {
+            IntentOutcome::Obstructed {
+                submission_id,
+                obstruction,
+            } => {
+                assert_eq!(submission_id, correlation.submission_id);
+                assert_eq!(
+                    obstruction.kind,
+                    crate::ContractObstructionKind::MissingRetention
+                );
+                assert_eq!(
+                    obstruction.subject,
+                    crate::ContractObstructionSubject::Retention {
+                        retention_id: correlation.tick_receipt_digest
+                    }
+                );
+            }
+            other => panic!("expected obstructed outcome, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -100,6 +100,10 @@ pub enum RuntimeError {
     /// or conflicted with an existing witnessed submission.
     #[error("witnessed intent submission replay mismatch: {0:?}")]
     IntentSubmissionReplayMismatch(Hash),
+    /// A witnessed submission exists without the canonical envelope material
+    /// required to build a full persistence snapshot.
+    #[error("witnessed intent submission envelope unavailable: {0:?}")]
+    WitnessedSubmissionEnvelopeUnavailable(Hash),
     /// Ticketed runtime ingress referenced a submission Echo has not witnessed.
     #[error("unknown intent submission: {0:?}")]
     UnknownIntentSubmission(Hash),
@@ -1080,24 +1084,30 @@ impl WorldlineRuntime {
     /// The snapshot is host-persistable semantic ingress material. Restoring it
     /// does not make application code tick and does not stage scheduler-visible
     /// runtime ingress.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError::WitnessedSubmissionEnvelopeUnavailable`] when a
+    /// witnessed submission lacks the canonical envelope material required for
+    /// a complete persistence snapshot.
     pub fn witnessed_submission_persistence_snapshot(
         &self,
-    ) -> WitnessedSubmissionPersistenceSnapshot {
-        let records = self
-            .witnessed_submission_replay_records()
-            .into_iter()
-            .filter_map(|submission| {
-                self.witnessed_submission_envelopes
-                    .get(&submission.submission_id)
-                    .cloned()
-                    .map(|envelope| WitnessedSubmissionPersistenceRecord {
-                        submission,
-                        envelope,
-                    })
-            })
-            .collect();
-        WitnessedSubmissionPersistenceSnapshot::new(records)
+    ) -> Result<WitnessedSubmissionPersistenceSnapshot, RuntimeError> {
+        let mut records = Vec::new();
+        for submission in self.witnessed_submission_replay_records() {
+            let envelope = self
+                .witnessed_submission_envelopes
+                .get(&submission.submission_id)
+                .cloned()
+                .ok_or(RuntimeError::WitnessedSubmissionEnvelopeUnavailable(
+                    submission.submission_id,
+                ))?;
+            records.push(WitnessedSubmissionPersistenceRecord {
+                submission,
+                envelope,
+            });
+        }
+        Ok(WitnessedSubmissionPersistenceSnapshot::new(records))
     }
 
     /// Returns the number of witnessed submission records.
@@ -2325,6 +2335,7 @@ fn scheduler_fault_scope_for_error(
         | RuntimeError::Strand(_)
         | RuntimeError::IntentSubmissionGenerationOverflow
         | RuntimeError::IntentSubmissionReplayMismatch(_)
+        | RuntimeError::WitnessedSubmissionEnvelopeUnavailable(_)
         | RuntimeError::UnknownIntentSubmission(_)
         | RuntimeError::TicketedIngressSubmissionMismatch(_)
         | RuntimeError::TicketedIngressAlreadyStaged(_)
@@ -2843,6 +2854,10 @@ fn scheduler_error_cause_digest(err: &RuntimeError) -> Hash {
         }
         RuntimeError::IntentSubmissionReplayMismatch(submission_id) => {
             hasher.update(b"intent-submission-replay-mismatch");
+            hasher.update(submission_id);
+        }
+        RuntimeError::WitnessedSubmissionEnvelopeUnavailable(submission_id) => {
+            hasher.update(b"witnessed-submission-envelope-unavailable");
             hasher.update(submission_id);
         }
         RuntimeError::UnknownIntentSubmission(submission_id) => {
@@ -4222,7 +4237,7 @@ mod tests {
             }
         };
 
-        let snapshot = runtime.witnessed_submission_persistence_snapshot();
+        let snapshot = runtime.witnessed_submission_persistence_snapshot().unwrap();
         assert_eq!(snapshot.len(), 1);
 
         let mut restored = WorldlineRuntime::new();
@@ -4306,7 +4321,7 @@ mod tests {
                 panic!("first submission should be accepted")
             }
         };
-        let snapshot = runtime.witnessed_submission_persistence_snapshot();
+        let snapshot = runtime.witnessed_submission_persistence_snapshot().unwrap();
 
         let mut restored = WorldlineRuntime::new();
         restored
@@ -4336,9 +4351,60 @@ mod tests {
     }
 
     #[test]
-    fn persistence_restore_rejects_mismatched_envelope_without_partial_import() {
+    fn witnessed_submission_persistence_snapshot_rejects_replayed_submission_without_envelope() {
         let mut runtime = WorldlineRuntime::new();
         let worldline_id = wl(3);
+        runtime
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut runtime,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        let env = IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            make_intent_kind("test"),
+            b"replayed-without-envelope".to_vec(),
+        );
+        let submission_id = match runtime.submit_intent(env).unwrap() {
+            IntentSubmissionDisposition::Accepted { submission_id, .. } => submission_id,
+            IntentSubmissionDisposition::Duplicate { .. } => {
+                panic!("first submission should be accepted")
+            }
+        };
+        let replay_records = runtime.witnessed_submission_replay_records();
+
+        let mut replayed = WorldlineRuntime::new();
+        replayed
+            .register_worldline(worldline_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut replayed,
+            worldline_id,
+            "default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+        replayed
+            .replay_witnessed_submissions(replay_records)
+            .unwrap();
+
+        assert_eq!(replayed.witnessed_submission_count(), 1);
+        assert!(matches!(
+            replayed.witnessed_submission_persistence_snapshot(),
+            Err(RuntimeError::WitnessedSubmissionEnvelopeUnavailable(id)) if id == submission_id
+        ));
+    }
+
+    #[test]
+    fn persistence_restore_rejects_mismatched_envelope_without_partial_import() {
+        let mut runtime = WorldlineRuntime::new();
+        let worldline_id = wl(4);
         runtime
             .register_worldline(worldline_id, WorldlineState::empty())
             .unwrap();
@@ -4358,6 +4424,7 @@ mod tests {
         runtime.submit_intent(env).unwrap();
         let mut record = runtime
             .witnessed_submission_persistence_snapshot()
+            .unwrap()
             .records()[0]
             .clone();
         record.envelope = IngressEnvelope::local_intent(
@@ -4387,6 +4454,7 @@ mod tests {
         assert_eq!(restored.witnessed_submission_count(), 0);
         assert!(restored
             .witnessed_submission_persistence_snapshot()
+            .unwrap()
             .is_empty());
     }
 

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -46,6 +46,7 @@ mod clock;
 mod cmd;
 mod constants;
 mod contract_host;
+mod contract_obstruction;
 mod contract_registry;
 /// Domain separation prefixes for hashing.
 pub mod domain;
@@ -237,6 +238,9 @@ pub use payload::{
     motion_payload_type_id_v0,
 };
 // --- Cursor types ---
+pub use contract_obstruction::{
+    ContractObstruction, ContractObstructionKind, ContractObstructionSubject,
+};
 pub use playback::{
     CursorId, CursorRole, PlaybackCursor, PlaybackMode, SeekError, SeekThen, StepResult,
 };

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -358,7 +358,8 @@ pub use coordinator::{
     SchedulerFaultGeneration, SchedulerFaultId, SchedulerFaultRecord,
     SchedulerFaultRecoveryAuthority, SchedulerFaultScope, SchedulerFaultStatus, SchedulerRunId,
     StepRecord, TicketedRuntimeIngressAuthority, TicketedRuntimeIngressDisposition,
-    TicketedRuntimeIngressRecord, WorldlineRuntime,
+    TicketedRuntimeIngressRecord, WitnessedSubmissionPersistenceRecord,
+    WitnessedSubmissionPersistenceSnapshot, WorldlineRuntime,
 };
 /// Writer-head registry and routing primitives used by the runtime-owned ingress path.
 pub use head::{

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -152,6 +152,8 @@ mod snapshot_accum;
 mod telemetry;
 mod tick_delta;
 mod tick_patch;
+#[cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
+mod trusted_runtime_host;
 mod tx;
 mod warp_state;
 mod witnessed_suffix;
@@ -331,6 +333,10 @@ pub use tick_delta::{DeltaStats, OpOrigin, ScopedDelta, TickDelta};
 pub use tick_patch::{
     slice_worldline_indices, PortalInit, SlotId, TickCommitStatus, TickPatchError, WarpOp,
     WarpOpKey, WarpTickPatchV1,
+};
+#[cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
+pub use trusted_runtime_host::{
+    TrustedRuntimeApp, TrustedRuntimeHost, TrustedRuntimeHostError, TrustedRuntimeHostRunReport,
 };
 pub use tx::TxId;
 pub use warp_state::{WarpInstance, WarpState};

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -353,13 +353,13 @@ pub use worldline::{
 /// Prefer this coordinator/runtime API for new stepping and routing code.
 pub use coordinator::{
     ForkStrandReceipt, ForkStrandRequest, IngressDisposition, IngressSubmissionGeneration,
-    IntentOutcomeDecision, IntentOutcomeObservation, IntentSubmissionDisposition,
-    IntentSubmissionRecord, ReceiptCorrelationRecord, RuntimeError, SchedulerCoordinator,
-    SchedulerFaultGeneration, SchedulerFaultId, SchedulerFaultRecord,
-    SchedulerFaultRecoveryAuthority, SchedulerFaultScope, SchedulerFaultStatus, SchedulerRunId,
-    StepRecord, TicketedRuntimeIngressAuthority, TicketedRuntimeIngressDisposition,
-    TicketedRuntimeIngressRecord, WitnessedSubmissionPersistenceRecord,
-    WitnessedSubmissionPersistenceSnapshot, WorldlineRuntime,
+    IntentOutcome, IntentOutcomeDecision, IntentOutcomeObservation, IntentOutcomeReceipt,
+    IntentSubmissionDisposition, IntentSubmissionHandle, IntentSubmissionRecord,
+    ReceiptCorrelationRecord, RuntimeError, SchedulerCoordinator, SchedulerFaultGeneration,
+    SchedulerFaultId, SchedulerFaultRecord, SchedulerFaultRecoveryAuthority, SchedulerFaultScope,
+    SchedulerFaultStatus, SchedulerRunId, StepRecord, TicketedRuntimeIngressAuthority,
+    TicketedRuntimeIngressDisposition, TicketedRuntimeIngressRecord,
+    WitnessedSubmissionPersistenceRecord, WitnessedSubmissionPersistenceSnapshot, WorldlineRuntime,
 };
 /// Writer-head registry and routing primitives used by the runtime-owned ingress path.
 pub use head::{

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -139,6 +139,7 @@ mod playback;
 mod provenance_store;
 mod receipt;
 mod record;
+mod retained_evidence;
 mod retention;
 mod rule;
 mod sandbox;
@@ -243,6 +244,9 @@ pub use contract_obstruction::{
 };
 pub use playback::{
     CursorId, CursorRole, PlaybackCursor, PlaybackMode, SeekError, SeekThen, StepResult,
+};
+pub use retained_evidence::{
+    RetainedEvidenceCoordinate, RetainedEvidencePosture, RetainedEvidenceRef, RetainedEvidenceRole,
 };
 // --- Session types ---
 pub use playback::{SessionId, ViewSession};

--- a/crates/warp-core/src/observation.rs
+++ b/crates/warp-core/src/observation.rs
@@ -933,11 +933,14 @@ impl ReadingEnvelope {
 fn contract_evidence_to_abi(evidence: &ContractEvidenceIdentity) -> abi::ContractEvidenceIdentity {
     abi::ContractEvidenceIdentity {
         package_id: evidence.package_id.as_bytes().to_vec(),
+        echo_abi_version: evidence.echo_abi_version,
         package_name: evidence.package_name.clone(),
         package_version: evidence.package_version.clone(),
         artifact_hash_hex: evidence.artifact_hash_hex.clone(),
         codec_id: evidence.codec_id.clone(),
         registry_version: evidence.registry_version,
+        wesley_generator_version: evidence.wesley_generator_version.clone(),
+        helper_api_version: evidence.helper_api_version,
         schema_sha256_hex: evidence.schema_sha256_hex.clone(),
         op_id: evidence.op_id,
         op_kind: match evidence.op_kind {

--- a/crates/warp-core/src/retained_evidence.rs
+++ b/crates/warp-core/src/retained_evidence.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Retained contract evidence references.
+//!
+//! CAS names bytes. These references name retained evidence under contract
+//! semantics so missing material can obstruct explicitly instead of becoming an
+//! empty read, cache hit, or generic runtime failure.
+
+use blake3::Hasher;
+
+use crate::contract_obstruction::ContractObstruction;
+use crate::contract_registry::{ContractEvidenceIdentity, ContractOperationKind};
+use crate::ident::Hash;
+
+const RETAINED_EVIDENCE_COORDINATE_ID_DOMAIN: &[u8] = b"echo:retained-evidence-coordinate-id:v1\0";
+const RETAINED_EVIDENCE_REF_ID_DOMAIN: &[u8] = b"echo:retained-evidence-ref-id:v1\0";
+
+/// Semantic role of retained contract evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RetainedEvidenceRole {
+    /// Generated contract artifact bytes.
+    ContractArtifact,
+    /// Scheduler receipt or receipt-adjacent material.
+    ContractReceipt,
+    /// Law witness or witness-adjacent material.
+    Witness,
+    /// Reading payload bytes.
+    ReadingPayload,
+    /// Encoded reading envelope bytes.
+    ReadingEnvelope,
+    /// Generated observer artifact bytes.
+    ObserverArtifact,
+}
+
+impl RetainedEvidenceRole {
+    fn tag(self) -> u8 {
+        match self {
+            Self::ContractArtifact => 0,
+            Self::ContractReceipt => 1,
+            Self::Witness => 2,
+            Self::ReadingPayload => 3,
+            Self::ReadingEnvelope => 4,
+            Self::ObserverArtifact => 5,
+        }
+    }
+}
+
+/// Semantic coordinate for retained contract evidence.
+///
+/// The coordinate names what the bytes answer. It is intentionally separate
+/// from content hash because equal bytes can answer different semantic
+/// questions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetainedEvidenceCoordinate {
+    /// Installed contract evidence identity that owns the coordinate.
+    pub contract: ContractEvidenceIdentity,
+    /// Retained evidence role.
+    pub role: RetainedEvidenceRole,
+    /// Domain-separated semantic digest for the exact receipt, witness,
+    /// reading, or artifact coordinate.
+    pub semantic_digest: Hash,
+}
+
+impl RetainedEvidenceCoordinate {
+    /// Builds a retained evidence coordinate.
+    #[must_use]
+    pub fn new(
+        contract: ContractEvidenceIdentity,
+        role: RetainedEvidenceRole,
+        semantic_digest: Hash,
+    ) -> Self {
+        Self {
+            contract,
+            role,
+            semantic_digest,
+        }
+    }
+
+    /// Stable coordinate id used for missing-retention obstruction subjects.
+    #[must_use]
+    pub fn coordinate_id(&self) -> Hash {
+        let mut hasher = Hasher::new();
+        hasher.update(RETAINED_EVIDENCE_COORDINATE_ID_DOMAIN);
+        update_contract_identity(&mut hasher, &self.contract);
+        hasher.update(&[self.role.tag()]);
+        hasher.update(&self.semantic_digest);
+        hasher.finalize().into()
+    }
+
+    /// Builds a typed missing-retention obstruction for this coordinate.
+    #[must_use]
+    pub fn missing_retention_obstruction(&self) -> ContractObstruction {
+        ContractObstruction::missing_retention(self.coordinate_id())
+            .with_contract(self.contract.clone())
+    }
+}
+
+/// First-class reference to retained contract evidence bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetainedEvidenceRef {
+    /// Semantic coordinate that explains what the retained bytes answer.
+    pub coordinate: RetainedEvidenceCoordinate,
+    /// Content-only hash for the retained bytes.
+    pub content_hash: Hash,
+    /// Retained byte length.
+    pub byte_len: u64,
+}
+
+impl RetainedEvidenceRef {
+    /// Builds a retained evidence reference.
+    #[must_use]
+    pub fn new(coordinate: RetainedEvidenceCoordinate, content_hash: Hash, byte_len: u64) -> Self {
+        Self {
+            coordinate,
+            content_hash,
+            byte_len,
+        }
+    }
+
+    /// Stable id that binds semantic coordinate, content hash, and byte length.
+    #[must_use]
+    pub fn evidence_ref_id(&self) -> Hash {
+        let mut hasher = Hasher::new();
+        hasher.update(RETAINED_EVIDENCE_REF_ID_DOMAIN);
+        hasher.update(&self.coordinate.coordinate_id());
+        hasher.update(&self.content_hash);
+        hasher.update(&self.byte_len.to_le_bytes());
+        hasher.finalize().into()
+    }
+
+    /// Builds a typed missing-retention obstruction for this exact retained ref.
+    #[must_use]
+    pub fn missing_retention_obstruction(&self) -> ContractObstruction {
+        ContractObstruction::missing_retention(self.evidence_ref_id())
+            .with_contract(self.coordinate.contract.clone())
+    }
+}
+
+/// Retained evidence availability posture.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RetainedEvidencePosture {
+    /// The retained evidence is locally available.
+    Available(RetainedEvidenceRef),
+    /// Required retained evidence is missing.
+    MissingRetention(ContractObstruction),
+}
+
+impl RetainedEvidencePosture {
+    /// Builds an available retained evidence posture.
+    #[must_use]
+    pub fn available(reference: RetainedEvidenceRef) -> Self {
+        Self::Available(reference)
+    }
+
+    /// Builds a missing posture for a semantic coordinate with no local
+    /// descriptor.
+    #[must_use]
+    pub fn missing_coordinate(coordinate: &RetainedEvidenceCoordinate) -> Self {
+        Self::MissingRetention(coordinate.missing_retention_obstruction())
+    }
+
+    /// Builds a missing posture for a descriptor whose content bytes are absent.
+    #[must_use]
+    pub fn missing_content(reference: &RetainedEvidenceRef) -> Self {
+        Self::MissingRetention(reference.missing_retention_obstruction())
+    }
+
+    /// Returns the missing-retention obstruction when this posture obstructs.
+    #[must_use]
+    pub fn obstruction(&self) -> Option<&ContractObstruction> {
+        match self {
+            Self::Available(_) => None,
+            Self::MissingRetention(obstruction) => Some(obstruction),
+        }
+    }
+}
+
+fn update_contract_identity(hasher: &mut Hasher, contract: &ContractEvidenceIdentity) {
+    hasher.update(contract.package_id.as_bytes());
+    update_string(hasher, &contract.package_name);
+    update_string(hasher, &contract.package_version);
+    update_string(hasher, &contract.artifact_hash_hex);
+    update_string(hasher, &contract.codec_id);
+    hasher.update(&contract.registry_version.to_le_bytes());
+    update_string(hasher, &contract.schema_sha256_hex);
+    hasher.update(&contract.op_id.to_le_bytes());
+    hasher.update(&[contract_operation_kind_tag(contract.op_kind)]);
+}
+
+fn update_string(hasher: &mut Hasher, value: &str) {
+    let bytes = value.as_bytes();
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+fn contract_operation_kind_tag(kind: ContractOperationKind) -> u8 {
+    match kind {
+        ContractOperationKind::Mutation => 0,
+        ContractOperationKind::Query => 1,
+    }
+}

--- a/crates/warp-core/src/retained_evidence.rs
+++ b/crates/warp-core/src/retained_evidence.rs
@@ -177,11 +177,14 @@ impl RetainedEvidencePosture {
 
 fn update_contract_identity(hasher: &mut Hasher, contract: &ContractEvidenceIdentity) {
     hasher.update(contract.package_id.as_bytes());
+    hasher.update(&contract.echo_abi_version.to_le_bytes());
     update_string(hasher, &contract.package_name);
     update_string(hasher, &contract.package_version);
     update_string(hasher, &contract.artifact_hash_hex);
     update_string(hasher, &contract.codec_id);
     hasher.update(&contract.registry_version.to_le_bytes());
+    update_string(hasher, &contract.wesley_generator_version);
+    hasher.update(&contract.helper_api_version.to_le_bytes());
     update_string(hasher, &contract.schema_sha256_hex);
     hasher.update(&contract.op_id.to_le_bytes());
     hasher.update(&[contract_operation_kind_tag(contract.op_kind)]);

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Reference trusted runtime host loop.
+//!
+//! This module names the local host role for the v0.1.0 contract path. It is a
+//! convenience wrapper around existing Echo runtime pieces; it does not create a
+//! daemon, does not make wall-clock cadence semantic, and does not give
+//! application code tick authority.
+
+use thiserror::Error;
+
+use crate::{
+    Engine, IngressEnvelope, InstalledContractPackage, InstalledContractPackageError,
+    InstalledContractPackageRecord, IntentOutcome, IntentSubmissionHandle, ObservationArtifact,
+    ObservationError, ObservationRequest, ObservationService, OpticAdmissionTicket,
+    ProvenanceService, RuntimeError, SchedulerCoordinator, StepRecord,
+    TicketedRuntimeIngressAuthority, TicketedRuntimeIngressDisposition, WorldlineRuntime,
+};
+use crate::{Hash, HistoryError};
+
+/// Error returned by the reference trusted host loop.
+#[derive(Debug, Error)]
+pub enum TrustedRuntimeHostError {
+    /// Provenance initialization failed.
+    #[error("trusted runtime host provenance error: {0}")]
+    Provenance(#[from] HistoryError),
+    /// Scheduler/runtime work failed.
+    #[error("trusted runtime host runtime error: {0}")]
+    Runtime(#[from] RuntimeError),
+    /// The host reached its caller-supplied scheduler-pass bound before idling.
+    #[error("trusted runtime host exceeded scheduler pass limit: {max_scheduler_passes}")]
+    SchedulerPassLimitExceeded {
+        /// Maximum scheduler passes the caller allowed.
+        max_scheduler_passes: u64,
+    },
+}
+
+/// Summary returned after a trusted host runs the scheduler until idle.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TrustedRuntimeHostRunReport {
+    /// Scheduler passes attempted, including the final idle pass.
+    pub scheduler_passes: u64,
+    /// Scheduler-owned step records committed across non-idle passes.
+    pub committed_steps: usize,
+}
+
+/// Local trusted runtime host for the app-safe contract-host path.
+///
+/// Application code should receive [`TrustedRuntimeApp`], not this type. This
+/// host owns package installation, ticketed runtime ingress, scheduler passes,
+/// and read-only observation service access.
+pub struct TrustedRuntimeHost {
+    runtime: WorldlineRuntime,
+    provenance: ProvenanceService,
+    engine: Engine,
+}
+
+impl TrustedRuntimeHost {
+    /// Builds a trusted host and initializes provenance from registered runtime
+    /// worldlines.
+    ///
+    /// # Errors
+    ///
+    /// Returns a provenance error if any runtime worldline cannot be registered.
+    pub fn new(runtime: WorldlineRuntime, engine: Engine) -> Result<Self, TrustedRuntimeHostError> {
+        let provenance = provenance_from_runtime(&runtime)?;
+        Ok(Self {
+            runtime,
+            provenance,
+            engine,
+        })
+    }
+
+    /// Builds a trusted host from already-initialized parts.
+    #[must_use]
+    pub fn from_parts(
+        runtime: WorldlineRuntime,
+        provenance: ProvenanceService,
+        engine: Engine,
+    ) -> Self {
+        Self {
+            runtime,
+            provenance,
+            engine,
+        }
+    }
+
+    /// Consumes the host and returns owned runtime parts.
+    #[must_use]
+    pub fn into_parts(self) -> (WorldlineRuntime, ProvenanceService, Engine) {
+        (self.runtime, self.provenance, self.engine)
+    }
+
+    /// Returns the host-owned runtime as read-only evidence.
+    #[must_use]
+    pub fn runtime(&self) -> &WorldlineRuntime {
+        &self.runtime
+    }
+
+    /// Returns the host-owned provenance service as read-only evidence.
+    #[must_use]
+    pub fn provenance(&self) -> &ProvenanceService {
+        &self.provenance
+    }
+
+    /// Returns the host-owned engine as read-only evidence.
+    #[must_use]
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    /// Returns the app-facing surface. This surface can submit and observe, but
+    /// it cannot tick, stage ticketed ingress, install packages, or recover
+    /// scheduler faults.
+    pub fn app(&mut self) -> TrustedRuntimeApp<'_> {
+        TrustedRuntimeApp { host: self }
+    }
+
+    /// Installs a generated contract package through the trusted host boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an installed-package error when registry verification fails or
+    /// any handler/observer conflicts with existing runtime state.
+    pub fn install_contract_package<'a>(
+        &mut self,
+        package: InstalledContractPackage<'a>,
+    ) -> Result<InstalledContractPackageRecord, InstalledContractPackageError<'a>> {
+        self.engine.install_contract_package(package)
+    }
+
+    /// Stages one witnessed installed-contract submission into runtime ingress.
+    ///
+    /// The host uses retained canonical envelope material and a supplied
+    /// admission ticket. This method does not tick or execute.
+    ///
+    /// # Errors
+    ///
+    /// Returns a runtime error if the submission is unknown, unsupported by an
+    /// installed package, or rejected by the ticketed ingress boundary.
+    pub fn stage_installed_contract_submission(
+        &mut self,
+        submission_id: Hash,
+        ticket: &OpticAdmissionTicket,
+    ) -> Result<TicketedRuntimeIngressDisposition, RuntimeError> {
+        let envelope = self
+            .runtime
+            .witnessed_submission_envelope(&submission_id)
+            .cloned()
+            .ok_or(RuntimeError::UnknownIntentSubmission(submission_id))?;
+        self.runtime.ingest_installed_contract_invocation(
+            &TicketedRuntimeIngressAuthority::assume_runtime_owner(),
+            &self.engine,
+            submission_id,
+            ticket,
+            envelope,
+        )
+    }
+
+    /// Runs one scheduler-owned pass.
+    ///
+    /// # Errors
+    ///
+    /// Returns a runtime error if the scheduler pass fails.
+    pub fn tick_once(&mut self) -> Result<Vec<StepRecord>, TrustedRuntimeHostError> {
+        SchedulerCoordinator::super_tick(&mut self.runtime, &mut self.provenance, &mut self.engine)
+            .map_err(Into::into)
+    }
+
+    /// Runs scheduler-owned passes until an idle pass occurs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the scheduler fails or if the caller-supplied pass
+    /// limit is reached before an idle pass.
+    pub fn run_until_idle(
+        &mut self,
+        max_scheduler_passes: u64,
+    ) -> Result<TrustedRuntimeHostRunReport, TrustedRuntimeHostError> {
+        if max_scheduler_passes == 0 {
+            return Err(TrustedRuntimeHostError::SchedulerPassLimitExceeded {
+                max_scheduler_passes,
+            });
+        }
+
+        let mut report = TrustedRuntimeHostRunReport::default();
+        loop {
+            if report.scheduler_passes == max_scheduler_passes {
+                return Err(TrustedRuntimeHostError::SchedulerPassLimitExceeded {
+                    max_scheduler_passes,
+                });
+            }
+            let steps = self.tick_once()?;
+            report.scheduler_passes += 1;
+            if steps.is_empty() {
+                return Ok(report);
+            }
+            report.committed_steps += steps.len();
+        }
+    }
+}
+
+/// App-facing handle for a trusted local runtime host.
+///
+/// This type intentionally exposes no scheduler control, package installation,
+/// ticketed ingress staging, or fault recovery authority.
+pub struct TrustedRuntimeApp<'a> {
+    host: &'a mut TrustedRuntimeHost,
+}
+
+impl TrustedRuntimeApp<'_> {
+    /// Submits canonical intent material as witnessed ingress history.
+    ///
+    /// # Errors
+    ///
+    /// Returns a runtime error if the target cannot accept the submission.
+    pub fn submit_intent(
+        &mut self,
+        envelope: IngressEnvelope,
+    ) -> Result<IntentSubmissionHandle, RuntimeError> {
+        self.host.runtime.submit_app_intent(envelope)
+    }
+
+    /// Observes the product-facing outcome for one witnessed submission.
+    #[must_use]
+    pub fn observe_intent_outcome(&self, submission_id: &Hash) -> IntentOutcome {
+        self.host.runtime.observe_app_intent_outcome(submission_id)
+    }
+
+    /// Runs a read-only observation through the host-owned query service.
+    ///
+    /// # Errors
+    ///
+    /// Returns an observation error when the query is unsupported, malformed, or
+    /// obstructed by the requested basis/aperture/budget.
+    pub fn observe(
+        &self,
+        request: ObservationRequest,
+    ) -> Result<ObservationArtifact, ObservationError> {
+        ObservationService::observe(
+            &self.host.runtime,
+            &self.host.provenance,
+            &self.host.engine,
+            request,
+        )
+    }
+}
+
+fn provenance_from_runtime(
+    runtime: &WorldlineRuntime,
+) -> Result<ProvenanceService, TrustedRuntimeHostError> {
+    let mut provenance = ProvenanceService::new();
+    for (worldline_id, frontier) in runtime.worldlines().iter() {
+        provenance.register_worldline(*worldline_id, frontier.state())?;
+    }
+    Ok(provenance)
+}

--- a/crates/warp-core/tests/contract_obstruction_taxonomy_tests.rs
+++ b/crates/warp-core/tests/contract_obstruction_taxonomy_tests.rs
@@ -84,13 +84,15 @@ fn residual_reading_posture_maps_to_residual_obstruction() {
     let obstruction = ContractObstruction::from_residual_posture(
         ReadingResidualPosture::Residual,
         Some(reading_id),
-    )
-    .expect("residual posture must map to contract obstruction");
+    );
 
-    assert_eq!(obstruction.kind, ContractObstructionKind::ResidualReading);
     assert_eq!(
-        obstruction.subject,
-        ContractObstructionSubject::Reading { reading_id }
+        obstruction.as_ref().map(|obstruction| obstruction.kind),
+        Some(ContractObstructionKind::ResidualReading)
+    );
+    assert_eq!(
+        obstruction.as_ref().map(|obstruction| &obstruction.subject),
+        Some(&ContractObstructionSubject::Reading { reading_id })
     );
 }
 

--- a/crates/warp-core/tests/contract_obstruction_taxonomy_tests.rs
+++ b/crates/warp-core/tests/contract_obstruction_taxonomy_tests.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Contract obstruction taxonomy regression tests.
+
+use warp_core::{
+    ContractObstruction, ContractObstructionKind, ContractObstructionSubject, ObservationAt,
+    ObservationError, ReadingResidualPosture, RuntimeError, SchedulerFaultId, WorldlineId,
+    WorldlineTick,
+};
+
+#[test]
+fn unsupported_query_maps_to_contract_query_obstruction() {
+    let obstruction =
+        ContractObstruction::from_observation_error(&ObservationError::UnsupportedQuery {
+            query_id: 42,
+        });
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::UnsupportedQuery);
+    assert_eq!(
+        obstruction.subject,
+        ContractObstructionSubject::Query { query_id: 42 }
+    );
+}
+
+#[test]
+fn observation_budget_error_maps_to_budget_obstruction() {
+    let obstruction =
+        ContractObstruction::from_observation_error(&ObservationError::BudgetExceeded {
+            max_payload_bytes: 8,
+            payload_bytes: 16,
+            max_witness_refs: 1,
+            witness_refs: 1,
+        });
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::BudgetExceeded);
+    assert_eq!(obstruction.subject, ContractObstructionSubject::Unspecified);
+}
+
+#[test]
+fn invalid_observation_basis_maps_to_stale_basis_obstruction() {
+    let worldline_id = WorldlineId::from_bytes([7; 32]);
+    let obstruction = ContractObstruction::from_observation_error(&ObservationError::InvalidTick {
+        worldline_id,
+        tick: WorldlineTick::from_raw(99),
+    });
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::StaleBasis);
+    assert_eq!(obstruction.subject, ContractObstructionSubject::Unspecified);
+}
+
+#[test]
+fn unsupported_installed_mutation_maps_to_operation_obstruction() {
+    let obstruction = ContractObstruction::from_runtime_error(
+        &RuntimeError::UnsupportedInstalledContractMutation { op_id: 7001 },
+    );
+
+    assert_eq!(
+        obstruction.kind,
+        ContractObstructionKind::UnsupportedOperation
+    );
+    assert_eq!(
+        obstruction.subject,
+        ContractObstructionSubject::Operation { op_id: 7001 }
+    );
+}
+
+#[test]
+fn scheduler_fault_maps_to_runtime_fault_obstruction() {
+    let fault_id = SchedulerFaultId::from_bytes([9; 32]);
+    let obstruction = ContractObstruction::from_runtime_error(
+        &RuntimeError::SchedulerRuntimeFaultActive(fault_id),
+    );
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::RuntimeFault);
+    assert_eq!(
+        obstruction.subject,
+        ContractObstructionSubject::SchedulerFault { fault_id }
+    );
+}
+
+#[test]
+fn residual_reading_posture_maps_to_residual_obstruction() {
+    let reading_id = [11; 32];
+    let obstruction = ContractObstruction::from_residual_posture(
+        ReadingResidualPosture::Residual,
+        Some(reading_id),
+    )
+    .expect("residual posture must map to contract obstruction");
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::ResidualReading);
+    assert_eq!(
+        obstruction.subject,
+        ContractObstructionSubject::Reading { reading_id }
+    );
+}
+
+#[test]
+fn complete_reading_posture_does_not_map_to_obstruction() {
+    assert_eq!(
+        ContractObstruction::from_residual_posture(ReadingResidualPosture::Complete, None),
+        None
+    );
+}
+
+#[test]
+fn direct_missing_retention_constructor_is_typed() {
+    let retention_id = [13; 32];
+    let obstruction = ContractObstruction::missing_retention(retention_id);
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::MissingRetention);
+    assert_eq!(
+        obstruction.subject,
+        ContractObstructionSubject::Retention { retention_id }
+    );
+}
+
+#[test]
+fn unavailable_observation_maps_to_stale_basis_obstruction() {
+    let worldline_id = WorldlineId::from_bytes([17; 32]);
+    let obstruction =
+        ContractObstruction::from_observation_error(&ObservationError::ObservationUnavailable {
+            worldline_id,
+            at: ObservationAt::Frontier,
+        });
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::StaleBasis);
+}
+
+#[test]
+fn codec_failure_maps_to_runtime_fault_obstruction() {
+    let obstruction = ContractObstruction::from_observation_error(&ObservationError::CodecFailure(
+        "canonical encoding failed".to_owned(),
+    ));
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::RuntimeFault);
+}
+
+#[test]
+fn unrelated_runtime_tick_overflow_maps_to_runtime_fault_obstruction() {
+    let obstruction = ContractObstruction::from_runtime_error(&RuntimeError::GlobalTickOverflow);
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::RuntimeFault);
+}
+
+#[test]
+fn admission_related_runtime_error_maps_to_admission_obstruction() {
+    let obstruction = ContractObstruction::from_runtime_error(
+        &RuntimeError::TicketedIngressAlreadyStaged([19; 32]),
+    );
+
+    assert_eq!(
+        obstruction.kind,
+        ContractObstructionKind::AdmissionObstruction
+    );
+}

--- a/crates/warp-core/tests/external_consumer_contract_fixture_tests.rs
+++ b/crates/warp-core/tests/external_consumer_contract_fixture_tests.rs
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Serious external-consumer-shaped contract fixture.
+#![cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
+#![allow(clippy::expect_used, clippy::panic)]
+
+use echo_cas::{MemoryTier, RetainedBlobIndex, RetainedBlobRole, SemanticBlobCoordinate};
+use echo_registry_api::{
+    ArgDef, ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, RegistryInfo,
+    RegistryProvider,
+};
+use warp_core::{
+    make_head_id, make_intent_kind, make_node_id, make_type_id, AuthoredObserverPlan,
+    ContractEvidenceIdentity, ContractMutationHandler, ContractOperationKind,
+    ContractPackageIdentity, ContractQueryObserver, ContractQueryObserverResult, EngineBuilder,
+    GraphStore, GraphView, InboxPolicy, IngressEnvelope, IngressTarget, IntentOutcome, NodeId,
+    NodeRecord, ObservationAt, ObservationCoordinate, ObservationFrame, ObservationPayload,
+    ObservationProjection, ObservationReadBudget, ObservationRequest, ObserverPlanId,
+    OpticAdmissionTicket, OpticArtifactHandle, PatternGraph, PlaybackMode, SchedulerKind,
+    TickDelta, TickReceiptRejection, TrustedRuntimeHost, WarpOp, WorldlineId, WorldlineRuntime,
+    WorldlineState, WriterHead, WriterHeadKey, OPTIC_ADMISSION_TICKET_KIND,
+    OPTIC_ARTIFACT_HANDLE_KIND,
+};
+
+const SCHEMA_SHA256_HEX: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const ARTIFACT_HASH_HEX: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const REPLACE_RANGE_OP_ID: u32 = 7101;
+const DOCUMENT_WINDOW_QUERY_ID: u32 = 7102;
+const REPLACE_VARS_A: &[u8] = b"doc=alpha;range=0..5;text=hello";
+const REPLACE_VARS_B: &[u8] = b"doc=alpha;range=0..5;text=hullo";
+const QUERY_VARS: &[u8] = b"doc=alpha;window=0..16";
+const QUERY_BYTES: &[u8] = b"doc=alpha;window=hello";
+const DOCUMENT_NODE_LABEL: &str = "external-consumer/jedit-like/document-alpha";
+const DOCUMENT_VALUE_TYPE: &str = "external-consumer/jedit-like/document-value";
+const REPLACE_RULE_NAME: &str =
+    "cmd/contract/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/7101/replaceRange";
+const REPLACE_RULE_ID_LABEL: &str =
+    "rule:cmd/contract/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/7101/replaceRange";
+
+static REPLACE_ARGS: &[ArgDef] = &[ArgDef {
+    name: "input",
+    ty: "ReplaceRangeInput",
+    required: true,
+    list: false,
+}];
+
+static OPS: &[OpDef] = &[
+    OpDef {
+        kind: OpKind::Mutation,
+        name: "replaceRange",
+        op_id: REPLACE_RANGE_OP_ID,
+        args: REPLACE_ARGS,
+        result_ty: "DocumentEditReceipt",
+        directives_json: "{}",
+        footprint_certificate: None,
+    },
+    OpDef {
+        kind: OpKind::Query,
+        name: "documentWindow",
+        op_id: DOCUMENT_WINDOW_QUERY_ID,
+        args: REPLACE_ARGS,
+        result_ty: "DocumentWindow",
+        directives_json: "{}",
+        footprint_certificate: None,
+    },
+];
+
+struct StaticRegistry;
+
+impl RegistryProvider for StaticRegistry {
+    fn info(&self) -> RegistryInfo {
+        RegistryInfo {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
+        }
+    }
+
+    fn op_by_id(&self, op_id: u32) -> Option<&'static OpDef> {
+        OPS.iter().find(|op| op.op_id == op_id)
+    }
+
+    fn all_ops(&self) -> &'static [OpDef] {
+        OPS
+    }
+
+    fn all_enums(&self) -> &'static [echo_registry_api::EnumDef] {
+        &[]
+    }
+
+    fn all_objects(&self) -> &'static [ObjectDef] {
+        &[]
+    }
+}
+
+fn empty_engine() -> warp_core::Engine {
+    let mut store = GraphStore::default();
+    let root = make_node_id("root");
+    store.insert_node(
+        root,
+        NodeRecord {
+            ty: make_type_id("world"),
+        },
+    );
+    EngineBuilder::new(store, root)
+        .scheduler(SchedulerKind::Radix)
+        .workers(1)
+        .build()
+}
+
+fn document_node_id() -> NodeId {
+    make_node_id(DOCUMENT_NODE_LABEL)
+}
+
+fn replace_matches(view: GraphView<'_>, scope: &NodeId) -> bool {
+    warp_core::eint_vars_for_op(view, scope, REPLACE_RANGE_OP_ID).is_some()
+}
+
+fn replace_execute(view: GraphView<'_>, scope: &NodeId, delta: &mut TickDelta) {
+    let Some(vars) = warp_core::eint_vars_for_op(view, scope, REPLACE_RANGE_OP_ID) else {
+        return;
+    };
+    let warp_id = view.warp_id();
+    let document = document_node_id();
+    delta.push(WarpOp::UpsertNode {
+        node: warp_core::NodeKey {
+            warp_id,
+            local_id: document,
+        },
+        record: NodeRecord {
+            ty: make_type_id(DOCUMENT_VALUE_TYPE),
+        },
+    });
+    delta.push(WarpOp::SetAttachment {
+        key: warp_core::AttachmentKey::node_alpha(warp_core::NodeKey {
+            warp_id,
+            local_id: document,
+        }),
+        value: Some(warp_core::AttachmentValue::Atom(
+            warp_core::AtomPayload::new(
+                make_type_id(DOCUMENT_VALUE_TYPE),
+                bytes::Bytes::copy_from_slice(vars),
+            ),
+        )),
+    });
+}
+
+fn replace_footprint(view: GraphView<'_>, scope: &NodeId) -> warp_core::Footprint {
+    let mut footprint = warp_core::runtime_ingress_eint_read_footprint(view, scope);
+    let warp_id = view.warp_id();
+    let document = document_node_id();
+    footprint.n_write.insert_with_warp(warp_id, document);
+    footprint
+        .a_write
+        .insert(warp_core::AttachmentKey::node_alpha(warp_core::NodeKey {
+            warp_id,
+            local_id: document,
+        }));
+    footprint
+}
+
+fn replace_rule() -> warp_core::RewriteRule {
+    warp_core::RewriteRule {
+        id: make_type_id(REPLACE_RULE_ID_LABEL).0,
+        name: REPLACE_RULE_NAME,
+        left: PatternGraph { nodes: vec![] },
+        matcher: replace_matches,
+        executor: replace_execute,
+        compute_footprint: replace_footprint,
+        factor_mask: 0,
+        conflict_policy: warp_core::ConflictPolicy::Abort,
+        join_fn: None,
+    }
+}
+
+fn document_window_observer() -> ContractQueryObserver {
+    ContractQueryObserver::new(DOCUMENT_WINDOW_QUERY_ID, observer_plan(), |context| {
+        assert_eq!(context.vars_bytes, QUERY_VARS);
+        Ok(ContractQueryObserverResult::complete(QUERY_BYTES.to_vec()))
+    })
+}
+
+fn observer_plan() -> AuthoredObserverPlan {
+    AuthoredObserverPlan {
+        plan_id: ObserverPlanId::from_bytes([31; 32]),
+        artifact_hash: [32; 32],
+        schema_hash: [33; 32],
+        state_schema_hash: [34; 32],
+        update_law_hash: [35; 32],
+        emission_law_hash: [36; 32],
+    }
+}
+
+fn package() -> warp_core::InstalledContractPackage<'static> {
+    static REGISTRY: StaticRegistry = StaticRegistry;
+    warp_core::InstalledContractPackage {
+        identity: ContractPackageIdentity {
+            package_name: "jedit-shaped-hot-text",
+            package_version: "0.1.0",
+            artifact_hash_hex: ARTIFACT_HASH_HEX,
+        },
+        registry: &REGISTRY,
+        verification_policy: ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
+            footprint_certificates: &[],
+            require_mutation_footprint_certificates: false,
+        },
+        mutation_handlers: vec![ContractMutationHandler {
+            op_id: REPLACE_RANGE_OP_ID,
+            rule: replace_rule(),
+        }],
+        query_observers: vec![document_window_observer()],
+    }
+}
+
+fn runtime() -> (WorldlineRuntime, WorldlineId) {
+    let mut runtime = WorldlineRuntime::new();
+    let worldline_id = WorldlineId::from_bytes([1; 32]);
+    runtime
+        .register_worldline(worldline_id, WorldlineState::empty())
+        .expect("worldline should register");
+    runtime
+        .register_writer_head(WriterHead::with_routing(
+            WriterHeadKey {
+                worldline_id,
+                head_id: make_head_id("default"),
+            },
+            PlaybackMode::Play,
+            InboxPolicy::AcceptAll,
+            None,
+            true,
+        ))
+        .expect("writer head should register");
+    (runtime, worldline_id)
+}
+
+fn replace_envelope(worldline_id: WorldlineId, vars: &[u8]) -> IngressEnvelope {
+    IngressEnvelope::local_intent(
+        IngressTarget::DefaultWriter { worldline_id },
+        make_intent_kind("echo.intent/eint-v1"),
+        echo_wasm_abi::pack_intent_v1(REPLACE_RANGE_OP_ID, vars).expect("EINT should pack"),
+    )
+}
+
+fn query_request(worldline_id: WorldlineId) -> ObservationRequest {
+    let mut request = ObservationRequest::builtin_one_shot(
+        ObservationCoordinate {
+            worldline_id,
+            at: ObservationAt::Frontier,
+        },
+        ObservationFrame::QueryView,
+        ObservationProjection::Query {
+            query_id: DOCUMENT_WINDOW_QUERY_ID,
+            vars_bytes: QUERY_VARS.to_vec(),
+        },
+    )
+    .expect("query request should build");
+    request.budget = ObservationReadBudget::Bounded {
+        max_payload_bytes: 128,
+        max_witness_refs: 1,
+    };
+    request
+}
+
+fn admission_ticket(seed: u8) -> OpticAdmissionTicket {
+    OpticAdmissionTicket {
+        kind: OPTIC_ADMISSION_TICKET_KIND.to_owned(),
+        artifact_handle: OpticArtifactHandle {
+            kind: OPTIC_ARTIFACT_HANDLE_KIND.to_owned(),
+            id: format!("external-consumer-{seed}"),
+        },
+        artifact_hash: format!("artifact-hash-{seed}"),
+        operation_id: format!("operation-{seed}"),
+        requirements_digest: format!("requirements-{seed}"),
+        canonical_variables_digest: vec![seed],
+        basis_request_digest: [seed; 32],
+        aperture_request_digest: [seed.wrapping_add(1); 32],
+        budget_request_digest: [seed.wrapping_add(2); 32],
+        law_witness_digest: [seed.wrapping_add(3); 32],
+        ticket_digest: [seed.wrapping_add(4); 32],
+    }
+}
+
+fn semantic_coordinate(
+    contract: &ContractEvidenceIdentity,
+    role: RetainedBlobRole,
+    semantic_digest: [u8; 32],
+) -> SemanticBlobCoordinate {
+    SemanticBlobCoordinate {
+        namespace: contract.package_name.clone(),
+        schema_hash_hex: contract.schema_sha256_hex.clone(),
+        artifact_hash_hex: contract.artifact_hash_hex.clone(),
+        role,
+        semantic_digest,
+    }
+}
+
+#[test]
+fn serious_external_consumer_fixture_proves_hosted_contract_path() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.install_contract_package(package())
+        .expect("external package should install");
+
+    let (submission_a, submission_b) = {
+        let mut app = host.app();
+        let submission_a = app
+            .submit_intent(replace_envelope(worldline_id, REPLACE_VARS_A))
+            .expect("first edit should submit");
+        let submission_b = app
+            .submit_intent(replace_envelope(worldline_id, REPLACE_VARS_B))
+            .expect("conflicting edit should submit");
+        assert!(matches!(
+            app.observe_intent_outcome(&submission_a.submission_id),
+            IntentOutcome::Pending { .. }
+        ));
+        (submission_a, submission_b)
+    };
+
+    host.stage_installed_contract_submission(submission_a.submission_id, &admission_ticket(41))
+        .expect("first edit should stage");
+    host.stage_installed_contract_submission(submission_b.submission_id, &admission_ticket(42))
+        .expect("second edit should stage");
+    host.run_until_idle(4)
+        .expect("trusted host should tick until idle");
+
+    let outcome_a = host
+        .runtime()
+        .observe_app_intent_outcome(&submission_a.submission_id);
+    let outcome_b = host
+        .runtime()
+        .observe_app_intent_outcome(&submission_b.submission_id);
+    let rejected = [&outcome_a, &outcome_b]
+        .into_iter()
+        .filter_map(|outcome| match outcome {
+            IntentOutcome::Rejected {
+                reason, blocked_by, ..
+            } => Some((*reason, blocked_by.as_slice())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(rejected.len(), 1);
+    assert_eq!(rejected[0].0, TickReceiptRejection::FootprintConflict);
+    assert_eq!(rejected[0].1, &[0]);
+
+    let reading = {
+        let app = host.app();
+        app.observe(query_request(worldline_id))
+            .expect("external query should observe")
+    };
+    assert!(matches!(
+        reading.payload,
+        ObservationPayload::QueryBytes(bytes) if bytes == QUERY_BYTES
+    ));
+    let query_contract = reading
+        .reading
+        .contract
+        .as_ref()
+        .expect("external reading should carry contract evidence");
+    assert_eq!(query_contract.op_kind, ContractOperationKind::Query);
+    assert_eq!(query_contract.package_name, "jedit-shaped-hot-text");
+
+    let mut blobs = MemoryTier::new();
+    let mut retained = RetainedBlobIndex::default();
+    let reading_identity = reading
+        .reading
+        .query_identity
+        .as_ref()
+        .expect("external reading should carry query identity");
+    let reading_coord = semantic_coordinate(
+        query_contract,
+        RetainedBlobRole::ReadingPayload,
+        reading_identity.reading_id,
+    );
+    let reading_descriptor = retained
+        .retain(&mut blobs, reading_coord.clone(), QUERY_BYTES)
+        .expect("reading payload should retain");
+    assert_eq!(reading_descriptor.byte_len, QUERY_BYTES.len() as u64);
+    assert_eq!(
+        retained
+            .load_range(&blobs, &reading_coord, 4, 9, 9)
+            .expect("semantic retained reading range should load")
+            .bytes
+            .as_ref(),
+        b"alpha;win"
+    );
+
+    let receipt_correlation = host
+        .runtime()
+        .receipt_correlation_for_submission(&submission_a.submission_id)
+        .or_else(|| {
+            host.runtime()
+                .receipt_correlation_for_submission(&submission_b.submission_id)
+        })
+        .expect("one external edit should carry receipt correlation");
+    let receipt_contract = receipt_correlation
+        .contract
+        .as_ref()
+        .expect("external receipt should carry contract evidence");
+    assert_eq!(receipt_contract.op_kind, ContractOperationKind::Mutation);
+    let receipt_coord = semantic_coordinate(
+        receipt_contract,
+        RetainedBlobRole::ContractReceipt,
+        receipt_correlation.tick_receipt_digest,
+    );
+    let receipt_descriptor = retained
+        .retain(&mut blobs, receipt_coord, b"external-jedit-shaped-receipt")
+        .expect("receipt evidence should retain");
+    assert_eq!(receipt_descriptor.byte_len, 29);
+}

--- a/crates/warp-core/tests/installed_contract_intent_pipeline_tests.rs
+++ b/crates/warp-core/tests/installed_contract_intent_pipeline_tests.rs
@@ -86,9 +86,12 @@ struct StaticRegistry;
 impl RegistryProvider for StaticRegistry {
     fn info(&self) -> RegistryInfo {
         RegistryInfo {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
         }
     }
 
@@ -134,9 +137,12 @@ fn package_identity() -> ContractPackageIdentity<'static> {
 
 fn verification_policy() -> ContractArtifactVerificationPolicy<'static> {
     ContractArtifactVerificationPolicy {
+        echo_abi_version: 1,
         codec_id: "cbor-canon-v1",
         registry_version: 1,
         schema_sha256_hex: SCHEMA_SHA256_HEX,
+        wesley_generator_version: "echo-wesley-gen/0.1.0",
+        helper_api_version: 1,
         footprint_certificates: &[],
         require_mutation_footprint_certificates: false,
     }

--- a/crates/warp-core/tests/installed_contract_registry_tests.rs
+++ b/crates/warp-core/tests/installed_contract_registry_tests.rs
@@ -4,8 +4,8 @@
 #![cfg(feature = "native_rule_bootstrap")]
 
 use echo_registry_api::{
-    ArgDef, ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, RegistryInfo,
-    RegistryProvider,
+    ArgDef, ContractArtifactRejection, ContractArtifactVerificationPolicy, ObjectDef, OpDef,
+    OpKind, RegistryInfo, RegistryProvider,
 };
 use warp_core::{
     make_node_id, make_type_id, AuthoredObserverPlan, ContractMutationHandler,
@@ -73,9 +73,12 @@ struct StaticRegistry;
 impl RegistryProvider for StaticRegistry {
     fn info(&self) -> RegistryInfo {
         RegistryInfo {
+            echo_abi_version: 1,
             codec_id: "cbor-canon-v1",
             registry_version: 1,
             schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
         }
     }
 
@@ -118,9 +121,12 @@ fn package_identity() -> ContractPackageIdentity<'static> {
 
 fn verification_policy() -> ContractArtifactVerificationPolicy<'static> {
     ContractArtifactVerificationPolicy {
+        echo_abi_version: 1,
         codec_id: "cbor-canon-v1",
         registry_version: 1,
         schema_sha256_hex: SCHEMA_SHA256_HEX,
+        wesley_generator_version: "echo-wesley-gen/0.1.0",
+        helper_api_version: 1,
         footprint_certificates: &[],
         require_mutation_footprint_certificates: false,
     }
@@ -128,9 +134,12 @@ fn verification_policy() -> ContractArtifactVerificationPolicy<'static> {
 
 fn mismatched_verification_policy() -> ContractArtifactVerificationPolicy<'static> {
     ContractArtifactVerificationPolicy {
+        echo_abi_version: 1,
         codec_id: "cbor-canon-v1",
         registry_version: 1,
         schema_sha256_hex: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        wesley_generator_version: "echo-wesley-gen/0.1.0",
+        helper_api_version: 1,
         footprint_certificates: &[],
         require_mutation_footprint_certificates: false,
     }
@@ -309,8 +318,11 @@ fn installed_contract_package_binds_supported_mutation_and_query() -> Result<(),
         package_identity().artifact_hash_hex
     );
     assert_eq!(contract.schema_sha256_hex, SCHEMA_SHA256_HEX);
+    assert_eq!(contract.echo_abi_version, 1);
     assert_eq!(contract.codec_id, "cbor-canon-v1");
     assert_eq!(contract.registry_version, 1);
+    assert_eq!(contract.wesley_generator_version, "echo-wesley-gen/0.1.0");
+    assert_eq!(contract.helper_api_version, 1);
     assert_eq!(contract.op_id, QUERY_OP_ID);
     assert_eq!(contract.op_kind, warp_core::ContractOperationKind::Query);
     Ok(())
@@ -548,6 +560,43 @@ fn installed_contract_package_rejects_artifact_verification_without_registration
     assert!(matches!(
         err,
         InstalledContractPackageError::ArtifactRejected(_)
+    ));
+    assert_eq!(
+        engine.installed_contract_mutation_package_id(MUTATION_OP_ID),
+        None
+    );
+    assert_eq!(
+        engine.installed_contract_query_package_id(QUERY_OP_ID),
+        None
+    );
+    Ok(())
+}
+
+#[test]
+fn installed_contract_package_rejects_helper_api_mismatch_without_registration(
+) -> Result<(), String> {
+    let mut engine = engine();
+    let mut policy = verification_policy();
+    policy.helper_api_version = 2;
+    let package = package_with_handlers(
+        package_identity(),
+        policy,
+        vec![mutation_handler(MUTATION_OP_ID)],
+        vec![query_observer(QUERY_OP_ID)],
+    );
+
+    let Err(err) = engine.install_contract_package(package) else {
+        return Err("helper API mismatch must be rejected".to_owned());
+    };
+
+    assert!(matches!(
+        err,
+        InstalledContractPackageError::ArtifactRejected(
+            ContractArtifactRejection::HelperApiVersionMismatch {
+                expected: 2,
+                actual: 1,
+            }
+        )
     ));
     assert_eq!(
         engine.installed_contract_mutation_package_id(MUTATION_OP_ID),

--- a/crates/warp-core/tests/retained_evidence_ref_tests.rs
+++ b/crates/warp-core/tests/retained_evidence_ref_tests.rs
@@ -97,17 +97,24 @@ fn retained_evidence_role_separates_payload_from_envelope() {
 fn missing_coordinate_returns_missing_retention_obstruction_with_contract() {
     let coord = coordinate(RetainedEvidenceRole::Witness, 5);
     let posture = RetainedEvidencePosture::missing_coordinate(&coord);
-    let obstruction = posture
-        .obstruction()
-        .expect("missing coordinate should obstruct");
 
-    assert_eq!(obstruction.kind, ContractObstructionKind::MissingRetention);
-    assert_eq!(obstruction.contract.as_ref(), Some(&coord.contract));
     assert_eq!(
-        obstruction.subject,
-        ContractObstructionSubject::Retention {
-            retention_id: coord.coordinate_id()
-        }
+        posture.obstruction().map(|obstruction| obstruction.kind),
+        Some(ContractObstructionKind::MissingRetention)
+    );
+    assert_eq!(
+        posture
+            .obstruction()
+            .and_then(|obstruction| obstruction.contract.as_ref()),
+        Some(&coord.contract)
+    );
+    assert_eq!(
+        posture
+            .obstruction()
+            .map(|obstruction| &obstruction.subject),
+        Some(&ContractObstructionSubject::Retention {
+            retention_id: coord.coordinate_id(),
+        })
     );
 }
 
@@ -119,16 +126,18 @@ fn missing_content_returns_missing_retention_obstruction_with_ref_id() {
         16,
     );
     let posture = RetainedEvidencePosture::missing_content(&reference);
-    let obstruction = posture
-        .obstruction()
-        .expect("missing content should obstruct");
 
-    assert_eq!(obstruction.kind, ContractObstructionKind::MissingRetention);
     assert_eq!(
-        obstruction.subject,
-        ContractObstructionSubject::Retention {
-            retention_id: reference.evidence_ref_id()
-        }
+        posture.obstruction().map(|obstruction| obstruction.kind),
+        Some(ContractObstructionKind::MissingRetention)
+    );
+    assert_eq!(
+        posture
+            .obstruction()
+            .map(|obstruction| &obstruction.subject),
+        Some(&ContractObstructionSubject::Retention {
+            retention_id: reference.evidence_ref_id(),
+        })
     );
 }
 

--- a/crates/warp-core/tests/retained_evidence_ref_tests.rs
+++ b/crates/warp-core/tests/retained_evidence_ref_tests.rs
@@ -19,11 +19,14 @@ fn content_hash(bytes: &[u8]) -> [u8; 32] {
 fn contract(seed: u8, op_id: u32, op_kind: ContractOperationKind) -> ContractEvidenceIdentity {
     ContractEvidenceIdentity {
         package_id: InstalledContractPackageId::from_bytes(hash(seed)),
+        echo_abi_version: 1,
         package_name: format!("pkg-{seed}"),
         package_version: "0.1.0".to_owned(),
         artifact_hash_hex: format!("{seed:02x}").repeat(32),
         codec_id: format!("codec-{seed}"),
         registry_version: 1,
+        wesley_generator_version: "echo-wesley-gen/0.1.0".to_owned(),
+        helper_api_version: 1,
         schema_sha256_hex: format!("{:02x}", seed.wrapping_add(1)).repeat(32),
         op_id,
         op_kind,

--- a/crates/warp-core/tests/retained_evidence_ref_tests.rs
+++ b/crates/warp-core/tests/retained_evidence_ref_tests.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Retained evidence reference regression tests.
+
+use warp_core::{
+    ContractEvidenceIdentity, ContractObstructionKind, ContractObstructionSubject,
+    ContractOperationKind, InstalledContractPackageId, RetainedEvidenceCoordinate,
+    RetainedEvidencePosture, RetainedEvidenceRef, RetainedEvidenceRole,
+};
+
+fn hash(seed: u8) -> [u8; 32] {
+    [seed; 32]
+}
+
+fn content_hash(bytes: &[u8]) -> [u8; 32] {
+    blake3::hash(bytes).into()
+}
+
+fn contract(seed: u8, op_id: u32, op_kind: ContractOperationKind) -> ContractEvidenceIdentity {
+    ContractEvidenceIdentity {
+        package_id: InstalledContractPackageId::from_bytes(hash(seed)),
+        package_name: format!("pkg-{seed}"),
+        package_version: "0.1.0".to_owned(),
+        artifact_hash_hex: format!("{seed:02x}").repeat(32),
+        codec_id: format!("codec-{seed}"),
+        registry_version: 1,
+        schema_sha256_hex: format!("{:02x}", seed.wrapping_add(1)).repeat(32),
+        op_id,
+        op_kind,
+    }
+}
+
+fn coordinate(role: RetainedEvidenceRole, semantic_seed: u8) -> RetainedEvidenceCoordinate {
+    RetainedEvidenceCoordinate::new(
+        contract(7, 42, ContractOperationKind::Query),
+        role,
+        hash(semantic_seed),
+    )
+}
+
+#[test]
+fn retained_evidence_ref_id_binds_semantic_coordinate() {
+    let content_hash = content_hash(b"same bytes");
+    let first = RetainedEvidenceRef::new(
+        coordinate(RetainedEvidenceRole::ReadingPayload, 1),
+        content_hash,
+        10,
+    );
+    let second = RetainedEvidenceRef::new(
+        coordinate(RetainedEvidenceRole::ReadingPayload, 2),
+        content_hash,
+        10,
+    );
+
+    assert_ne!(
+        first.coordinate.coordinate_id(),
+        second.coordinate.coordinate_id()
+    );
+    assert_ne!(first.evidence_ref_id(), second.evidence_ref_id());
+}
+
+#[test]
+fn retained_evidence_ref_id_binds_content_hash_and_byte_len() {
+    let coord = coordinate(RetainedEvidenceRole::ContractReceipt, 3);
+    let first = RetainedEvidenceRef::new(coord.clone(), content_hash(b"receipt"), 7);
+    let different_bytes = RetainedEvidenceRef::new(coord.clone(), content_hash(b"receipt!"), 8);
+    let different_len = RetainedEvidenceRef::new(coord, content_hash(b"receipt"), 99);
+
+    assert_ne!(first.evidence_ref_id(), different_bytes.evidence_ref_id());
+    assert_ne!(first.evidence_ref_id(), different_len.evidence_ref_id());
+}
+
+#[test]
+fn retained_evidence_role_separates_payload_from_envelope() {
+    let semantic_digest = hash(4);
+    let reading_payload = RetainedEvidenceCoordinate::new(
+        contract(8, 7, ContractOperationKind::Query),
+        RetainedEvidenceRole::ReadingPayload,
+        semantic_digest,
+    );
+    let reading_envelope = RetainedEvidenceCoordinate::new(
+        reading_payload.contract.clone(),
+        RetainedEvidenceRole::ReadingEnvelope,
+        semantic_digest,
+    );
+
+    assert_ne!(
+        reading_payload.coordinate_id(),
+        reading_envelope.coordinate_id()
+    );
+}
+
+#[test]
+fn missing_coordinate_returns_missing_retention_obstruction_with_contract() {
+    let coord = coordinate(RetainedEvidenceRole::Witness, 5);
+    let posture = RetainedEvidencePosture::missing_coordinate(&coord);
+    let obstruction = posture
+        .obstruction()
+        .expect("missing coordinate should obstruct");
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::MissingRetention);
+    assert_eq!(obstruction.contract.as_ref(), Some(&coord.contract));
+    assert_eq!(
+        obstruction.subject,
+        ContractObstructionSubject::Retention {
+            retention_id: coord.coordinate_id()
+        }
+    );
+}
+
+#[test]
+fn missing_content_returns_missing_retention_obstruction_with_ref_id() {
+    let reference = RetainedEvidenceRef::new(
+        coordinate(RetainedEvidenceRole::ReadingPayload, 6),
+        content_hash(b"retained reading"),
+        16,
+    );
+    let posture = RetainedEvidencePosture::missing_content(&reference);
+    let obstruction = posture
+        .obstruction()
+        .expect("missing content should obstruct");
+
+    assert_eq!(obstruction.kind, ContractObstructionKind::MissingRetention);
+    assert_eq!(
+        obstruction.subject,
+        ContractObstructionSubject::Retention {
+            retention_id: reference.evidence_ref_id()
+        }
+    );
+}
+
+#[test]
+fn available_retained_evidence_is_not_an_obstruction() {
+    let reference = RetainedEvidenceRef::new(
+        coordinate(RetainedEvidenceRole::ObserverArtifact, 9),
+        content_hash(b"observer artifact"),
+        17,
+    );
+    let posture = RetainedEvidencePosture::available(reference.clone());
+
+    assert_eq!(posture.obstruction(), None);
+    assert_eq!(posture, RetainedEvidencePosture::Available(reference));
+}
+
+#[test]
+fn query_identity_does_not_imply_payload_retention() {
+    let query_reading_id = hash(10);
+    let reading_payload = RetainedEvidenceCoordinate::new(
+        contract(10, 11, ContractOperationKind::Query),
+        RetainedEvidenceRole::ReadingPayload,
+        query_reading_id,
+    );
+    let missing = RetainedEvidencePosture::missing_coordinate(&reading_payload);
+
+    assert_eq!(
+        missing.obstruction().map(|obstruction| obstruction.kind),
+        Some(ContractObstructionKind::MissingRetention)
+    );
+}

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Reference trusted runtime host loop tests.
+#![cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
+#![allow(clippy::expect_used, clippy::panic)]
+
+use echo_registry_api::{
+    ArgDef, ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, RegistryInfo,
+    RegistryProvider,
+};
+use warp_core::{
+    make_head_id, make_intent_kind, make_node_id, make_type_id, AuthoredObserverPlan,
+    ContractMutationHandler, ContractOperationKind, ContractPackageIdentity, ContractQueryObserver,
+    ContractQueryObserverResult, EngineBuilder, GraphStore, GraphView, InboxPolicy,
+    IngressEnvelope, IngressTarget, IntentOutcome, NodeId, NodeRecord, ObservationAt,
+    ObservationCoordinate, ObservationFrame, ObservationPayload, ObservationProjection,
+    ObservationReadBudget, ObservationRequest, ObserverPlanId, OpticAdmissionTicket,
+    OpticArtifactHandle, PatternGraph, PlaybackMode, SchedulerKind, TickDelta, TrustedRuntimeHost,
+    WarpOp, WorldlineId, WorldlineRuntime, WorldlineState, WriterHead, WriterHeadKey,
+    OPTIC_ADMISSION_TICKET_KIND, OPTIC_ARTIFACT_HANDLE_KIND,
+};
+
+const SCHEMA_SHA256_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const MUTATION_OP_ID: u32 = 6001;
+const QUERY_OP_ID: u32 = 6002;
+const MUTATION_VARS: &[u8] = b"amount=7";
+const QUERY_VARS: &[u8] = b"window=frontier";
+const RESULT_TYPE: &str = "test/reference-host/result";
+const RESULT_BYTES: &[u8] = b"value=7";
+const QUERY_BYTES: &[u8] = b"window-value=7";
+const MUTATION_RULE_NAME: &str =
+    "cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/6001/increment";
+const MUTATION_RULE_ID_LABEL: &str =
+    "rule:cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/6001/increment";
+
+static INCREMENT_ARGS: &[ArgDef] = &[ArgDef {
+    name: "input",
+    ty: "IncrementInput",
+    required: true,
+    list: false,
+}];
+
+static OPS: &[OpDef] = &[
+    OpDef {
+        kind: OpKind::Mutation,
+        name: "increment",
+        op_id: MUTATION_OP_ID,
+        args: INCREMENT_ARGS,
+        result_ty: "CounterValue",
+        directives_json: "{}",
+        footprint_certificate: None,
+    },
+    OpDef {
+        kind: OpKind::Query,
+        name: "counterWindow",
+        op_id: QUERY_OP_ID,
+        args: INCREMENT_ARGS,
+        result_ty: "CounterWindow",
+        directives_json: "{}",
+        footprint_certificate: None,
+    },
+];
+
+struct StaticRegistry;
+
+impl RegistryProvider for StaticRegistry {
+    fn info(&self) -> RegistryInfo {
+        RegistryInfo {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
+        }
+    }
+
+    fn op_by_id(&self, op_id: u32) -> Option<&'static OpDef> {
+        OPS.iter().find(|op| op.op_id == op_id)
+    }
+
+    fn all_ops(&self) -> &'static [OpDef] {
+        OPS
+    }
+
+    fn all_enums(&self) -> &'static [echo_registry_api::EnumDef] {
+        &[]
+    }
+
+    fn all_objects(&self) -> &'static [ObjectDef] {
+        &[]
+    }
+}
+
+fn empty_engine() -> warp_core::Engine {
+    let mut store = GraphStore::default();
+    let root = make_node_id("root");
+    store.insert_node(
+        root,
+        NodeRecord {
+            ty: make_type_id("world"),
+        },
+    );
+    EngineBuilder::new(store, root)
+        .scheduler(SchedulerKind::Radix)
+        .workers(1)
+        .build()
+}
+
+fn contract_execute(view: GraphView<'_>, scope: &NodeId, delta: &mut TickDelta) {
+    if warp_core::eint_vars_for_op(view, scope, MUTATION_OP_ID) != Some(MUTATION_VARS) {
+        return;
+    }
+    let warp_id = view.warp_id();
+    let result = result_node_id(scope);
+    delta.push(WarpOp::UpsertNode {
+        node: warp_core::NodeKey {
+            warp_id,
+            local_id: result,
+        },
+        record: NodeRecord {
+            ty: make_type_id(RESULT_TYPE),
+        },
+    });
+    delta.push(WarpOp::SetAttachment {
+        key: warp_core::AttachmentKey::node_alpha(warp_core::NodeKey {
+            warp_id,
+            local_id: result,
+        }),
+        value: Some(warp_core::AttachmentValue::Atom(
+            warp_core::AtomPayload::new(
+                make_type_id(RESULT_TYPE),
+                bytes::Bytes::copy_from_slice(RESULT_BYTES),
+            ),
+        )),
+    });
+}
+
+fn contract_matches(view: GraphView<'_>, scope: &NodeId) -> bool {
+    warp_core::eint_vars_for_op(view, scope, MUTATION_OP_ID) == Some(MUTATION_VARS)
+}
+
+fn contract_footprint(view: GraphView<'_>, scope: &NodeId) -> warp_core::Footprint {
+    let mut footprint = warp_core::runtime_ingress_eint_read_footprint(view, scope);
+    let warp_id = view.warp_id();
+    let result = result_node_id(scope);
+    footprint.n_write.insert_with_warp(warp_id, result);
+    footprint
+        .a_write
+        .insert(warp_core::AttachmentKey::node_alpha(warp_core::NodeKey {
+            warp_id,
+            local_id: result,
+        }));
+    footprint
+}
+
+fn contract_rule() -> warp_core::RewriteRule {
+    warp_core::RewriteRule {
+        id: make_type_id(MUTATION_RULE_ID_LABEL).0,
+        name: MUTATION_RULE_NAME,
+        left: PatternGraph { nodes: vec![] },
+        matcher: contract_matches,
+        executor: contract_execute,
+        compute_footprint: contract_footprint,
+        factor_mask: 0,
+        conflict_policy: warp_core::ConflictPolicy::Abort,
+        join_fn: None,
+    }
+}
+
+fn query_observer() -> ContractQueryObserver {
+    ContractQueryObserver::new(QUERY_OP_ID, observer_plan(), |context| {
+        assert_eq!(context.vars_bytes, QUERY_VARS);
+        Ok(ContractQueryObserverResult::complete(QUERY_BYTES.to_vec()))
+    })
+}
+
+fn observer_plan() -> AuthoredObserverPlan {
+    AuthoredObserverPlan {
+        plan_id: ObserverPlanId::from_bytes([11; 32]),
+        artifact_hash: [12; 32],
+        schema_hash: [13; 32],
+        state_schema_hash: [14; 32],
+        update_law_hash: [15; 32],
+        emission_law_hash: [16; 32],
+    }
+}
+
+fn package() -> warp_core::InstalledContractPackage<'static> {
+    static REGISTRY: StaticRegistry = StaticRegistry;
+    warp_core::InstalledContractPackage {
+        identity: ContractPackageIdentity {
+            package_name: "reference-counter",
+            package_version: "0.1.0",
+            artifact_hash_hex: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        },
+        registry: &REGISTRY,
+        verification_policy: ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
+            footprint_certificates: &[],
+            require_mutation_footprint_certificates: false,
+        },
+        mutation_handlers: vec![ContractMutationHandler {
+            op_id: MUTATION_OP_ID,
+            rule: contract_rule(),
+        }],
+        query_observers: vec![query_observer()],
+    }
+}
+
+fn runtime() -> (WorldlineRuntime, WorldlineId) {
+    let mut runtime = WorldlineRuntime::new();
+    let worldline_id = WorldlineId::from_bytes([1; 32]);
+    runtime
+        .register_worldline(worldline_id, WorldlineState::empty())
+        .expect("worldline should register");
+    runtime
+        .register_writer_head(WriterHead::with_routing(
+            WriterHeadKey {
+                worldline_id,
+                head_id: make_head_id("default"),
+            },
+            PlaybackMode::Play,
+            InboxPolicy::AcceptAll,
+            None,
+            true,
+        ))
+        .expect("writer head should register");
+    (runtime, worldline_id)
+}
+
+fn eint_envelope(worldline_id: WorldlineId) -> IngressEnvelope {
+    IngressEnvelope::local_intent(
+        IngressTarget::DefaultWriter { worldline_id },
+        make_intent_kind("echo.intent/eint-v1"),
+        echo_wasm_abi::pack_intent_v1(MUTATION_OP_ID, MUTATION_VARS).expect("EINT should pack"),
+    )
+}
+
+fn query_request(worldline_id: WorldlineId) -> ObservationRequest {
+    let mut request = ObservationRequest::builtin_one_shot(
+        ObservationCoordinate {
+            worldline_id,
+            at: ObservationAt::Frontier,
+        },
+        ObservationFrame::QueryView,
+        ObservationProjection::Query {
+            query_id: QUERY_OP_ID,
+            vars_bytes: QUERY_VARS.to_vec(),
+        },
+    )
+    .expect("query request should build");
+    request.budget = ObservationReadBudget::Bounded {
+        max_payload_bytes: 128,
+        max_witness_refs: 1,
+    };
+    request
+}
+
+fn admission_ticket(seed: u8) -> OpticAdmissionTicket {
+    OpticAdmissionTicket {
+        kind: OPTIC_ADMISSION_TICKET_KIND.to_owned(),
+        artifact_handle: OpticArtifactHandle {
+            kind: OPTIC_ARTIFACT_HANDLE_KIND.to_owned(),
+            id: format!("reference-host-{seed}"),
+        },
+        artifact_hash: format!("artifact-hash-{seed}"),
+        operation_id: format!("operation-{seed}"),
+        requirements_digest: format!("requirements-{seed}"),
+        canonical_variables_digest: vec![seed],
+        basis_request_digest: [seed; 32],
+        aperture_request_digest: [seed.wrapping_add(1); 32],
+        budget_request_digest: [seed.wrapping_add(2); 32],
+        law_witness_digest: [seed.wrapping_add(3); 32],
+        ticket_digest: [seed.wrapping_add(4); 32],
+    }
+}
+
+fn result_node_id(scope: &NodeId) -> NodeId {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"test.reference-runtime-host.result-node");
+    hasher.update(scope.as_bytes());
+    NodeId(hasher.finalize().into())
+}
+
+#[test]
+fn reference_host_loop_keeps_tick_authority_out_of_app_surface() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.install_contract_package(package())
+        .expect("host should install package");
+
+    let envelope = eint_envelope(worldline_id);
+    let submission = {
+        let mut app = host.app();
+        let submission = app
+            .submit_intent(envelope)
+            .expect("app should submit witnessed intent");
+        assert_eq!(
+            app.observe_intent_outcome(&submission.submission_id),
+            IntentOutcome::Pending {
+                submission_id: submission.submission_id,
+                submission_generation: submission.submission_generation,
+                ticketed_ingress_id: None,
+            }
+        );
+        submission
+    };
+
+    assert_eq!(host.runtime().ticketed_runtime_ingress_count(), 0);
+    assert_eq!(host.runtime().receipt_correlation_count(), 0);
+
+    host.stage_installed_contract_submission(submission.submission_id, &admission_ticket(17))
+        .expect("trusted host should stage package-supported ticketed ingress");
+    assert_eq!(
+        host.runtime()
+            .observe_app_intent_outcome(&submission.submission_id),
+        IntentOutcome::Pending {
+            submission_id: submission.submission_id,
+            submission_generation: submission.submission_generation,
+            ticketed_ingress_id: host
+                .runtime()
+                .ticketed_runtime_ingress_records()
+                .next()
+                .map(|record| record.ticketed_ingress_id),
+        }
+    );
+
+    let report = host
+        .run_until_idle(4)
+        .expect("trusted host should tick until idle");
+    assert_eq!(report.committed_steps, 1);
+    assert_eq!(report.scheduler_passes, 2);
+
+    {
+        let app = host.app();
+        assert!(matches!(
+            app.observe_intent_outcome(&submission.submission_id),
+            IntentOutcome::Applied { .. }
+        ));
+        let reading = app
+            .observe(query_request(worldline_id))
+            .expect("app should observe through host query service");
+        assert!(matches!(
+            reading.payload,
+            ObservationPayload::QueryBytes(bytes) if bytes == QUERY_BYTES
+        ));
+        let contract = reading
+            .reading
+            .contract
+            .as_ref()
+            .expect("installed query reading should carry package evidence");
+        assert_eq!(contract.op_id, QUERY_OP_ID);
+        assert_eq!(contract.op_kind, ContractOperationKind::Query);
+        assert_eq!(contract.package_name, "reference-counter");
+    }
+}

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -252,6 +252,13 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     without receiving tick, package-install, ingress-staging, or fault-recovery
     authority.
 
+8. **Serious External Consumer Proof Fixture**
+
+    The contract-host path now has a hot-text-shaped external consumer fixture
+    covering document-edit-style mutation, overlapping write conflict, bounded
+    QueryView reading, retained reading payload, and retained receipt evidence
+    while keeping application nouns in test fixture code.
+
 ## Next Candidate Slices
 
 1. **Contract Obstruction Taxonomy**
@@ -279,23 +286,17 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     Wrap the current core outcome observation into a developer-facing local API
     that preserves the authority boundary and does not tick synchronously.
 
-5. **Serious External Consumer Proof Fixture**
-
-    Replace the generic fixture as the only consumer proof with a serious
-    application-owned generated contract shape, preferably `jedit`-shaped, while
-    keeping text/editor nouns out of Echo core.
-
-6. **Local Replay/DIND Proof For Contract Path**
+5. **Local Replay/DIND Proof For Contract Path**
 
     Turn the local replay fixture into a release-gate proof over package,
     submissions, scheduler policy, receipts, readings, and retained evidence.
 
-7. **Release-Grade Quickstart**
+6. **Release-Grade Quickstart**
 
     Make the first clean-checkout contract-host flow executable end to end with
     documented commands.
 
-8. **Authority Boundary Audit**
+7. **Authority Boundary Audit**
 
     Prove the app-facing surfaces cannot tick, step, access trusted runtime
     control, resume faulted heads, install privileged host adapters, mutate

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -265,6 +265,12 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     v0.1 contract-host release witness: installed contract pipeline replay,
     reference trusted host loop, and the serious external consumer fixture.
 
+10. **Release-Grade Quickstart And Authority Audit**
+
+    `docs/quickstart-local-contract-host.md` now documents the executable local
+    contract-host path. `docs/design/v0.1.0-authority-boundary-audit.md` records
+    the app/host authority split, current evidence, and deferred release risks.
+
 ## Next Candidate Slices
 
 1. **Contract Obstruction Taxonomy**
@@ -292,17 +298,11 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     Wrap the current core outcome observation into a developer-facing local API
     that preserves the authority boundary and does not tick synchronously.
 
-5. **Release-Grade Quickstart**
+5. **Release Candidate Cleanup**
 
-    Make the first clean-checkout contract-host flow executable end to end with
-    documented commands.
-
-6. **Authority Boundary Audit**
-
-    Prove the app-facing surfaces cannot tick, step, access trusted runtime
-    control, resume faulted heads, install privileged host adapters, mutate
-    through query observers, bypass package compatibility checks, or turn retry
-    into hidden runtime behavior.
+    Polish product-facing adapters, finish any remaining release-card checkboxes,
+    and run the broader CI/DIND release gates before cutting a release
+    candidate.
 
 Direct `native_rule_bootstrap` registration remains an internal fixture and
 transitional engine-test path. Contract-host proofs that need package identity,

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -190,7 +190,7 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 | AdmissionTicket                | Complete | Echo can issue `OpticAdmissionTicket` evidence without executing.                                                         |
 | TicketedRuntimeIngress         | Complete | Ticketed ingress stages admitted submissions through runtime-owner authority without ticking.                             |
 | ReceiptCorrelation             | Complete | Scheduler-owned tick receipts correlate back to ticketed ingress, tickets, and submissions.                               |
-| IntentOutcomeObservation       | Complete | Core exposes zero-write pending/decided observation with applied/rejected receipt decisions and blockers.                 |
+| IntentOutcomeObservation       | Complete | Core exposes read-only product outcome states with applied/rejected receipt evidence and typed obstructions.              |
 | InstalledContractHostDispatch  | Complete | Installed packages can dispatch mutation handlers through witnessed, ticketed, scheduler-owned ticks.                     |
 | ConflictPolicy / ExplicitRetry | Partial  | Tick-scale conflict rejection is final and blocker-attributed; user-facing retry helpers remain future.                   |
 | QueryViewObserverBridge        | Complete | Core routes QueryView/Query to installed observers, and Wesley emits host helper constructors.                            |

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -237,6 +237,13 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     proof covering mutation, QueryView reading, retained evidence, and replay
     without application nouns in Echo core.
 
+6. **Versioned Contract And API Compatibility**
+
+    Generated packages now verify Echo contract ABI, Wesley generator,
+    contract-host helper API, codec, schema, registry layout, and footprint
+    compatibility at package install. Receipts and readings can cite the
+    verified compatibility metadata without treating it as execution authority.
+
 ## Next Candidate Slices
 
 1. **Contract Obstruction Taxonomy**
@@ -264,35 +271,28 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     Wrap the current core outcome observation into a developer-facing local API
     that preserves the authority boundary and does not tick synchronously.
 
-5. **Versioned Contract And API Compatibility**
-
-    Enforce the compatibility surface that makes generated packages fit a
-    specific Echo runtime: ABI version, Wesley generator version, contract
-    package version, schema hash, artifact hash, codec id, and generated helper
-    compatibility.
-
-6. **Reference Trusted Runtime Host Loop**
+5. **Reference Trusted Runtime Host Loop**
 
     Provide a boring host-owned loop that owns tick cadence, runs until idle, and
     exposes app-safe submit/observe/query surfaces.
 
-7. **Serious External Consumer Proof Fixture**
+6. **Serious External Consumer Proof Fixture**
 
     Replace the generic fixture as the only consumer proof with a serious
     application-owned generated contract shape, preferably `jedit`-shaped, while
     keeping text/editor nouns out of Echo core.
 
-8. **Local Replay/DIND Proof For Contract Path**
+7. **Local Replay/DIND Proof For Contract Path**
 
     Turn the local replay fixture into a release-gate proof over package,
     submissions, scheduler policy, receipts, readings, and retained evidence.
 
-9. **Release-Grade Quickstart**
+8. **Release-Grade Quickstart**
 
     Make the first clean-checkout contract-host flow executable end to end with
     documented commands.
 
-10. **Authority Boundary Audit**
+9. **Authority Boundary Audit**
 
     Prove the app-facing surfaces cannot tick, step, access trusted runtime
     control, resume faulted heads, install privileged host adapters, mutate

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -259,6 +259,12 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     QueryView reading, retained reading payload, and retained receipt evidence
     while keeping application nouns in test fixture code.
 
+9. **Local Replay/DIND Proof For Contract Path**
+
+    `cargo xtask test-slice contract-path-release` now runs the narrow local
+    v0.1 contract-host release witness: installed contract pipeline replay,
+    reference trusted host loop, and the serious external consumer fixture.
+
 ## Next Candidate Slices
 
 1. **Contract Obstruction Taxonomy**
@@ -286,17 +292,12 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     Wrap the current core outcome observation into a developer-facing local API
     that preserves the authority boundary and does not tick synchronously.
 
-5. **Local Replay/DIND Proof For Contract Path**
-
-    Turn the local replay fixture into a release-gate proof over package,
-    submissions, scheduler policy, receipts, readings, and retained evidence.
-
-6. **Release-Grade Quickstart**
+5. **Release-Grade Quickstart**
 
     Make the first clean-checkout contract-host flow executable end to end with
     documented commands.
 
-7. **Authority Boundary Audit**
+6. **Authority Boundary Audit**
 
     Prove the app-facing surfaces cannot tick, step, access trusted runtime
     control, resume faulted heads, install privileged host adapters, mutate

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -182,19 +182,19 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 ## Roadmap Status
 
-| Area                           | Status   | Notes                                                                                                                           |
-| :----------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| WitnessedIntentSubmission      | Partial  | Runtime records witnessed submissions and exports/imports deterministic replay records; durable storage remains follow-up work. |
-| SchedulerWorkCandidate         | Complete | The admission ladder can resolve the scheduler work candidate fixture.                                                          |
-| LawWitness                     | Complete | The admission ladder can resolve the law witness fixture.                                                                       |
-| AdmissionTicket                | Complete | Echo can issue `OpticAdmissionTicket` evidence without executing.                                                               |
-| TicketedRuntimeIngress         | Complete | Ticketed ingress stages admitted submissions through runtime-owner authority without ticking.                                   |
-| ReceiptCorrelation             | Complete | Scheduler-owned tick receipts correlate back to ticketed ingress, tickets, and submissions.                                     |
-| IntentOutcomeObservation       | Complete | Core exposes zero-write pending/decided observation with applied/rejected receipt decisions and blockers.                       |
-| InstalledContractHostDispatch  | Complete | Installed packages can dispatch mutation handlers through witnessed, ticketed, scheduler-owned ticks.                           |
-| ConflictPolicy / ExplicitRetry | Partial  | Tick-scale conflict rejection is final and blocker-attributed; user-facing retry helpers remain future.                         |
-| QueryViewObserverBridge        | Complete | Core routes QueryView/Query to installed observers, and Wesley emits host helper constructors.                                  |
-| Replay/DIND proof              | Partial  | Local installed intent pipeline replay converges; broader DIND/replay closure remains future work.                              |
+| Area                           | Status   | Notes                                                                                                                     |
+| :----------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------ |
+| WitnessedIntentSubmission      | Partial  | Runtime records witnessed submissions and restores local persistence images; host durable storage remains follow-up work. |
+| SchedulerWorkCandidate         | Complete | The admission ladder can resolve the scheduler work candidate fixture.                                                    |
+| LawWitness                     | Complete | The admission ladder can resolve the law witness fixture.                                                                 |
+| AdmissionTicket                | Complete | Echo can issue `OpticAdmissionTicket` evidence without executing.                                                         |
+| TicketedRuntimeIngress         | Complete | Ticketed ingress stages admitted submissions through runtime-owner authority without ticking.                             |
+| ReceiptCorrelation             | Complete | Scheduler-owned tick receipts correlate back to ticketed ingress, tickets, and submissions.                               |
+| IntentOutcomeObservation       | Complete | Core exposes zero-write pending/decided observation with applied/rejected receipt decisions and blockers.                 |
+| InstalledContractHostDispatch  | Complete | Installed packages can dispatch mutation handlers through witnessed, ticketed, scheduler-owned ticks.                     |
+| ConflictPolicy / ExplicitRetry | Partial  | Tick-scale conflict rejection is final and blocker-attributed; user-facing retry helpers remain future.                   |
+| QueryViewObserverBridge        | Complete | Core routes QueryView/Query to installed observers, and Wesley emits host helper constructors.                            |
+| Replay/DIND proof              | Partial  | Local installed intent pipeline replay converges; broader DIND/replay closure remains future work.                        |
 
 ## Future Scope Boundaries
 

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -244,6 +244,14 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     compatibility at package install. Receipts and readings can cite the
     verified compatibility metadata without treating it as execution authority.
 
+7. **Reference Trusted Runtime Host Loop**
+
+    `TrustedRuntimeHost` now owns generated package installation, ticketed
+    ingress staging, scheduler passes, until-idle policy, and read-only
+    observation service access. `TrustedRuntimeApp` can submit and observe
+    without receiving tick, package-install, ingress-staging, or fault-recovery
+    authority.
+
 ## Next Candidate Slices
 
 1. **Contract Obstruction Taxonomy**
@@ -271,28 +279,23 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     Wrap the current core outcome observation into a developer-facing local API
     that preserves the authority boundary and does not tick synchronously.
 
-5. **Reference Trusted Runtime Host Loop**
-
-    Provide a boring host-owned loop that owns tick cadence, runs until idle, and
-    exposes app-safe submit/observe/query surfaces.
-
-6. **Serious External Consumer Proof Fixture**
+5. **Serious External Consumer Proof Fixture**
 
     Replace the generic fixture as the only consumer proof with a serious
     application-owned generated contract shape, preferably `jedit`-shaped, while
     keeping text/editor nouns out of Echo core.
 
-7. **Local Replay/DIND Proof For Contract Path**
+6. **Local Replay/DIND Proof For Contract Path**
 
     Turn the local replay fixture into a release-gate proof over package,
     submissions, scheduler policy, receipts, readings, and retained evidence.
 
-8. **Release-Grade Quickstart**
+7. **Release-Grade Quickstart**
 
     Make the first clean-checkout contract-host flow executable end to end with
     documented commands.
 
-9. **Authority Boundary Audit**
+8. **Authority Boundary Audit**
 
     Prove the app-facing surfaces cannot tick, step, access trusted runtime
     control, resume faulted heads, install privileged host adapters, mutate

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -3,7 +3,7 @@
 
 # BEARING
 
-Last updated: 2026-05-21.
+Last updated: 2026-05-22.
 
 This signpost summarizes current direction. It does not create commitments or
 replace backlog items, design docs, retros, or CLI status. If it disagrees with
@@ -239,30 +239,65 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 ## Next Candidate Slices
 
-1. **Durable Witnessed Submission Persistence**
+1. **Contract Obstruction Taxonomy**
+
+    Stabilize contract-hosted obstruction names for unsupported operations,
+    unsupported queries, admission obstructions, runtime faults,
+    missing-retention posture, stale basis, residual readings, and budget
+    limits. Product-facing APIs should consume typed obstruction posture instead
+    of broad strings or catch-all runtime errors.
+
+2. **Retained Evidence Refs And Missing-Retention Posture**
+
+    Lift the local semantic retention index into typed retained evidence refs
+    that receipt, reading, witness, and artifact surfaces can cite. Missing
+    retained material should return explicit obstruction/posture, not empty
+    success or content-hash guesswork.
+
+3. **Durable Witnessed Submission Persistence**
 
     Accepted-but-not-yet-ticked submissions should survive restart without
     becoming half-accepted, uncorrelatable history.
 
-2. **Product-Facing Intent Outcome API**
+4. **Product-Facing Intent Outcome API**
 
     Wrap the current core outcome observation into a developer-facing local API
     that preserves the authority boundary and does not tick synchronously.
 
-3. **Reference Trusted Runtime Host Loop**
+5. **Versioned Contract And API Compatibility**
+
+    Enforce the compatibility surface that makes generated packages fit a
+    specific Echo runtime: ABI version, Wesley generator version, contract
+    package version, schema hash, artifact hash, codec id, and generated helper
+    compatibility.
+
+6. **Reference Trusted Runtime Host Loop**
 
     Provide a boring host-owned loop that owns tick cadence, runs until idle, and
     exposes app-safe submit/observe/query surfaces.
 
-4. **Local Replay/DIND Proof For Contract Path**
+7. **Serious External Consumer Proof Fixture**
+
+    Replace the generic fixture as the only consumer proof with a serious
+    application-owned generated contract shape, preferably `jedit`-shaped, while
+    keeping text/editor nouns out of Echo core.
+
+8. **Local Replay/DIND Proof For Contract Path**
 
     Turn the local replay fixture into a release-gate proof over package,
     submissions, scheduler policy, receipts, readings, and retained evidence.
 
-5. **Release-Grade Quickstart**
+9. **Release-Grade Quickstart**
 
     Make the first clean-checkout contract-host flow executable end to end with
     documented commands.
+
+10. **Authority Boundary Audit**
+
+    Prove the app-facing surfaces cannot tick, step, access trusted runtime
+    control, resume faulted heads, install privileged host adapters, mutate
+    through query observers, bypass package compatibility checks, or turn retry
+    into hidden runtime behavior.
 
 Direct `native_rule_bootstrap` registration remains an internal fixture and
 transitional engine-test path. Contract-host proofs that need package identity,

--- a/docs/design/contract-obstruction-taxonomy.md
+++ b/docs/design/contract-obstruction-taxonomy.md
@@ -1,0 +1,49 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Contract Obstruction Taxonomy
+
+Status: accepted local boundary.
+
+## Purpose
+
+Contract-hosted applications need typed obstruction posture before Echo exposes
+more polished product-facing APIs. A caller should not infer application
+behavior from generic strings, internal runtime errors, or empty successful
+readings.
+
+## Boundary
+
+`warp-core` now exposes:
+
+- `ContractObstructionKind`;
+- `ContractObstructionSubject`;
+- `ContractObstruction`;
+- deterministic classifiers from current observation and runtime errors.
+
+The taxonomy names generic contract-hosting posture only. It does not import
+application-domain obstruction types into Echo core.
+
+## Initial Kinds
+
+- `UnsupportedOperation`
+- `UnsupportedQuery`
+- `AdmissionObstruction`
+- `RuntimeFault`
+- `MissingRetention`
+- `StaleBasis`
+- `ResidualReading`
+- `BudgetExceeded`
+
+## Authority Rule
+
+Runtime faults remain runtime faults. They do not become lawful domain
+rejections. Query residual posture remains read-side posture. It does not imply
+application mutation or scheduler progress.
+
+## Non-Goals
+
+- Do not replace all existing error enums in this slice.
+- Do not expose scheduler control through product-facing obstruction APIs.
+- Do not add application-specific obstruction names to `warp-core`.
+- Do not turn missing retention into empty successful reads.

--- a/docs/design/local-contract-path-replay-dind-proof.md
+++ b/docs/design/local-contract-path-replay-dind-proof.md
@@ -1,0 +1,54 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Local Contract Path Replay And DIND Proof
+
+Status: implemented narrow release witness.
+
+This packet records the local v0.1.0 contract-path replay witness. The full DIND
+suite remains the broader determinism gate. This slice adds a narrow,
+documented `test-slice` entry that proves the local contract-host path without
+requiring developers to run every deterministic scenario during normal
+iteration.
+
+## Claim
+
+The v0.1.0 local contract path has a named release witness:
+
+```bash
+cargo xtask test-slice contract-path-release
+```
+
+That witness runs the explicit tests that prove:
+
+- installed contract mutation dispatch happens only through scheduler-owned
+  ticks;
+- unsupported package operations do not become runtime-visible work;
+- conflict rejection is final for that tick attempt;
+- witnessed submissions replay with stable identity;
+- the installed contract pipeline replays to the same receipt and outcome;
+- a generic external fixture retains reading and receipt evidence;
+- the reference trusted host loop owns tick authority;
+- the serious external-consumer-shaped fixture exercises mutation, conflict,
+  QueryView reading, and semantic retention.
+
+## Boundary
+
+This is a local release witness, not distributed replica proof. It does not
+implement settlement shells, adversarial import, or the full observer-rights
+revelation lattice.
+
+The witness is intentionally explicit. It names exact Cargo test targets so
+local iteration does not accidentally compile every integration test binary.
+
+## Evidence
+
+- `cargo test -p xtask test_slice_contract_path_release_stays_explicit`
+- `cargo xtask test-slice contract-path-release --dry-run`
+- `cargo xtask test-slice contract-path-release`
+
+## Remaining Release Work
+
+Later release work still needs the broader DIND/reproducibility gates to run in
+CI and the release candidate, but this slice gives the local app contract path a
+small, repeatable proof command.

--- a/docs/design/post-contract-evidence-roadmap-refresh.md
+++ b/docs/design/post-contract-evidence-roadmap-refresh.md
@@ -1,0 +1,44 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Post-Contract Evidence Roadmap Refresh
+
+Status: accepted docs slice.
+
+## Purpose
+
+PR #371 completed the local contract evidence, reading identity, semantic
+retention, and generic external proof fixture batch. The roadmap signpost must
+therefore move from that completed work to the remaining `v0.1.0` release-bar
+work.
+
+## Current Truth
+
+- Contract-aware receipt correlation and QueryView reading evidence exist as
+  local proof.
+- Query readings carry stable `QueryReadingIdentity`.
+- `echo-cas` has a local semantic retention index above content-only blobs.
+- A generic external-consumer-shaped fixture proves mutation, QueryView,
+  retained evidence, and replay without application nouns in Echo core.
+
+## Next Release-Bar Order
+
+The next work should keep narrowing the local contract-host release:
+
+1. contract obstruction taxonomy;
+2. retained evidence refs and missing-retention posture;
+3. durable witnessed submission persistence;
+4. product-facing intent outcome API;
+5. versioned contract/API compatibility;
+6. reference trusted runtime host loop;
+7. serious external consumer proof fixture;
+8. local replay/DIND proof for the contract path;
+9. release-grade quickstart;
+10. authority boundary audit.
+
+## Non-Goals
+
+- Do not reopen the completed contract-evidence batch as future work.
+- Do not add new runtime behavior in this documentation slice.
+- Do not weaken the authority boundary: application dispatch still does not
+  execute synchronously or tick.

--- a/docs/design/product-facing-intent-outcome-api.md
+++ b/docs/design/product-facing-intent-outcome-api.md
@@ -1,0 +1,55 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Product-Facing Intent Outcome API
+
+Status: accepted and implemented local core surface.
+
+## Claim
+
+Echo now has a small app-facing submit/observe outcome surface over the
+existing witnessed submission and scheduler receipt correlation machinery. The
+surface returns stable submission handles and product-level outcome states
+without exposing trusted runtime control.
+
+## Boundary
+
+`WorldlineRuntime::submit_app_intent(...)` records witnessed ingress history and
+returns `IntentSubmissionHandle`. It does not tick, stage runtime ingress,
+dispatch handlers, execute contracts, or mutate application state.
+
+`WorldlineRuntime::observe_app_intent_outcome(...)` is a read-only polling
+surface returning `IntentOutcome`:
+
+- `Unknown`;
+- `Pending`;
+- `Applied`;
+- `Rejected`;
+- `Obstructed`.
+
+Applied and rejected outcomes carry `IntentOutcomeReceipt`, which names the
+ticketed ingress id, admission ticket digest, tick receipt digest, commit hash,
+worldline tick, entry index, and rule id. Obstructed outcomes use the
+contract-host obstruction taxonomy.
+
+## Invariants
+
+- Submission handles are not tick receipts.
+- Outcome observation is read-only.
+- Pending does not imply failure or retry.
+- Rejected is a lawful scheduler outcome, not a runtime fault.
+- Obstructed means Echo cannot honestly interpret required evidence.
+- Missing receipt evidence maps to `MissingRetention`.
+- The surface exposes no tick, step, scheduler, or trusted runtime authority.
+
+## Non-Goals
+
+- Do not implement streaming subscriptions.
+- Do not add hidden retry.
+- Do not expose scheduler control.
+- Do not make submit mean execute.
+- Do not replace lower-level receipt correlation APIs.
+
+## Witnesses
+
+- `cargo test -p warp-core --lib app_intent`

--- a/docs/design/reference-trusted-runtime-host-loop.md
+++ b/docs/design/reference-trusted-runtime-host-loop.md
@@ -1,0 +1,80 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Reference Trusted Runtime Host Loop
+
+Status: implemented local reference boundary.
+
+This packet records the reference local host loop for the v0.1.0 contract path.
+The loop is deliberately boring: it names the trusted runtime-owner role that
+already existed implicitly in tests and wires it through a small wrapper. It is
+not a daemon, not wall-clock semantics, and not an application tick API.
+
+## Claim
+
+Application code can submit canonical intent material and observe outcomes or
+readings through an app-facing handle, while the trusted host owns:
+
+- generated package installation;
+- ticketed runtime ingress staging;
+- scheduler-owned tick passes;
+- until-idle policy;
+- query service access;
+- future trusted fault recovery.
+
+The app-facing handle exposes no package installation, no ticketed ingress
+staging, no `super_tick`, no scheduler pass, and no fault recovery authority.
+
+## Implemented Surface
+
+`warp-core` now provides:
+
+- `TrustedRuntimeHost`, gated behind the trusted runtime and native bootstrap
+  features;
+- `TrustedRuntimeApp`, the app-facing submit/observe/query handle;
+- `TrustedRuntimeHost::install_contract_package(...)`;
+- `TrustedRuntimeHost::stage_installed_contract_submission(...)`;
+- `TrustedRuntimeHost::tick_once(...)`;
+- `TrustedRuntimeHost::run_until_idle(...)`;
+- `TrustedRuntimeHostRunReport`, which records scheduler passes and committed
+  step count.
+
+The host initializes provenance from registered runtime worldlines, owns the
+engine and runtime, and uses existing `SchedulerCoordinator::super_tick(...)`
+for scheduler-owned execution.
+
+## Authority Boundary
+
+```text
+application
+-> TrustedRuntimeApp::submit_intent(...)
+-> witnessed submission handle
+
+trusted runtime host
+-> installs package
+-> stages ticketed ingress
+-> runs scheduler-owned ticks
+-> app observes outcome or bounded query reading
+```
+
+The host loop does not make application dispatch synchronous. A submitted
+intent remains pending until trusted runtime-owned ingress staging and
+scheduler-owned tick execution decide it.
+
+## Non-Goals
+
+- No production daemon.
+- No wall-clock cadence semantics.
+- No hidden retry.
+- No app-controlled tick, scheduler pass, or trusted recovery.
+- No new admission law.
+- No dynamic plugin loading.
+
+## Evidence
+
+- `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime" --test trusted_runtime_host_loop_tests`
+
+The witness installs a generated-style package, submits through the app handle,
+stages ticketed ingress through the host, runs until idle, observes an applied
+intent outcome, and queries through the read-only observer service with package
+evidence.

--- a/docs/design/retained-evidence-refs-and-missing-retention.md
+++ b/docs/design/retained-evidence-refs-and-missing-retention.md
@@ -1,0 +1,55 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Retained Evidence Refs And Missing-Retention Posture
+
+Status: accepted and implemented local boundary.
+
+## Claim
+
+Echo now has first-class retained evidence references in `warp-core`. A retained
+evidence reference binds:
+
+- installed contract evidence identity;
+- retained evidence role;
+- semantic digest;
+- content-only hash;
+- byte length.
+
+Missing retained material returns typed `MissingRetention` obstruction posture.
+It does not become empty success, a cache hit, a stale query identity, or a
+generic runtime fault.
+
+## Boundary
+
+`RetainedEvidenceCoordinate` names the semantic coordinate for retained
+contract material. `RetainedEvidenceRef` then binds that coordinate to retained
+bytes by content hash and byte length. `RetainedEvidencePosture` reports either
+available evidence or a `ContractObstructionKind::MissingRetention` obstruction.
+
+This is the core/product-facing reference layer above local byte retention. It
+does not change `echo-cas`: CAS still names bytes only, and `RetainedBlobIndex`
+still owns local semantic byte lookup.
+
+## Invariants
+
+- CAS byte identity is not semantic evidence identity.
+- Equal bytes under different semantic coordinates produce different evidence
+  reference ids.
+- Reading payload refs and reading-envelope refs are distinct roles.
+- A query or reading identity does not imply payload retention.
+- Missing semantic coordinates and missing retained bytes surface as
+  `MissingRetention`.
+- Missing-retention obstructions carry the installed contract evidence identity
+  when available.
+
+## Non-Goals
+
+- Do not add distributed retention, settlement shells, or replica import.
+- Do not add disk persistence or garbage-collection policy.
+- Do not treat retained reading refs as query identities.
+- Do not make content hashes stand in for semantic coordinates.
+
+## Witnesses
+
+- `cargo test -p warp-core --test retained_evidence_ref_tests`

--- a/docs/design/serious-external-consumer-proof-fixture.md
+++ b/docs/design/serious-external-consumer-proof-fixture.md
@@ -1,0 +1,66 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Serious External Consumer Proof Fixture
+
+Status: implemented local proof fixture.
+
+This packet records the v0.1.0 external-consumer proof slice. The fixture is
+intentionally shaped like a real application contract, but it remains outside
+Echo core. Echo proves generic hosting behavior; it does not import editor,
+document, buffer, rope, or product-specific nouns into production APIs.
+
+## Claim
+
+A serious external-consumer-shaped contract can use the local contract-host
+path:
+
+```text
+generated-style package
+-> trusted host install
+-> app-safe submit
+-> ticketed runtime ingress
+-> scheduler-owned tick
+-> applied/rejected intent outcome
+-> bounded QueryView reading
+-> retained reading and receipt evidence
+```
+
+The fixture uses document-edit semantics only inside a test package. The generic
+runtime boundary still sees package metadata, operation ids, canonical EINT
+bytes, query ids, readings, receipts, and retained evidence coordinates.
+
+## Implemented Surface
+
+`external_consumer_contract_fixture_tests` now installs a generated-style
+`jedit`-shaped hot-text package with:
+
+- one `replaceRange` mutation operation;
+- one `documentWindow` QueryView operation;
+- non-trivial canonical vars bytes;
+- scheduler-owned mutation execution;
+- overlapping write footprint conflict;
+- bounded QueryView reading;
+- installed package evidence on readings and receipt correlations;
+- semantic retention of the reading payload and receipt evidence.
+
+## Invariants
+
+- Application nouns stay in the external fixture, not `warp-core` production
+  APIs.
+- Application submission does not tick.
+- Query observers remain read-only.
+- Conflict rejection is final for that tick attempt.
+- Retained payload lookup requires semantic coordinates, not raw CAS hash
+  guessing.
+- Package evidence is metadata, not execution or query authority.
+
+## Evidence
+
+- `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime" --test external_consumer_contract_fixture_tests`
+
+## Remaining Release Work
+
+This fixture is serious enough to pressure the generic contract-host path, but
+it is still an in-repo test fixture. Later work can point the same shape at an
+actual external `jedit`-owned generated package once that package is ready.

--- a/docs/design/v0.1.0-authority-boundary-audit.md
+++ b/docs/design/v0.1.0-authority-boundary-audit.md
@@ -1,0 +1,63 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# v0.1.0 Authority Boundary Audit
+
+Status: initial local audit recorded.
+
+This audit records the current authority boundary for the local contract-host
+path. It is not a sandbox claim and not a substitute for later security review.
+It states what the current release witness proves and what remains deferred.
+
+## Authority Bar
+
+The v0.1.0 local path must preserve these boundaries:
+
+- application code cannot tick;
+- application code cannot access trusted runtime control;
+- submit/admit APIs do not execute synchronously;
+- `AdmissionTicket` is not `TickReceipt`;
+- `AdmissionTicket` is not execution;
+- query observers are read-only;
+- mutation handlers run only during scheduler-owned ticks;
+- retry is explicit new causal input, not hidden runtime behavior;
+- wall-clock cadence is host/runtime-owner policy, not semantic history.
+
+## Current Evidence
+
+| Boundary                                           | Evidence                                                                                                          |
+| :------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------- |
+| App submit does not tick                           | `submit_app_intent_returns_handle_without_ticking`; `reference_host_loop_keeps_tick_authority_out_of_app_surface` |
+| App outcome observation is read-only               | `observe_app_intent_outcome_reports_unknown_and_pending`; reference host app observation path                     |
+| Trusted host owns tick authority                   | `TrustedRuntimeHost::tick_once(...)`; `TrustedRuntimeHost::run_until_idle(...)`; reference host loop test         |
+| Ticketed ingress is host-owned                     | `stage_installed_contract_submission(...)`; installed contract pipeline tests                                     |
+| Mutation handlers run during scheduler-owned ticks | `installed_contract_mutation_dispatches_only_through_ticketed_scheduler_tick`                                     |
+| Query observers are read-only                      | Query observer helper tests and external fixture QueryView reading                                                |
+| Compatibility drift fails closed                   | registry API mismatch tests and installed package helper API mismatch test                                        |
+| Conflict retry is not hidden                       | `footprint_conflict_is_final_without_hidden_retry`                                                                |
+| Missing retained material is obstruction           | retained evidence ref tests and retention index tests                                                             |
+
+## Deferred Risks
+
+- WASM, Node, and browser application packages are authority-sensitive only if
+  they are shipped as part of the v0.1.0 artifact set.
+- Runtime-local scheduler fault quarantine exists; durable fault provenance is
+  future work.
+- Full observer-rights/revelation governance remains post-v0.1.0.
+- This audit does not claim a production sandbox or adversarial plugin loader.
+
+## Release Witness
+
+Run the local contract path witness:
+
+```bash
+cargo xtask test-slice contract-path-release
+```
+
+Run the focused authority-related unit and integration witnesses:
+
+```bash
+cargo test -p warp-core --lib app_intent
+cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime" --test trusted_runtime_host_loop_tests
+cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime" --test external_consumer_contract_fixture_tests
+```

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -391,30 +391,30 @@ Remaining pieces:
 
 ## Feature Checklist
 
-| Feature                                               | Needed for `v0.1.0`?         | Current status                                                                                         |
-| :---------------------------------------------------- | :--------------------------- | :----------------------------------------------------------------------------------------------------- |
-| Deterministic scheduler-owned execution               | Yes                          | Mostly complete                                                                                        |
-| Application cannot tick                               | Yes                          | Complete                                                                                               |
-| Witnessed intent submission                           | Yes                          | Partial: local persistence shell exists; host durable storage remains                                  |
-| Admission evidence through ticket                     | Yes                          | Complete for local pipeline                                                                            |
-| Ticketed runtime ingress                              | Yes                          | Complete                                                                                               |
-| Installed contract package registry                   | Yes                          | Complete locally                                                                                       |
-| Installed mutation handler dispatch                   | Yes                          | Complete locally                                                                                       |
-| Intent outcome observation                            | Yes                          | Local product-facing core surface complete; adapter polish remains                                     |
-| Contract-aware receipts                               | Yes                          | Complete local correlation proof; product API polish remains                                           |
-| Contract-aware readings                               | Yes                          | Complete local QueryView proof                                                                         |
-| QueryView observer bridge                             | Yes                          | Complete core surface                                                                                  |
-| Wesley query and mutation host helpers                | Yes                          | Complete for current seam                                                                              |
-| Bounded reading identity and payloads                 | Yes                          | Complete local proof                                                                                   |
-| Local retention for artifacts, readings, and receipts | Yes                          | `RetainedBlobIndex` and core retained-evidence refs complete; ABI adapters and durable recovery remain |
-| Durable accepted-submission recovery                  | Yes                          | Local persistence shell complete; host storage and crash protocol remain                               |
-| App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                                  |
-| Reference trusted host loop                           | Yes                          | Local reference host/app boundary complete; product adapter and fault recovery polish remain           |
-| External consumer proof fixture                       | Yes                          | Serious in-repo fixture complete; real external package follow-through remains                         |
-| Quickstart/docs that actually work                    | Yes                          | Partial                                                                                                |
-| Versioned contract/API compatibility                  | Yes                          | Local package-boundary checks complete; release automation and adapter reporting remain                |
-| Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                                   |
-| CI release gate for v0.1 path                         | Yes                          | Narrow local `contract-path-release` witness complete; broader CI/DIND release gates remain            |
+| Feature                                               | Needed for `v0.1.0`?         | Current status                                                                                          |
+| :---------------------------------------------------- | :--------------------------- | :------------------------------------------------------------------------------------------------------ |
+| Deterministic scheduler-owned execution               | Yes                          | Mostly complete                                                                                         |
+| Application cannot tick                               | Yes                          | Complete                                                                                                |
+| Witnessed intent submission                           | Yes                          | Partial: local persistence shell exists; host durable storage remains                                   |
+| Admission evidence through ticket                     | Yes                          | Complete for local pipeline                                                                             |
+| Ticketed runtime ingress                              | Yes                          | Complete                                                                                                |
+| Installed contract package registry                   | Yes                          | Complete locally                                                                                        |
+| Installed mutation handler dispatch                   | Yes                          | Complete locally                                                                                        |
+| Intent outcome observation                            | Yes                          | Local product-facing core surface complete; adapter polish remains                                      |
+| Contract-aware receipts                               | Yes                          | Complete local correlation proof; product API polish remains                                            |
+| Contract-aware readings                               | Yes                          | Complete local QueryView proof                                                                          |
+| QueryView observer bridge                             | Yes                          | Complete core surface                                                                                   |
+| Wesley query and mutation host helpers                | Yes                          | Complete for current seam                                                                               |
+| Bounded reading identity and payloads                 | Yes                          | Complete local proof                                                                                    |
+| Local retention for artifacts, readings, and receipts | Yes                          | `RetainedBlobIndex` and core retained-evidence refs complete; ABI adapters and durable recovery remain  |
+| Durable accepted-submission recovery                  | Yes                          | Local persistence shell complete; host storage and crash protocol remain                                |
+| App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                                   |
+| Reference trusted host loop                           | Yes                          | Local reference host/app boundary complete; product adapter and fault recovery polish remain            |
+| External consumer proof fixture                       | Yes                          | Serious in-repo fixture complete; real external package follow-through remains                          |
+| Quickstart/docs that actually work                    | Yes                          | Initial executable local contract-host quickstart complete; product guide polish remains                |
+| Versioned contract/API compatibility                  | Yes                          | Local package-boundary checks complete; release automation and adapter reporting remain                 |
+| Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                                    |
+| CI release gate for v0.1 path                         | Yes                          | Narrow local `contract-path-release` witness and authority audit complete; broader CI/DIND gates remain |
 
 ## Explicit Non-Goals For v0.1.0
 

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -303,6 +303,22 @@ Developers need clear "this package fits this runtime" behavior. Runtime
 package installation must reject version, codec, schema, artifact, or helper
 drift instead of accepting an ambiguous contract-host seam.
 
+Implemented local pieces:
+
+- generated registries name Echo contract ABI, Wesley generator, and helper API
+  compatibility versions;
+- package verification policy rejects Echo ABI, Wesley generator, helper API,
+  codec, registry layout, schema, and footprint drift before install;
+- installed package receipt and reading evidence can cite the verified
+  compatibility metadata.
+
+Remaining pieces:
+
+- release automation and release notes that publish the supported compatibility
+  set;
+- product-facing adapter reporting for compatibility rejection;
+- migration policy for future incompatible generated helper seams.
+
 ### 7. Trusted Runtime Host Loop
 
 The model is:
@@ -388,7 +404,7 @@ Missing pieces:
 | Reference trusted host loop                           | Yes                          | Missing                                                                                                |
 | External consumer proof fixture                       | Yes                          | Complete generic fixture; serious app-owned fixture remains                                            |
 | Quickstart/docs that actually work                    | Yes                          | Partial                                                                                                |
-| Versioned contract/API compatibility                  | Yes                          | Missing/release work                                                                                   |
+| Versioned contract/API compatibility                  | Yes                          | Local package-boundary checks complete; release automation and adapter reporting remain                |
 | Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                                   |
 | CI release gate for v0.1 path                         | Yes                          | Partial                                                                                                |
 

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -183,14 +183,16 @@ Implemented local pieces:
 - retained blob roles for artifacts, receipts, witnesses, reading payloads,
   reading envelopes, and observer artifacts;
 - bounded `load_range` with budget and typed errors;
+- first-class `RetainedEvidenceCoordinate`, `RetainedEvidenceRef`, and
+  `RetainedEvidencePosture` in core;
+- missing retained evidence surfaces as typed `MissingRetention` obstruction;
 - same semantic coordinate plus different content is rejected as a conflict;
 - no fake cache hits;
 - no raw CAS hash pretending to be semantic reading identity.
 
 Remaining pieces:
 
-- first-class retained artifact, receipt, reading, and witness refs in core/ABI;
-- missing-retention obstruction integrated into observation and product APIs;
+- ABI/product adapter projection for retained evidence refs;
 - durable recovery, disk persistence, garbage collection, and rehydration;
 - release-grade retained `TickReceipt` and reading-envelope material beyond the
   current local fixture.
@@ -347,30 +349,30 @@ Missing pieces:
 
 ## Feature Checklist
 
-| Feature                                               | Needed for `v0.1.0`?         | Current status                                                                                |
-| :---------------------------------------------------- | :--------------------------- | :-------------------------------------------------------------------------------------------- |
-| Deterministic scheduler-owned execution               | Yes                          | Mostly complete                                                                               |
-| Application cannot tick                               | Yes                          | Complete                                                                                      |
-| Witnessed intent submission                           | Yes                          | Partial: in-memory/replay shape exists; durable persistence missing                           |
-| Admission evidence through ticket                     | Yes                          | Complete for local pipeline                                                                   |
-| Ticketed runtime ingress                              | Yes                          | Complete                                                                                      |
-| Installed contract package registry                   | Yes                          | Complete locally                                                                              |
-| Installed mutation handler dispatch                   | Yes                          | Complete locally                                                                              |
-| Intent outcome observation                            | Yes                          | Complete core surface; product API polish missing                                             |
-| Contract-aware receipts                               | Yes                          | Complete local correlation proof; product API polish remains                                  |
-| Contract-aware readings                               | Yes                          | Complete local QueryView proof                                                                |
-| QueryView observer bridge                             | Yes                          | Complete core surface                                                                         |
-| Wesley query and mutation host helpers                | Yes                          | Complete for current seam                                                                     |
-| Bounded reading identity and payloads                 | Yes                          | Complete local proof                                                                          |
-| Local retention for artifacts, readings, and receipts | Yes                          | `RetainedBlobIndex` boundary complete; retained refs/obstructions and durable recovery remain |
-| Durable accepted-submission recovery                  | Yes                          | Missing                                                                                       |
-| App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                         |
-| Reference trusted host loop                           | Yes                          | Missing                                                                                       |
-| External consumer proof fixture                       | Yes                          | Complete generic fixture; serious app-owned fixture remains                                   |
-| Quickstart/docs that actually work                    | Yes                          | Partial                                                                                       |
-| Versioned contract/API compatibility                  | Yes                          | Missing/release work                                                                          |
-| Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                          |
-| CI release gate for v0.1 path                         | Yes                          | Partial                                                                                       |
+| Feature                                               | Needed for `v0.1.0`?         | Current status                                                                                         |
+| :---------------------------------------------------- | :--------------------------- | :----------------------------------------------------------------------------------------------------- |
+| Deterministic scheduler-owned execution               | Yes                          | Mostly complete                                                                                        |
+| Application cannot tick                               | Yes                          | Complete                                                                                               |
+| Witnessed intent submission                           | Yes                          | Partial: in-memory/replay shape exists; durable persistence missing                                    |
+| Admission evidence through ticket                     | Yes                          | Complete for local pipeline                                                                            |
+| Ticketed runtime ingress                              | Yes                          | Complete                                                                                               |
+| Installed contract package registry                   | Yes                          | Complete locally                                                                                       |
+| Installed mutation handler dispatch                   | Yes                          | Complete locally                                                                                       |
+| Intent outcome observation                            | Yes                          | Complete core surface; product API polish missing                                                      |
+| Contract-aware receipts                               | Yes                          | Complete local correlation proof; product API polish remains                                           |
+| Contract-aware readings                               | Yes                          | Complete local QueryView proof                                                                         |
+| QueryView observer bridge                             | Yes                          | Complete core surface                                                                                  |
+| Wesley query and mutation host helpers                | Yes                          | Complete for current seam                                                                              |
+| Bounded reading identity and payloads                 | Yes                          | Complete local proof                                                                                   |
+| Local retention for artifacts, readings, and receipts | Yes                          | `RetainedBlobIndex` and core retained-evidence refs complete; ABI adapters and durable recovery remain |
+| Durable accepted-submission recovery                  | Yes                          | Missing                                                                                                |
+| App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                                  |
+| Reference trusted host loop                           | Yes                          | Missing                                                                                                |
+| External consumer proof fixture                       | Yes                          | Complete generic fixture; serious app-owned fixture remains                                            |
+| Quickstart/docs that actually work                    | Yes                          | Partial                                                                                                |
+| Versioned contract/API compatibility                  | Yes                          | Missing/release work                                                                                   |
+| Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                                   |
+| CI release gate for v0.1 path                         | Yes                          | Partial                                                                                                |
 
 ## Explicit Non-Goals For v0.1.0
 

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -222,11 +222,21 @@ Crash/restart behavior must recover to one of these states:
 
 It must not recover to a half-accepted, uncorrelatable state.
 
-Missing pieces:
+Implemented local pieces:
 
-- durable local ledger or equivalent persistence hook for witnessed submissions;
-- restart/recovery test;
-- duplicate posture after recovery;
+- deterministic witnessed submission replay records;
+- `WitnessedSubmissionPersistenceSnapshot` pairs accepted submission records
+  with canonical ingress envelopes;
+- restore validates ingress id, resolved writer head, and inbox policy before
+  import;
+- restore retains envelope material without staging scheduler-visible inbox
+  work;
+- duplicate posture after recovery.
+
+Remaining pieces:
+
+- host-owned durable storage medium for witnessed submission persistence images;
+- crash-consistency protocol around accepted-but-not-yet-ticked submissions;
 - clear boundary between semantic Echo acceptance and transport arrival.
 
 ### 5. App-Safe Developer API
@@ -353,7 +363,7 @@ Missing pieces:
 | :---------------------------------------------------- | :--------------------------- | :----------------------------------------------------------------------------------------------------- |
 | Deterministic scheduler-owned execution               | Yes                          | Mostly complete                                                                                        |
 | Application cannot tick                               | Yes                          | Complete                                                                                               |
-| Witnessed intent submission                           | Yes                          | Partial: in-memory/replay shape exists; durable persistence missing                                    |
+| Witnessed intent submission                           | Yes                          | Partial: local persistence shell exists; host durable storage remains                                  |
 | Admission evidence through ticket                     | Yes                          | Complete for local pipeline                                                                            |
 | Ticketed runtime ingress                              | Yes                          | Complete                                                                                               |
 | Installed contract package registry                   | Yes                          | Complete locally                                                                                       |
@@ -365,7 +375,7 @@ Missing pieces:
 | Wesley query and mutation host helpers                | Yes                          | Complete for current seam                                                                              |
 | Bounded reading identity and payloads                 | Yes                          | Complete local proof                                                                                   |
 | Local retention for artifacts, readings, and receipts | Yes                          | `RetainedBlobIndex` and core retained-evidence refs complete; ABI adapters and durable recovery remain |
-| Durable accepted-submission recovery                  | Yes                          | Missing                                                                                                |
+| Durable accepted-submission recovery                  | Yes                          | Local persistence shell complete; host storage and crash protocol remain                               |
 | App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                                  |
 | Reference trusted host loop                           | Yes                          | Missing                                                                                                |
 | External consumer proof fixture                       | Yes                          | Complete generic fixture; serious app-owned fixture remains                                            |

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -371,18 +371,21 @@ external contract shape
 -> replay proof
 ```
 
-Missing pieces:
+Implemented local pieces:
 
-- external generated fixture committed or vendored as test artifact;
-- generic Echo host path only;
-- at least one mutation;
-- at least one `QueryView`/`Query` reading;
-- non-trivial vars;
-- bounded basis, aperture, and budget identity;
-- retained receipt and reading evidence;
-- one conflict or rejection path;
-- replay proof;
-- no `jedit`, text, editor, rope, or buffer nouns in `warp-core`;
+- generic external-consumer-shaped fixture with mutation, QueryView reading,
+  retained evidence, conflict posture, and replay;
+- serious hot-text-shaped fixture with document-edit-style mutation,
+  overlapping write conflict, bounded document-window QueryView reading, and
+  semantic retention;
+- no production `warp-core` API imports `jedit`, text, editor, rope, or buffer
+  nouns.
+
+Remaining pieces:
+
+- real application-owned generated package from outside Echo, preferably the
+  `jedit` contract package;
+- release-grade fixture documentation and quickstart integration.
 - operations/readings serious enough to exercise bounded query, receipts, and
   retention.
 
@@ -407,7 +410,7 @@ Missing pieces:
 | Durable accepted-submission recovery                  | Yes                          | Local persistence shell complete; host storage and crash protocol remain                               |
 | App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                                  |
 | Reference trusted host loop                           | Yes                          | Local reference host/app boundary complete; product adapter and fault recovery polish remain           |
-| External consumer proof fixture                       | Yes                          | Complete generic fixture; serious app-owned fixture remains                                            |
+| External consumer proof fixture                       | Yes                          | Serious in-repo fixture complete; real external package follow-through remains                         |
 | Quickstart/docs that actually work                    | Yes                          | Partial                                                                                                |
 | Versioned contract/API compatibility                  | Yes                          | Local package-boundary checks complete; release automation and adapter reporting remain                |
 | Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                                   |

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -414,7 +414,7 @@ Remaining pieces:
 | Quickstart/docs that actually work                    | Yes                          | Partial                                                                                                |
 | Versioned contract/API compatibility                  | Yes                          | Local package-boundary checks complete; release automation and adapter reporting remain                |
 | Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                                   |
-| CI release gate for v0.1 path                         | Yes                          | Partial                                                                                                |
+| CI release gate for v0.1 path                         | Yes                          | Narrow local `contract-path-release` witness complete; broader CI/DIND release gates remain            |
 
 ## Explicit Non-Goals For v0.1.0
 

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -341,12 +341,17 @@ The runtime owner should own:
 - receipt publication;
 - query service.
 
-Missing pieces:
+Implemented local pieces:
 
-- reference runtime owner or host adapter;
-- fixed logical tick and until-idle policy docs;
-- clear app/client versus host/runtime-owner split;
-- examples showing app code never calls tick;
+- `TrustedRuntimeHost` owns package installation, ticketed ingress staging,
+  scheduler passes, until-idle policy, and read-only observation service access;
+- `TrustedRuntimeApp` exposes submit/observe/query without tick authority;
+- reference witness proves submitted intents remain pending until host-owned
+  staging and scheduler-owned ticks decide them.
+
+Remaining pieces:
+
+- product adapter polish around the host/app split;
 - fault recovery as host-owned behavior, not app-owned behavior.
 
 ### 8. External Consumer Proof
@@ -401,7 +406,7 @@ Missing pieces:
 | Local retention for artifacts, readings, and receipts | Yes                          | `RetainedBlobIndex` and core retained-evidence refs complete; ABI adapters and durable recovery remain |
 | Durable accepted-submission recovery                  | Yes                          | Local persistence shell complete; host storage and crash protocol remain                               |
 | App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                                  |
-| Reference trusted host loop                           | Yes                          | Missing                                                                                                |
+| Reference trusted host loop                           | Yes                          | Local reference host/app boundary complete; product adapter and fault recovery polish remain           |
 | External consumer proof fixture                       | Yes                          | Complete generic fixture; serious app-owned fixture remains                                            |
 | Quickstart/docs that actually work                    | Yes                          | Partial                                                                                                |
 | Versioned contract/API compatibility                  | Yes                          | Local package-boundary checks complete; release automation and adapter reporting remain                |

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -267,11 +267,19 @@ packages are mandatory only if they are published as part of the release
 artifact set. If those packages ship, they must expose the app-safe surface
 without leaking trusted runtime control.
 
+Implemented local pieces:
+
+- `submit_app_intent(...)` returns `IntentSubmissionHandle` without ticking;
+- `observe_app_intent_outcome(...)` returns `IntentOutcome`;
+- outcomes distinguish unknown, pending, applied, rejected, and obstructed
+  states;
+- applied/rejected outcomes carry `IntentOutcomeReceipt`;
+- obstructed outcomes use the contract obstruction taxonomy.
+
 Missing pieces:
 
 - polished submit/admit API naming;
-- product-facing intent outcome API;
-- stable error and obstruction types;
+- adapter-level API packaging;
 - app-safe WASM, browser, and Node package surface;
 - no privileged scheduler or tick controls exposed to application code;
 - generated Wesley helpers that target this app-safe surface directly;
@@ -368,7 +376,7 @@ Missing pieces:
 | Ticketed runtime ingress                              | Yes                          | Complete                                                                                               |
 | Installed contract package registry                   | Yes                          | Complete locally                                                                                       |
 | Installed mutation handler dispatch                   | Yes                          | Complete locally                                                                                       |
-| Intent outcome observation                            | Yes                          | Complete core surface; product API polish missing                                                      |
+| Intent outcome observation                            | Yes                          | Local product-facing core surface complete; adapter polish remains                                     |
 | Contract-aware receipts                               | Yes                          | Complete local correlation proof; product API polish remains                                           |
 | Contract-aware readings                               | Yes                          | Complete local QueryView proof                                                                         |
 | QueryView observer bridge                             | Yes                          | Complete core surface                                                                                  |

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -110,9 +110,7 @@ Implemented local pieces:
 Remaining pieces:
 
 - product-facing contract-aware receipt identity and outcome API polish;
-- contract-aware obstruction taxonomy, including unsupported operation,
-  unsupported query, admission obstruction, runtime fault, missing retention,
-  stale basis, residual reading, and budget exceeded;
+- product-facing integration of the contract-aware obstruction taxonomy;
 - release-grade retained `TickReceipt` and reading-envelope material beyond the
   current local correlation/payload fixture.
 
@@ -359,7 +357,7 @@ Missing pieces:
 | Installed contract package registry                   | Yes                          | Complete locally                                                                              |
 | Installed mutation handler dispatch                   | Yes                          | Complete locally                                                                              |
 | Intent outcome observation                            | Yes                          | Complete core surface; product API polish missing                                             |
-| Contract-aware receipts                               | Yes                          | Complete local correlation proof; product API/taxonomy polish remains                         |
+| Contract-aware receipts                               | Yes                          | Complete local correlation proof; product API polish remains                                  |
 | Contract-aware readings                               | Yes                          | Complete local QueryView proof                                                                |
 | QueryView observer bridge                             | Yes                          | Complete core surface                                                                         |
 | Wesley query and mutation host helpers                | Yes                          | Complete for current seam                                                                     |

--- a/docs/design/versioned-contract-api-compatibility.md
+++ b/docs/design/versioned-contract-api-compatibility.md
@@ -1,0 +1,91 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Versioned Contract And API Compatibility
+
+Status: implemented local package-boundary slice.
+
+This packet records the v0.1.0 compatibility boundary for generated contract
+packages. The goal is narrow: Echo should reject a generated package that does
+not fit the host runtime before the package can install mutation handlers,
+install query observers, stage runtime-visible work, or answer accepted reads.
+
+## Claim
+
+Generated contract packages now carry and verify the compatibility identity
+needed by the local Echo contract-host seam:
+
+- Echo contract ABI version;
+- Wesley generator version;
+- contract-host helper API version;
+- registry layout version;
+- codec identity;
+- schema hash;
+- package artifact hash;
+- per-operation footprint certificate identity.
+
+The package boundary rejects drift as `ContractArtifactRejection` instead of
+accepting ambiguous generated code and discovering the mismatch later through
+malformed runtime ingress, missing handlers, or misleading readings.
+
+## Boundary
+
+The compatibility check is host/runtime-owner policy. It does not make
+application payloads valid, does not authorize execution, does not grant query
+rights, and does not turn package metadata into semantic reading identity.
+
+The verified identity is evidence metadata:
+
+```text
+package install policy
+-> generated registry metadata
+-> verified installed package record
+-> receipt and reading contract evidence
+```
+
+Runtime-visible work still requires witnessed submission, admission evidence,
+ticketed runtime ingress, and a scheduler-owned tick. Readings still require a
+registered read-only query observer and bounded observation request.
+
+## Implemented Surface
+
+- `echo-registry-api` exposes `ECHO_CONTRACT_ABI_VERSION` and
+  `CONTRACT_HOST_HELPER_API_VERSION`.
+- `RegistryInfo` includes Echo ABI, Wesley generator, and helper API versions.
+- `ContractArtifactVerificationPolicy` requires those expected versions.
+- `verify_contract_artifact(...)` rejects Echo ABI, Wesley generator, and helper
+  API drift before weaker schema, codec, or footprint checks can pass.
+- `echo-wesley-gen --contract-host` emits generated constants for the same
+  compatibility identity and uses them in the generated registry provider.
+- `warp-core` retains verified compatibility metadata in
+  `ContractEvidenceIdentity`.
+- Installed contract readings and receipt correlations can cite the verified
+  compatibility metadata that produced them.
+
+## Invariants
+
+- Unsupported compatibility is rejected at package install, not at scheduler
+  work time.
+- Generated compatibility metadata is not caller testimony.
+- Receipts and readings may cite compatibility identity, but that citation is
+  not execution authority.
+- A CAS content hash is still byte identity only; compatibility metadata does
+  not become semantic lookup identity.
+- Echo core remains generic. Wesley-generated code owns application nouns.
+
+## Evidence
+
+- `cargo test -p echo-registry-api`
+- `cargo test -p echo-wesley-gen --test generation`
+- `cargo test -p warp-core --features native_rule_bootstrap --test installed_contract_registry_tests`
+- `cargo test -p warp-core --features "native_rule_bootstrap host_test" --test installed_contract_intent_pipeline_tests`
+- `cargo check -p echo-wasm-abi`
+
+## Remaining Release Work
+
+This slice is not release automation. Later v0.1.0 work still needs:
+
+- stable package publishing metadata;
+- release notes that name the supported compatibility set;
+- adapter-level compatibility reporting for product-facing clients;
+- migration policy for future incompatible contract-host seams.

--- a/docs/design/witnessed-submission-persistence.md
+++ b/docs/design/witnessed-submission-persistence.md
@@ -38,6 +38,9 @@ persistence shell needed for the host to persist accepted submission material.
 - The envelope ingress id must match the persisted submission record.
 - The envelope route must resolve to the persisted writer head.
 - The target inbox policy must still accept the envelope.
+- Snapshot export fails if any witnessed submission lacks canonical envelope
+  material; replay-only records must not silently disappear from persisted
+  state.
 - Invalid snapshots fail without partial import.
 - Duplicate submission after restore returns duplicate posture, not a new
   semantic submission event.

--- a/docs/design/witnessed-submission-persistence.md
+++ b/docs/design/witnessed-submission-persistence.md
@@ -1,0 +1,56 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Witnessed Submission Persistence
+
+Status: accepted and implemented local persistence shell.
+
+## Claim
+
+Echo can export and restore accepted witnessed submission material without
+running the scheduler. The persistence image binds each witnessed submission
+record to its canonical ingress envelope so a trusted host can recover
+accepted-but-not-yet-ticked work after restart.
+
+## Boundary
+
+`WitnessedSubmissionPersistenceSnapshot` is a deterministic local image of
+accepted submission records and canonical ingress envelopes. Restoring the image
+does all of the following:
+
+- restores witnessed submission identity;
+- restores Echo-owned submission generation;
+- restores canonical envelope material;
+- preserves duplicate detection after restart.
+
+Restoring the image does none of the following:
+
+- does not enter envelopes into scheduler-visible head inboxes;
+- does not stage ticketed runtime ingress;
+- does not advance `GlobalTick` or `WorldlineTick`;
+- does not dispatch handlers or execute contracts.
+
+The host still owns durable storage. This slice supplies the smallest core
+persistence shell needed for the host to persist accepted submission material.
+
+## Invariants
+
+- The envelope ingress id must match the persisted submission record.
+- The envelope route must resolve to the persisted writer head.
+- The target inbox policy must still accept the envelope.
+- Invalid snapshots fail without partial import.
+- Duplicate submission after restore returns duplicate posture, not a new
+  semantic submission event.
+- Recovery is not scheduler admission and does not grant application tick
+  authority.
+
+## Non-Goals
+
+- Do not implement disk storage or a write-ahead log.
+- Do not stage scheduler work during restore.
+- Do not issue admission tickets, law witnesses, or receipt correlations.
+- Do not retry or execute restored submissions automatically.
+
+## Witnesses
+
+- `cargo test -p warp-core --lib witnessed_submission_persistence`

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Echo's live documentation centers on the runtime carrier, the retained witnesses
 - Runtime model: [/architecture/outline](/architecture/outline)
 - WSC, Verkle, IPA, and retained readings: [/architecture/wsc-verkle-ipa-retained-readings](/architecture/wsc-verkle-ipa-retained-readings)
 - Application contract hosting: [/architecture/application-contract-hosting](/architecture/application-contract-hosting)
+- Local contract host quickstart: [/quickstart-local-contract-host](/quickstart-local-contract-host)
 - WARP optic implementation map: [/design/warp-optic-implementation-map](/design/warp-optic-implementation-map)
 - Echo v0.1.0 release plan: [/design/v0.1.0-release-plan](/design/v0.1.0-release-plan)
 - Theory map: [/theory/THEORY](/theory/THEORY)

--- a/docs/method/backlog/v0.1.0/DOCS_release-grade-quickstart.md
+++ b/docs/method/backlog/v0.1.0/DOCS_release-grade-quickstart.md
@@ -3,7 +3,7 @@
 
 # Release-Grade Quickstart
 
-Status: v0.1.0 release blocker.
+Status: initial executable quickstart implemented; product guide polish remains.
 
 Depends on:
 
@@ -33,12 +33,19 @@ The quickstart should show:
 
 ## Acceptance criteria
 
-- Commands pass on a clean checkout.
-- The guide names which APIs are application-facing and which are host-only.
-- Examples do not call tick from application code.
-- Error examples include unsupported operation/query and missing retention or
-  bounded residual posture.
-- The guide links to the version compatibility policy.
+- [x] Commands pass on a clean checkout.
+- [x] The guide names which APIs are application-facing and which are host-only.
+- [x] Examples do not call tick from application code.
+- [ ] Error examples include unsupported operation/query and missing retention
+      or bounded residual posture.
+- [x] The guide links to the version compatibility policy.
+
+## Implemented local slice
+
+`docs/quickstart-local-contract-host.md` now documents the executable local
+contract-host release witness, the app/host API split, compatibility checks,
+and retention boundary. The command path is
+`cargo xtask test-slice contract-path-release`.
 
 ## Non-goals
 

--- a/docs/method/backlog/v0.1.0/KERNEL_contract-obstruction-taxonomy.md
+++ b/docs/method/backlog/v0.1.0/KERNEL_contract-obstruction-taxonomy.md
@@ -3,7 +3,7 @@
 
 # Contract Obstruction Taxonomy
 
-Status: v0.1.0 release blocker.
+Status: implemented local boundary.
 
 Depends on:
 
@@ -33,6 +33,14 @@ The first release bar needs typed, contract-aware outcomes for at least:
 The taxonomy may reuse existing core variants where they already express the
 truth. It should add only the missing generic names needed by contract-hosted
 applications.
+
+Local boundary:
+
+- `warp-core` exposes generic `ContractObstructionKind`,
+  `ContractObstructionSubject`, and `ContractObstruction` types;
+- observation and runtime errors can be classified into the release-bar
+  obstruction family;
+- product-facing API integration remains a later release-bar slice.
 
 ## Acceptance criteria
 

--- a/docs/method/backlog/v0.1.0/KERNEL_witnessed-intent-submission-persistence.md
+++ b/docs/method/backlog/v0.1.0/KERNEL_witnessed-intent-submission-persistence.md
@@ -3,7 +3,7 @@
 
 # Witnessed Intent Submission Persistence
 
-Status: v0.1.0 release blocker.
+Status: implemented local persistence shell; durable host storage remains.
 
 Depends on:
 
@@ -43,10 +43,19 @@ Add a failing replay/recovery test:
 
 ## GREEN
 
-Persist and restore witnessed submission records and pending ingress membership
-through the existing runtime/provenance storage boundary, or add the smallest
-new storage shell needed to make accepted-but-not-yet-ticked submissions
-replayable after restart.
+Persist and restore witnessed submission records plus canonical ingress envelope
+material through the smallest core storage shell needed to make accepted-but-
+not-yet-ticked submissions recoverable after restart. The host still owns the
+durable storage medium.
+
+Implemented local shell:
+
+- `WitnessedSubmissionPersistenceSnapshot` exports accepted submission records
+  in deterministic replay order.
+- Each persistence record carries the canonical ingress envelope.
+- Restore validates ingress id, resolved head, and inbox policy before import.
+- Restore records semantic submission history and envelope material without
+  entering scheduler-visible inboxes.
 
 ## Acceptance Criteria
 
@@ -57,6 +66,7 @@ replayable after restart.
 - Submission recovery does not call `SchedulerCoordinator::super_tick(...)`.
 - Submission recovery does not dispatch installed handlers or execute contracts.
 - Raw transport arrival order remains outside semantic Echo history.
+- Invalid persistence images fail without partial import.
 
 ## Non-goals
 

--- a/docs/method/backlog/v0.1.0/KERNEL_witnessed-intent-submission-persistence.md
+++ b/docs/method/backlog/v0.1.0/KERNEL_witnessed-intent-submission-persistence.md
@@ -53,6 +53,8 @@ Implemented local shell:
 - `WitnessedSubmissionPersistenceSnapshot` exports accepted submission records
   in deterministic replay order.
 - Each persistence record carries the canonical ingress envelope.
+- Snapshot export rejects incomplete witnessed-submission state instead of
+  silently dropping replayed records that lack envelope material.
 - Restore validates ingress id, resolved head, and inbox policy before import.
 - Restore records semantic submission history and envelope material without
   entering scheduler-visible inboxes.
@@ -65,6 +67,8 @@ Implemented local shell:
 - Submission recovery does not advance `GlobalTick` or `WorldlineTick`.
 - Submission recovery does not call `SchedulerCoordinator::super_tick(...)`.
 - Submission recovery does not dispatch installed handlers or execute contracts.
+- Persistence snapshot export preserves all witnessed submissions or returns a
+  typed missing-envelope error.
 - Raw transport arrival order remains outside semantic Echo history.
 - Invalid persistence images fail without partial import.
 

--- a/docs/method/backlog/v0.1.0/PLATFORM_contract-retention-and-semantic-lookup-seams.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_contract-retention-and-semantic-lookup-seams.md
@@ -3,7 +3,7 @@
 
 # Contract Retention And Semantic Lookup Seams
 
-Status: implemented local boundary.
+Status: implemented local boundary; retained evidence refs complete.
 
 Depends on:
 
@@ -32,6 +32,15 @@ Add a bounded blob reader seam if `BlobStore::get Arc<[u8]>` cannot support
 bounded observers without full materialization. This is retained-payload lookup,
 not a streaming subscription surface.
 
+Core now also exposes retained evidence references above the byte-retention
+layer:
+
+- `RetainedEvidenceCoordinate` names contract identity, retained role, and
+  semantic digest;
+- `RetainedEvidenceRef` binds that coordinate to content hash and byte length;
+- `RetainedEvidencePosture` returns available evidence or a typed
+  `MissingRetention` obstruction.
+
 ## Acceptance criteria
 
 - Contract payloads can refer to retained blob fragments by CAS ref.
@@ -41,6 +50,8 @@ not a streaming subscription surface.
 - If retention is unavailable, lookup returns typed obstruction.
 - GC or compaction cannot silently produce false successful retained readings.
 - Cache hits are accepted only when the semantic coordinate matches.
+- Retained reading refs are not query identities.
+- Reading payload and reading-envelope references remain distinct roles.
 
 ## Non-goals
 

--- a/docs/method/backlog/v0.1.0/PLATFORM_external-contract-proof-fixture.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_external-contract-proof-fixture.md
@@ -3,7 +3,7 @@
 
 # External Contract Proof Fixture
 
-Status: implemented local proof fixture.
+Status: serious local fixture implemented; external package follow-through remains.
 
 Depends on:
 
@@ -41,17 +41,28 @@ the external contract and generated payloads.
 
 ## Acceptance criteria
 
-- The fixture includes at least one mutation.
-- The fixture includes at least one `QueryView`/`Query` reading.
-- The mutation and query use non-trivial vars.
-- The reading evidence includes bounded basis, aperture, and budget identity.
-- Receipt and reading evidence can be retained and inspected.
-- At least one conflict, rejection, obstruction, or residual path is exercised.
-- Local replay reproduces the fixture outcome.
-- Echo core contains no `jedit`, text, rope, buffer, editor, or Graft APIs
-  outside generated fixture payloads.
-- The fixture may declare retained tick/receipt obligations, but application
-  code does not create ticks or `TickReceipt` values.
+- [x] The fixture includes at least one mutation.
+- [x] The fixture includes at least one `QueryView`/`Query` reading.
+- [x] The mutation and query use non-trivial vars.
+- [x] The reading evidence includes bounded basis, aperture, and budget
+      identity.
+- [x] Receipt and reading evidence can be retained and inspected.
+- [x] At least one conflict, rejection, obstruction, or residual path is
+      exercised.
+- [x] Local replay reproduces the generic fixture outcome.
+- [x] Echo core contains no `jedit`, text, rope, buffer, editor, or Graft APIs
+      outside generated fixture payloads.
+- [x] The fixture may declare retained tick/receipt obligations, but
+      application code does not create ticks or `TickReceipt` values.
+
+## Implemented local slice
+
+`external_consumer_contract_fixture_tests` adds a serious
+external-consumer-shaped hot-text fixture. The document/edit names live only in
+the test package. The fixture installs through the generic package boundary,
+submits through the app-facing host handle, resolves one overlapping edit as a
+footprint conflict, observes a bounded query reading, and retains reading plus
+receipt evidence through semantic coordinates.
 
 ## Non-goals
 

--- a/docs/method/backlog/v0.1.0/PLATFORM_product-facing-intent-outcome-api.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_product-facing-intent-outcome-api.md
@@ -3,7 +3,7 @@
 
 # Product-Facing Intent Outcome API
 
-Status: v0.1.0 release blocker.
+Status: implemented local core surface; adapter polish remains.
 
 Depends on:
 
@@ -35,6 +35,16 @@ match echo.observe_intent_outcome(submission.id)? {
 ```
 
 The exact names may differ, but the authority boundary may not.
+
+Current local core surface:
+
+- `WorldlineRuntime::submit_app_intent(...)`;
+- `IntentSubmissionHandle`;
+- `WorldlineRuntime::observe_app_intent_outcome(...)`;
+- `IntentOutcome`;
+- `IntentOutcomeReceipt`.
+
+The remaining work is adapter/API polish above this core surface.
 
 ## Acceptance criteria
 

--- a/docs/method/backlog/v0.1.0/PLATFORM_reference-trusted-runtime-host-loop.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_reference-trusted-runtime-host-loop.md
@@ -3,7 +3,7 @@
 
 # Reference Trusted Runtime Host Loop
 
-Status: v0.1.0 release blocker.
+Status: local reference boundary implemented; product adapter polish remains.
 
 Depends on:
 
@@ -35,13 +35,21 @@ The reference host loop owns:
 
 ## Acceptance criteria
 
-- A clean example hosts one installed contract package locally.
-- Application code submits through the app-safe API only.
-- The host loop owns scheduler control and tick cadence.
-- The host can run until idle without exposing that capability to application
-  code.
-- Runtime-local fault recovery is host-owned.
-- The example can observe intent outcomes and query readings after ticks.
+- [x] A clean example hosts one installed contract package locally.
+- [x] Application code submits through the app-safe API only.
+- [x] The host loop owns scheduler control and tick cadence.
+- [x] The host can run until idle without exposing that capability to
+      application code.
+- [ ] Runtime-local fault recovery is host-owned.
+- [x] The example can observe intent outcomes and query readings after ticks.
+
+## Implemented local slice
+
+`warp-core` now provides `TrustedRuntimeHost` and `TrustedRuntimeApp` for the
+local contract-host path. The host installs generated packages, stages ticketed
+runtime ingress, runs `super_tick` until idle, and serves observations. The app
+handle can submit intents and observe outcomes/readings, but it cannot tick,
+install packages, stage ingress, or recover scheduler faults.
 
 ## Non-goals
 

--- a/docs/method/backlog/v0.1.0/PLATFORM_versioned-contract-api-compatibility.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_versioned-contract-api-compatibility.md
@@ -3,7 +3,7 @@
 
 # Versioned Contract And API Compatibility
 
-Status: v0.1.0 release blocker.
+Status: local package-boundary slice implemented; release automation remains.
 
 Depends on:
 
@@ -31,11 +31,20 @@ or call time, not discovered through malformed receipts.
 
 ## Acceptance criteria
 
-- Package installation records version and compatibility metadata.
-- Version, schema, artifact, codec, or helper mismatch fails closed.
-- Receipts and readings can cite the installed package identity they came from.
-- The external proof fixture documents the Echo/Wesley versions used.
-- Release notes identify the supported ABI/package compatibility set.
+- [x] Package installation records version and compatibility metadata.
+- [x] Version, schema, artifact, codec, or helper mismatch fails closed.
+- [x] Receipts and readings can cite the installed package identity they came
+      from.
+- [ ] The external proof fixture documents the Echo/Wesley versions used.
+- [ ] Release notes identify the supported ABI/package compatibility set.
+
+## Implemented local slice
+
+`echo-registry-api` now requires Echo contract ABI, Wesley generator, and
+contract-host helper API compatibility in generated registry metadata and host
+verification policy. `echo-wesley-gen --contract-host` emits those constants,
+and `warp-core` carries the verified identity into installed package evidence
+for receipts and readings.
 
 ## Non-goals
 

--- a/docs/method/backlog/v0.1.0/SECURITY_authority-boundary-audit.md
+++ b/docs/method/backlog/v0.1.0/SECURITY_authority-boundary-audit.md
@@ -3,7 +3,7 @@
 
 # Authority Boundary Audit
 
-Status: v0.1.0 release blocker.
+Status: initial local audit recorded; final release security review remains.
 
 Depends on:
 
@@ -31,12 +31,20 @@ Verify that application-facing paths cannot:
 
 ## Acceptance criteria
 
-- Tests prove app-facing dispatch cannot tick or access trusted runtime control.
-- WASM/Node/browser exports are app-safe if those packages ship.
-- Generated helpers target app-safe request APIs or host-only install APIs
-  explicitly.
-- Host-only APIs are documented as runtime-owner authority.
-- Security review records any deferred risks before release candidate.
+- [x] Tests prove app-facing dispatch cannot tick or access trusted runtime
+      control.
+- [ ] WASM/Node/browser exports are app-safe if those packages ship.
+- [x] Generated helpers target app-safe request APIs or host-only install APIs
+      explicitly.
+- [x] Host-only APIs are documented as runtime-owner authority.
+- [x] Security review records deferred risks before release candidate.
+
+## Implemented local slice
+
+`docs/design/v0.1.0-authority-boundary-audit.md` records the current
+authority-boundary evidence and deferred risks. The local release witness keeps
+application code on `TrustedRuntimeApp` and trusted runtime control on
+`TrustedRuntimeHost`.
 
 ## Non-goals
 

--- a/docs/method/backlog/v0.1.0/TEST_v0.1.0-replay-dind-proof.md
+++ b/docs/method/backlog/v0.1.0/TEST_v0.1.0-replay-dind-proof.md
@@ -3,7 +3,7 @@
 
 # v0.1.0 Replay And DIND Proof
 
-Status: v0.1.0 release blocker.
+Status: narrow local release witness implemented; broader DIND gate remains.
 
 Depends on:
 
@@ -31,13 +31,21 @@ same package
 
 ## Acceptance criteria
 
-- The external proof fixture participates in replay.
-- Accepted submissions replay with stable submission identity.
-- Tick receipts reproduce for the same scheduler-owned decision set.
-- Reading envelopes reproduce for the same query basis, vars, aperture, and
-  observer identity.
-- Missing retained material produces obstruction rather than fake success.
-- `cargo xtask dind` or a narrower documented release witness covers the path.
+- [x] The external proof fixture participates in replay.
+- [x] Accepted submissions replay with stable submission identity.
+- [x] Tick receipts reproduce for the same scheduler-owned decision set.
+- [x] Reading envelopes reproduce for the same query basis, vars, aperture, and
+      observer identity.
+- [x] Missing retained material produces obstruction rather than fake success.
+- [x] `cargo xtask dind` or a narrower documented release witness covers the
+      path.
+
+## Implemented local slice
+
+`cargo xtask test-slice contract-path-release` now runs the explicit local
+contract path release witness: installed contract pipeline replay, reference
+trusted host loop, and the serious external-consumer-shaped fixture. The command
+is a narrow release witness, not a replacement for broader DIND CI gates.
 
 ## Non-goals
 

--- a/docs/quickstart-local-contract-host.md
+++ b/docs/quickstart-local-contract-host.md
@@ -1,0 +1,113 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Quickstart: Local Contract Host
+
+Status: v0.1.0 executable quickstart baseline.
+
+This quickstart shows the current local contract-host path. It is not a product
+app, not a daemon, and not distributed Continuum transport. It is the smallest
+release-grade proof that Echo can host a generated contract locally while
+preserving the authority boundary:
+
+```text
+application submits
+trusted runtime host stages and ticks
+application observes outcomes and readings
+```
+
+## Run The Witness
+
+From a clean checkout:
+
+```bash
+cargo xtask test-slice contract-path-release --dry-run
+cargo xtask test-slice contract-path-release
+```
+
+The dry run prints the exact Cargo targets. The real run executes:
+
+- installed contract pipeline replay;
+- reference trusted runtime host loop;
+- serious external-consumer-shaped contract fixture.
+
+## What The Witness Proves
+
+The witness covers the current v0.1.0 local contract path:
+
+1. Install a generated-style package through the package boundary.
+2. Submit canonical EINT bytes through an app-facing handle.
+3. Keep the submission pending until trusted runtime-owned staging.
+4. Stage ticketed runtime ingress through the trusted host.
+5. Run scheduler-owned ticks until idle.
+6. Observe applied and rejected intent outcomes.
+7. Query a bounded `QueryView` reading through a read-only observer.
+8. Retain reading payload and receipt evidence through semantic coordinates.
+9. Replay the local installed pipeline to the same receipt and outcome.
+
+## Application Surface
+
+Application code should use the app-facing surface:
+
+```rust
+let mut app = host.app();
+let submission = app.submit_intent(envelope)?;
+let outcome = app.observe_intent_outcome(&submission.submission_id);
+let reading = app.observe(query_request)?;
+```
+
+The app surface does not expose:
+
+- package installation;
+- ticketed runtime ingress staging;
+- `super_tick`;
+- scheduler pass or run-until-idle control;
+- scheduler fault recovery authority.
+
+## Trusted Host Surface
+
+The trusted runtime owner uses the host surface:
+
+```rust
+host.install_contract_package(package)?;
+host.stage_installed_contract_submission(submission.submission_id, &ticket)?;
+host.run_until_idle(4)?;
+```
+
+That host role owns scheduler control. Wall-clock cadence is host policy; fixed
+logical ticks are Echo semantic history.
+
+## Compatibility Boundary
+
+Generated packages must fit the runtime before they install. The package
+boundary verifies:
+
+- Echo contract ABI version;
+- Wesley generator version;
+- contract-host helper API version;
+- registry layout version;
+- codec id;
+- schema hash;
+- footprint certificate identity.
+
+Unsupported compatibility fails closed at package install. It does not become
+runtime-visible work or an accepted read.
+
+## Retention Boundary
+
+Retention uses semantic coordinates above content-only CAS:
+
+```text
+CAS hash = bytes
+semantic coordinate = question those bytes answer
+```
+
+Missing retained material is an obstruction, not an empty successful reading.
+
+## Non-Goals
+
+- No streaming subscriptions.
+- No hidden retry queue.
+- No distributed replica import.
+- No full observer-rights revelation lattice.
+- No application-created ticks or `TickReceipt` values.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -141,6 +141,7 @@ The repo also exposes maintenance commands via `cargo xtask …`:
 - `cargo xtask test-slice observation` runs only `warp-core` observation module unit tests via `--lib`.
 - `cargo xtask test-slice neighborhood` runs only `warp-core` neighborhood module unit tests via `--lib`.
 - `cargo xtask test-slice warp-core-smoke` runs the `warp-core` lib tests plus the strand integration target without launching every integration-test binary.
+- `cargo xtask test-slice contract-path-release` runs the v0.1 local contract-host release witness: installed contract pipeline replay, reference trusted host loop, and the serious external consumer fixture.
 - `cargo xtask pr-preflight` runs the default changed-scope pre-PR gate against `origin/main`.
 - `cargo xtask pr-preflight --full` runs the broader explicit full pre-PR gate.
 - `cargo xtask dind` runs the DIND (Deterministic Ironclad Nightmare Drills) harness locally.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -89,6 +89,8 @@ enum TestSlice {
     Neighborhood,
     /// High-signal warp-core smoke without compiling every integration-test target.
     WarpCoreSmoke,
+    /// v0.1 local contract-host replay/release witness.
+    ContractPathRelease,
 }
 
 #[derive(Args)]
@@ -573,6 +575,35 @@ fn build_test_slice_commands(slice: TestSlice) -> Vec<Command> {
         TestSlice::WarpCoreSmoke => vec![
             cargo_command(["test", "-p", "warp-core", "--lib"]),
             cargo_command(["test", "-p", "warp-core", "--test", "strand_contract_tests"]),
+        ],
+        TestSlice::ContractPathRelease => vec![
+            cargo_command([
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap host_test",
+                "--test",
+                "installed_contract_intent_pipeline_tests",
+            ]),
+            cargo_command([
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime",
+                "--test",
+                "trusted_runtime_host_loop_tests",
+            ]),
+            cargo_command([
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime",
+                "--test",
+                "external_consumer_contract_fixture_tests",
+            ]),
         ],
     }
 }
@@ -6290,6 +6321,57 @@ mod tests {
         assert_eq!(
             args,
             vec!["test", "-p", "warp-core", "--test", "strand_contract_tests"]
+        );
+    }
+
+    #[test]
+    fn test_slice_contract_path_release_stays_explicit() {
+        let commands = build_test_slice_commands(TestSlice::ContractPathRelease);
+        assert_eq!(commands.len(), 3);
+
+        let (program, args) = command_program_and_args(&commands[0]);
+        assert_eq!(program, "cargo");
+        assert_eq!(
+            args,
+            vec![
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap host_test",
+                "--test",
+                "installed_contract_intent_pipeline_tests",
+            ]
+        );
+
+        let (program, args) = command_program_and_args(&commands[1]);
+        assert_eq!(program, "cargo");
+        assert_eq!(
+            args,
+            vec![
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime",
+                "--test",
+                "trusted_runtime_host_loop_tests",
+            ]
+        );
+
+        let (program, args) = command_program_and_args(&commands[2]);
+        assert_eq!(program, "cargo");
+        assert_eq!(
+            args,
+            vec![
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime",
+                "--test",
+                "external_consumer_contract_fixture_tests",
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary

This PR advances the v0.1 local contract-host release bar across the next ten planned slices. It keeps Echo scoped to a deterministic local contract host: application code submits intent and observes evidence, while trusted runtime control owns admission, ticks, scheduling, and receipt production.

## Slices

1. Refresh the v0.1 release roadmap and BEARING status around the local contract-host bar.
2. Add a contract-aware obstruction taxonomy for unsupported operations, queries, admission failures, runtime faults, retention gaps, stale basis, residual readings, and budget limits.
3. Add retained evidence references that separate byte identity from semantic reading coordinates and return explicit missing-retention obstructions.
4. Persist witnessed submissions in a deterministic snapshot shape for accepted-but-not-yet-decided app intents.
5. Add an app-facing intent outcome API for pending, applied, rejected, obstructed, faulted, and unknown outcomes.
6. Enforce contract/API compatibility metadata across registry, ABI, generated helpers, and contract evidence identity.
7. Add a reference trusted runtime host loop that drains submitted app intents without granting app code tick authority.
8. Add a serious external contract fixture proving mutation, conflict, QueryView reading, retention, and no app nouns in core.
9. Add a contract-path release witness slice for the v0.1 local host path.
10. Add the local contract-host quickstart and authority-boundary audit docs.

A final test-only commit fixes local preflight witnesses after the hook exposed direct-test-target and clippy issues.

## Validation

- `cargo xtask pr-preflight --base origin/main`
- `cargo xtask test-slice contract-path-release`
- `cargo test -p warp-core --lib app_intent`
- Pre-push `verify-local` hook passed during branch push.

## Authority Boundaries Preserved

- Application code cannot tick.
- Application code cannot access trusted runtime control.
- Submit/admit APIs do not execute synchronously.
- `AdmissionTicket` is not `TickReceipt`.
- `AdmissionTicket` is not execution.
- Query observers are read-only.
- Mutation handlers run only during scheduler-owned ticks.
- Retry is explicit new causal input, not hidden runtime behavior.
- CAS byte identity is not semantic reading identity.
