### PR TITLE
docs: require direct-main authorization evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,7 +422,8 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   docs-only direct-main exception for the Echo graph model checkpoint, including
   authorization context, exact commits, validation, changed files, and the
   future rule to prefer PRs unless an emergency or docs-only fast path is
-  explicitly authorized.
+  explicitly authorized. Future exception records must also cite explicit
+  authorizer identity and authorization evidence.
 - `docs/design/built-in-echo-graph-data-model.md` defines Echo's native
   graph ontology for future optic admission, authority, transaction atomicity,
   receipts, witnessed readings, footprint addressing, transaction-local object

--- a/docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md
+++ b/docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md
@@ -76,6 +76,9 @@ a maintainer.
 Even for docs-only direct pushes:
 
 - state the exception before pushing;
+- record the explicit authorizer identity and authorization evidence, such as a
+  link or citation to the issue, PR comment, thread, or chat log where the
+  exception was approved;
 - run the relevant docs validation;
 - record exact commits and changed files;
 - confirm no source/runtime code was touched;


### PR DESCRIPTION
## Summary
- requires direct-main exception records to cite explicit authorizer identity and authorization evidence
- updates the changelog entry for the existing direct-main exception procedure

## Validation
- git diff --check
- pnpm exec markdownlint-cli2 CHANGELOG.md docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md
- cargo xtask lint-dead-refs --file CHANGELOG.md --file docs/procedures/DIRECT-MAIN-EXCEPTION-LOG.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated direct-main exception procedures to require recording explicit authorizer identity and authorization evidence when documenting future exceptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/echo/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->