### PR TITLE
feat(wasm): support jedit v0.1 release witness

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -3,7 +3,9 @@
 
 # VISION
 
-Echo is an industrial-grade graph-rewrite simulation engine where state is a graph, time is a hash chain, and determinism is structurally enforced.
+Echo is a deterministic WARP runtime for witnessed causal history. It owns
+admission, scheduler-owned ticks, receipts, readings, and retained evidence so
+applications can stay focused on authored domain semantics.
 
 ```mermaid
 mindmap
@@ -51,6 +53,28 @@ Deterministic replay is not a feature you turn on; it is how the engine works. E
 ### 5. Systems Integrity
 
 The engine is built for the systems engineer. Strict lints, panic-free paths (Mr. Clean), and comprehensive determinism drills (DIND) ensure that Echo remains a professional-grade bedrock for causal simulation.
+
+### 6. Product Pressure Proves Release Truth
+
+The `v0.1.0` release is delayed until a real external consumer proves Echo's
+local contract-host path. That consumer is `jedit`.
+
+The in-repo external fixture proves generic mechanics; it does not prove that
+Echo is ready to build applications with. The release bar is a sibling jedit
+checkout that can submit a contract-backed edit intent, let a trusted Echo host
+tick, observe the outcome, query a bounded text reading, retain evidence, and
+replay the result without granting application code tick authority or moving
+editor nouns into Echo core.
+
+This keeps the north star honest:
+
+```text
+Application submits intent.
+Trusted runtime owns ticks.
+Receipts witness decisions.
+Readings carry evidence.
+External applications prove the seam.
+```
 
 ---
 

--- a/crates/warp-wasm/README.md
+++ b/crates/warp-wasm/README.md
@@ -25,9 +25,10 @@ See the repository root `README.md` for the full overview.
   `WorldlineTick` is per-worldline append identity and `GlobalTick` is runtime
   cycle correlation metadata. No wall-clock time enters Echo internals.
 - Public application dispatch rejects privileged scheduler control envelopes.
-  Trusted runtime control is kept on a separate Rust host/runtime-owner trait,
-  not on the public browser application dispatch export. Browser adapters must
-  not hand the raw kernel/control surface to untrusted application code.
+  Trusted runtime control is kept on a separate host/runtime-owner export,
+  `dispatch_control_intent_trusted(...)`, and a separate Rust
+  `TrustedKernelControlPort` installation path. Browser adapters must not hand
+  the raw kernel/control surface to untrusted application code.
 - Intended to power future browser-based visualizers and inspectors built on
   top of the same core engine as native tools.
 

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -32,8 +32,9 @@ use echo_wasm_abi::kernel_port::HeadInfo;
 use echo_wasm_abi::kernel_port::{
     self, AbiError, DispatchOpticIntentRequest, ErrEnvelope, KernelPort, ObservationRequest,
     ObserveOpticRequest, OkEnvelope, OpticIntentPayload, SettlementRequest,
+    TrustedKernelControlPort,
 };
-use echo_wasm_abi::{unpack_intent_v1, CONTROL_INTENT_V1_OP_ID};
+use echo_wasm_abi::{unpack_control_intent_v1, unpack_intent_v1, CONTROL_INTENT_V1_OP_ID};
 
 use std::cell::RefCell;
 
@@ -42,7 +43,35 @@ use std::cell::RefCell;
 // ---------------------------------------------------------------------------
 
 thread_local! {
-    static KERNEL: RefCell<Option<Box<dyn KernelPort>>> = const { RefCell::new(None) };
+    static KERNEL: RefCell<Option<InstalledKernel>> = const { RefCell::new(None) };
+}
+
+enum InstalledKernel {
+    App(Box<dyn KernelPort>),
+    Trusted(Box<dyn TrustedKernelControlPort>),
+}
+
+impl InstalledKernel {
+    fn kernel(&self) -> &dyn KernelPort {
+        match self {
+            Self::App(kernel) => kernel.as_ref(),
+            Self::Trusted(kernel) => kernel.as_ref(),
+        }
+    }
+
+    fn kernel_mut(&mut self) -> &mut dyn KernelPort {
+        match self {
+            Self::App(kernel) => kernel.as_mut(),
+            Self::Trusted(kernel) => kernel.as_mut(),
+        }
+    }
+
+    fn trusted_mut(&mut self) -> Option<&mut dyn TrustedKernelControlPort> {
+        match self {
+            Self::App(_) => None,
+            Self::Trusted(kernel) => Some(kernel.as_mut()),
+        }
+    }
 }
 
 /// Install a kernel implementation into the WASM boundary.
@@ -55,7 +84,22 @@ thread_local! {
 /// Does not panic. Replaces any previously installed kernel.
 pub fn install_kernel(kernel: Box<dyn KernelPort>) {
     KERNEL.with(|cell| {
-        *cell.borrow_mut() = Some(kernel);
+        *cell.borrow_mut() = Some(InstalledKernel::App(kernel));
+    });
+}
+
+/// Install a trusted runtime-owner kernel implementation into the WASM boundary.
+///
+/// Application adapters should use [`install_kernel`] or only receive app-safe
+/// exports. Host/runtime-owner adapters that own scheduler lifecycle may install
+/// this trusted boundary and call [`dispatch_control_intent_trusted`].
+///
+/// # Panics
+///
+/// Does not panic. Replaces any previously installed kernel.
+pub fn install_trusted_kernel(kernel: Box<dyn TrustedKernelControlPort>) {
+    KERNEL.with(|cell| {
+        *cell.borrow_mut() = Some(InstalledKernel::Trusted(kernel));
     });
 }
 
@@ -97,6 +141,26 @@ pub fn get_registry_info_cbor() -> Vec<u8> {
     encode_result_bytes(with_kernel_ref(|k| Ok(k.registry_info())))
 }
 
+/// Dispatch a privileged control intent through the trusted runtime boundary.
+///
+/// `control_intent_bytes` must be a packed `ControlIntentV1` EINT envelope. This
+/// is the native Rust equivalent of the `dispatch_control_intent_trusted` WASM
+/// export and is intentionally separate from application `dispatch_intent`.
+pub fn dispatch_control_intent_trusted_cbor(control_intent_bytes: &[u8]) -> Vec<u8> {
+    let control = match unpack_control_intent_v1(control_intent_bytes) {
+        Ok(control) => control,
+        Err(err) => {
+            return encode_err_bytes(&AbiError {
+                code: kernel_port::error_codes::INVALID_PAYLOAD,
+                message: format!("invalid trusted control intent payload: {err}"),
+            })
+        }
+    };
+    encode_result_bytes(with_trusted_kernel(|k| {
+        k.dispatch_control_intent_trusted(control)
+    }))
+}
+
 /// Remove any installed kernel from the WASM boundary.
 #[cfg(feature = "engine")]
 fn clear_kernel() {
@@ -119,7 +183,7 @@ where
             code: kernel_port::error_codes::NOT_INITIALIZED,
             message: "kernel not initialized; call init() first".into(),
         })?;
-        f(kernel.as_mut())
+        f(kernel.kernel_mut())
     })
 }
 
@@ -134,7 +198,26 @@ where
             code: kernel_port::error_codes::NOT_INITIALIZED,
             message: "kernel not initialized; call init() first".into(),
         })?;
-        f(kernel.as_ref())
+        f(kernel.kernel())
+    })
+}
+
+/// Run a closure with a mutable reference to the trusted runtime boundary.
+fn with_trusted_kernel<F, R>(f: F) -> Result<R, AbiError>
+where
+    F: FnOnce(&mut dyn TrustedKernelControlPort) -> Result<R, AbiError>,
+{
+    KERNEL.with(|cell| {
+        let mut borrow = cell.borrow_mut();
+        let kernel = borrow.as_mut().ok_or_else(|| AbiError {
+            code: kernel_port::error_codes::NOT_INITIALIZED,
+            message: "kernel not initialized; call init() first".into(),
+        })?;
+        let trusted = kernel.trusted_mut().ok_or_else(|| AbiError {
+            code: kernel_port::error_codes::NOT_SUPPORTED,
+            message: "trusted runtime control is not installed".into(),
+        })?;
+        f(trusted)
     })
 }
 
@@ -292,7 +375,7 @@ where
         Ok((kernel, head)) => {
             let envelope = OkEnvelope::new(&head);
             if let Ok(bytes) = echo_wasm_abi::encode_cbor(&envelope) {
-                install_kernel(Box::new(kernel));
+                install_trusted_kernel(Box::new(kernel));
                 bytes_to_uint8array(&bytes)
             } else {
                 clear_kernel();
@@ -349,6 +432,27 @@ pub fn init() -> Uint8Array {
 pub fn dispatch_intent(intent_bytes: &[u8]) -> Uint8Array {
     encode_result(with_kernel(|k| {
         dispatch_application_intent(k, intent_bytes)
+    }))
+}
+
+/// Execute a privileged scheduler/runtime control intent.
+///
+/// This export is for trusted host/runtime-owner adapters. Application-facing
+/// clients must use `dispatch_intent`, `observe`, and `scheduler_status` only.
+/// The input bytes must be a packed `ControlIntentV1` EINT envelope.
+#[wasm_bindgen]
+pub fn dispatch_control_intent_trusted(control_intent_bytes: &[u8]) -> Uint8Array {
+    let control = match unpack_control_intent_v1(control_intent_bytes) {
+        Ok(control) => control,
+        Err(err) => {
+            return encode_err(&AbiError {
+                code: kernel_port::error_codes::INVALID_PAYLOAD,
+                message: format!("invalid trusted control intent payload: {err}"),
+            })
+        }
+    };
+    encode_result(with_trusted_kernel(|k| {
+        k.dispatch_control_intent_trusted(control)
     }))
 }
 
@@ -1012,6 +1116,38 @@ mod init_tests {
         }
     }
 
+    impl TrustedKernelControlPort for StubKernel {
+        fn dispatch_control_intent_trusted(
+            &mut self,
+            intent: ControlIntentV1,
+        ) -> Result<DispatchResponse, AbiError> {
+            assert!(matches!(
+                intent,
+                ControlIntentV1::Start {
+                    mode: SchedulerMode::UntilIdle {
+                        cycle_limit: Some(1)
+                    }
+                }
+            ));
+            Ok(DispatchResponse {
+                accepted: true,
+                intent_id: vec![42; 32],
+                submission_id: None,
+                submission_generation: None,
+                scheduler_status: SchedulerStatus {
+                    state: SchedulerState::Inactive,
+                    active_mode: None,
+                    work_state: WorkState::Quiescent,
+                    run_id: Some(RunId(7)),
+                    latest_cycle_global_tick: Some(GlobalTick(1)),
+                    latest_commit_global_tick: Some(GlobalTick(1)),
+                    last_quiescent_global_tick: Some(GlobalTick(1)),
+                    last_run_completion: Some(RunCompletion::Quiesced),
+                },
+            })
+        }
+    }
+
     #[test]
     fn clear_kernel_removes_previously_installed_kernel() {
         clear_kernel();
@@ -1042,6 +1178,57 @@ mod init_tests {
         let err: ErrEnvelope = echo_wasm_abi::decode_cbor(&response).unwrap();
 
         assert_eq!(err.code, kernel_port::error_codes::FORBIDDEN_CONTROL_INTENT);
+    }
+
+    #[test]
+    fn trusted_control_dispatches_packed_control_intent_start() {
+        clear_kernel();
+        install_trusted_kernel(Box::new(StubKernel));
+        let control = echo_wasm_abi::pack_control_intent_v1(&ControlIntentV1::Start {
+            mode: SchedulerMode::UntilIdle {
+                cycle_limit: Some(1),
+            },
+        })
+        .unwrap();
+
+        let response = dispatch_control_intent_trusted_cbor(&control);
+        let envelope: OkEnvelope<DispatchResponse> = echo_wasm_abi::decode_cbor(&response).unwrap();
+
+        assert!(envelope.data.accepted);
+        assert_eq!(envelope.data.intent_id, vec![42; 32]);
+        assert_eq!(
+            envelope.data.scheduler_status.last_run_completion,
+            Some(RunCompletion::Quiesced)
+        );
+    }
+
+    #[test]
+    fn trusted_control_is_unavailable_for_app_only_installed_kernel() {
+        clear_kernel();
+        install_kernel(Box::new(StubKernel));
+        let control = echo_wasm_abi::pack_control_intent_v1(&ControlIntentV1::Start {
+            mode: SchedulerMode::UntilIdle {
+                cycle_limit: Some(1),
+            },
+        })
+        .unwrap();
+
+        let response = dispatch_control_intent_trusted_cbor(&control);
+        let err: ErrEnvelope = echo_wasm_abi::decode_cbor(&response).unwrap();
+
+        assert_eq!(err.code, kernel_port::error_codes::NOT_SUPPORTED);
+    }
+
+    #[test]
+    fn trusted_control_rejects_non_control_intent_envelope() {
+        clear_kernel();
+        install_trusted_kernel(Box::new(StubKernel));
+        let app_intent = echo_wasm_abi::pack_intent_v1(1, b"not-control").unwrap();
+
+        let response = dispatch_control_intent_trusted_cbor(&app_intent);
+        let err: ErrEnvelope = echo_wasm_abi::decode_cbor(&response).unwrap();
+
+        assert_eq!(err.code, kernel_port::error_codes::INVALID_PAYLOAD);
     }
 
     #[test]

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -90,10 +90,10 @@ without moving application nouns into Echo core.
 - The semantic retention layer is local and in-memory; durable retained
   artifact, witness, receipt, and reading recovery remains future work.
 - Generic external contract proof exists, but the release gate now requires
-  real `jedit` follow-through from the sibling repository. The current jedit
-  real-WASM witness still carries stale app-owned scheduler-control
-  assumptions and must be replaced by an app/host split that matches Echo's
-  authority boundary.
+  real `jedit` follow-through from the sibling repository. jedit now has a
+  local app/host split for its opt-in real-WASM witness; the remaining gap is
+  moving from the old stack-witness fixture shape to retained evidence, replay,
+  and a jedit-owned generated contract path.
 
 ## Doctrine
 
@@ -311,10 +311,16 @@ The proof must preserve the authority split:
 - the existing fake transport may stay as a local harness, but the release
   witness must run against the real Echo boundary.
 
-The current opt-in jedit real-WASM stack witness is stale in one useful way: it
-attempts to carry scheduler control through app-facing dispatch. Echo correctly
-rejects that with `FORBIDDEN_CONTROL_INTENT`. The next integration slice should
-change jedit's witness shape, not weaken Echo's dispatch boundary.
+The current opt-in jedit real-WASM stack witness now uses a separate trusted
+host-control transport. Agents can run jedit's JSON-capable CLI witness:
+
+```sh
+ECHO_WARP_WASM_DIR=/path/to/echo/crates/warp-wasm \
+  node scripts/jedit-echo-witness.mjs --json
+```
+
+The next integration slice should improve witness content: retained evidence,
+replay, and a jedit-owned generated contract path, not scheduler authority.
 
 ## Next Candidate Slices
 

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -3,7 +3,7 @@
 
 # BEARING
 
-Last updated: 2026-05-22.
+Last updated: 2026-05-23.
 
 This signpost summarizes current direction. It does not create commitments or
 replace backlog items, design docs, retros, or CLI status. If it disagrees with
@@ -15,6 +15,9 @@ The WARP paper-to-Echo noun map is maintained in
 The feature bar for the eventual `v0.1.0` release is maintained in
 `docs/design/v0.1.0-release-plan.md`.
 
+The current external release gate is maintained in
+`docs/design/v0.1.0-jedit-release-gate.md`.
+
 The filesystem lane for release-bar backlog cards is
 `docs/method/backlog/v0.1.0/`.
 
@@ -25,9 +28,11 @@ application ingress can become witnessed submission history, lawful admission
 evidence, ticketed runtime ingress, scheduler-owned handler dispatch, receipt
 correlation, and observable intent outcome.
 
-The current priority is to make that pipeline consumer-grade for
-Wesley-compiled contract packages: contract-aware receipts, honest reading
-identity, bounded retained readings, and external consumer proof fixtures
+The current priority is to prove that pipeline with `jedit` as a real external
+consumer. The in-repo external fixture remains valuable, but it is no longer
+the `v0.1.0` release gate. Echo is not ready to release until jedit can submit
+an application-owned contract intent, let a trusted Echo host tick, observe the
+outcome, query a bounded reading, retain evidence, and replay the result
 without moving application nouns into Echo core.
 
 ## What Is Already True
@@ -84,9 +89,11 @@ without moving application nouns into Echo core.
   need release-grade stabilization.
 - The semantic retention layer is local and in-memory; durable retained
   artifact, witness, receipt, and reading recovery remains future work.
-- Generic external contract proof exists, but a serious application-owned
-  consumer proof, especially `jedit`, still needs to prove the host path with
-  generated artifacts outside Echo core.
+- Generic external contract proof exists, but the release gate now requires
+  real `jedit` follow-through from the sibling repository. The current jedit
+  real-WASM witness still carries stale app-owned scheduler-control
+  assumptions and must be replaced by an app/host split that matches Echo's
+  authority boundary.
 
 ## Doctrine
 
@@ -254,10 +261,10 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 
 8. **Serious External Consumer Proof Fixture**
 
-    The contract-host path now has a hot-text-shaped external consumer fixture
-    covering document-edit-style mutation, overlapping write conflict, bounded
-    QueryView reading, retained reading payload, and retained receipt evidence
-    while keeping application nouns in test fixture code.
+    The contract-host path now has a serious external-consumer fixture covering
+    non-trivial mutation, overlapping write conflict, bounded QueryView
+    reading, retained reading payload, and retained receipt evidence while
+    keeping application nouns in test fixture code.
 
 9. **Local Replay/DIND Proof For Contract Path**
 
@@ -270,6 +277,44 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
     `docs/quickstart-local-contract-host.md` now documents the executable local
     contract-host path. `docs/design/v0.1.0-authority-boundary-audit.md` records
     the app/host authority split, current evidence, and deferred release risks.
+
+## Release Gate Shift
+
+`v0.1.0` is officially delayed until the jedit/Echo proof passes outside the
+Echo repository.
+
+The required shape is:
+
+```text
+sibling application-owned contract and adapters
+-> Wesley generated Echo runtime artifacts
+-> Echo installs a generic generated package
+-> application submits canonical intent
+-> trusted Echo host stages and ticks
+-> application observes applied, rejected, or obstructed outcome
+-> application queries a bounded reading
+-> retained evidence and replay prove the same result
+```
+
+The proof must preserve the authority split:
+
+- application code does not tick;
+- product capabilities remain application-owned nouns and must not appear in
+  Echo core or Echo package boundary APIs;
+- application-facing code uses product capabilities rather than Echo runtime
+  coordinates;
+- application code does not send scheduler control through
+  `dispatch_intent`;
+- trusted host code owns package install, ticketed ingress staging, scheduler
+  passes, until-idle policy, and fault recovery;
+- Echo core does not import application product nouns or product concepts;
+- the existing fake transport may stay as a local harness, but the release
+  witness must run against the real Echo boundary.
+
+The current opt-in jedit real-WASM stack witness is stale in one useful way: it
+attempts to carry scheduler control through app-facing dispatch. Echo correctly
+rejects that with `FORBIDDEN_CONTROL_INTENT`. The next integration slice should
+change jedit's witness shape, not weaken Echo's dispatch boundary.
 
 ## Next Candidate Slices
 

--- a/docs/design/v0.1.0-jedit-release-gate.md
+++ b/docs/design/v0.1.0-jedit-release-gate.md
@@ -115,8 +115,11 @@ ECHO_WARP_WASM_DIR=/path/to/echo/crates/warp-wasm \
 ```
 
 That command is the right agent entry point for the current local release gate.
-An MCP wrapper can come later, but it should wrap the same CLI once retained
-evidence and replay output are strong enough to expose through a protocol.
+It emits a machine-readable command summary and, on success, a witness report
+with the app/host authority split, observed reading identity, artifact hash,
+residual posture, observer basis, and product-shaped text result. An MCP wrapper
+can come later, but it should wrap the same CLI once retained evidence and
+replay output are strong enough to expose through a protocol.
 
 ## Authority Bar
 

--- a/docs/design/v0.1.0-jedit-release-gate.md
+++ b/docs/design/v0.1.0-jedit-release-gate.md
@@ -116,10 +116,16 @@ ECHO_WARP_WASM_DIR=/path/to/echo/crates/warp-wasm \
 
 That command is the right agent entry point for the current local release gate.
 It emits a machine-readable command summary and, on success, a witness report
-with the app/host authority split, observed reading identity, artifact hash,
-residual posture, observer basis, and product-shaped text result. An MCP wrapper
-can come later, but it should wrap the same CLI once retained evidence and
-replay output are strong enough to expose through a protocol.
+with the app/host authority split, generated jedit contract metadata, observed
+reading identity, artifact hash, residual posture, observer basis, and
+product-shaped text result. An MCP wrapper can come later, but it should wrap
+the same CLI once retained evidence and replay output are strong enough to
+expose through a protocol.
+
+jedit keeps sibling Echo checkout paths and process execution behind its
+witness-runner port/adapter. The CLI is not the authority boundary; it delegates
+to a Node adapter that owns filesystem and process details while the witness
+orchestration stays path-blind.
 
 ## Authority Bar
 

--- a/docs/design/v0.1.0-jedit-release-gate.md
+++ b/docs/design/v0.1.0-jedit-release-gate.md
@@ -105,6 +105,19 @@ The proof must also include one non-happy path:
 The first passing path may choose the smallest of those non-happy paths, but
 `v0.1.0` should not rely on an all-success-only demonstration.
 
+## Agent Witness
+
+The sibling jedit repository now provides a CLI-first witness surface:
+
+```sh
+ECHO_WARP_WASM_DIR=/path/to/echo/crates/warp-wasm \
+  node scripts/jedit-echo-witness.mjs --json
+```
+
+That command is the right agent entry point for the current local release gate.
+An MCP wrapper can come later, but it should wrap the same CLI once retained
+evidence and replay output are strong enough to expose through a protocol.
+
 ## Authority Bar
 
 - application code in the sibling repository cannot tick.

--- a/docs/design/v0.1.0-jedit-release-gate.md
+++ b/docs/design/v0.1.0-jedit-release-gate.md
@@ -1,0 +1,174 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# v0.1.0 jedit Release Gate
+
+Status: active release gate.
+
+This document records the current release decision:
+
+```text
+Echo v0.1.0 does not ship until jedit works on Echo.
+```
+
+The in-repo external contract fixture remains necessary, but it is not
+sufficient. Echo must prove the same contract-host path from a real sibling
+application repository with application-owned contract nouns and generated
+artifacts outside `warp-core`.
+
+## Claim
+
+Echo is ready for `v0.1.0` only when jedit can use Echo as a real deterministic
+local contract host:
+
+```text
+sibling application-owned contract and adapters
+-> Wesley generated Echo runtime artifacts
+-> Echo installs a generic generated package
+-> app-safe intent submission
+-> trusted Echo host tick
+-> observable intent outcome
+-> bounded QueryView reading
+-> retained evidence
+-> deterministic replay proof
+```
+
+The proof must run from the jedit repository. A fixture that only lives inside
+Echo can prove generic mechanics, but it cannot prove the external developer
+surface, package boundary, or product-pressure ergonomics.
+
+## Current Fact
+
+The jedit default test suite has a fake Echo-shaped transport. That harness is
+still useful because it keeps the product-facing contract stable without
+requiring a sibling Echo build.
+
+jedit also has an opt-in real Echo WASM witness. That witness currently uses an
+old authority model: it tries to send scheduler `start` / `until_idle` control
+through app-facing `dispatch_intent`. Current Echo correctly rejects that path
+as forbidden control intent.
+
+That failure is not a release blocker to fix by weakening Echo. It is the next
+integration signal:
+
+```text
+application submits intent
+trusted host controls ticks
+application observes outcome and readings
+```
+
+## Application Boundary Model
+
+The sibling application may expose product capabilities above the Echo boundary.
+Those names are application nouns, not Echo nouns. Echo should see a generated
+runtime package, operation/query ids, canonical intent bytes, observer helpers,
+receipts, readings, and retained evidence.
+
+The release proof should preserve that split:
+
+```text
+application product capability or adapter
+-> app-safe intent
+-> opaque product token if the application needs one
+-> bounded product reading
+```
+
+The app-facing contract must not expose Echo worldline ids, head ids, scheduler
+state, or fixture root derivation. Those coordinates may exist below the
+adapter boundary where Echo and trusted host adapters can use them lawfully.
+Application product capabilities must not become Echo core or package nouns.
+
+## Required Proof
+
+The release witness should prove at least one serious application story:
+
+```text
+open or create application session
+-> issue or recover an application product capability
+-> submit a mutation with non-trivial vars
+-> trusted Echo host runs until idle
+-> application observes the outcome
+-> application queries a bounded reading
+-> application receives product-shaped payload plus Echo reading evidence
+-> retained receipt and reading evidence can be inspected
+-> replay reproduces the outcome and reading
+```
+
+The proof must also include one non-happy path:
+
+- unsupported operation or query rejected at package boundary;
+- footprint conflict or lawful rejection;
+- admission obstruction;
+- missing retention posture;
+- stale basis or residual bounded reading posture.
+
+The first passing path may choose the smallest of those non-happy paths, but
+`v0.1.0` should not rely on an all-success-only demonstration.
+
+## Authority Bar
+
+- application code in the sibling repository cannot tick.
+- application code in the sibling repository cannot access trusted runtime
+  control.
+- app-facing dispatch does not execute synchronously.
+- scheduler control is not tunneled through `dispatch_intent`.
+- mutation handlers run only during scheduler-owned execution.
+- query observers are read-only.
+- retry is a new explicit causal act.
+- wall-clock cadence is host/runtime-owner policy, not semantic history.
+
+## Ownership
+
+Echo owns:
+
+- package installation and compatibility rejection;
+- admission evidence;
+- ticketed runtime ingress;
+- scheduler-owned ticks;
+- receipts and outcome correlation;
+- retained evidence coordinates;
+- bounded observation machinery.
+
+jedit owns:
+
+- application product nouns;
+- session and user experience;
+- authored GraphQL contracts;
+- product-shaped intent and reading adapters;
+- product policy for ordinary user interactions.
+
+Wesley owns:
+
+- deterministic generation from authored SDL;
+- generated helper shapes;
+- schema, artifact, codec, and operation identity.
+
+Other application engines may help the sibling application interpret product
+state. They are not Echo mutation authority and are not the Echo release gate.
+
+## Non-Goals
+
+- Do not build all of jedit before `v0.1.0`.
+- Do not import jedit nouns into Echo core.
+- Do not add app-facing tick authority.
+- Do not make the fake transport the release proof.
+- Do not require full Continuum transport/import.
+- Do not require full observer-rights governance.
+- Do not require durable fault provenance.
+
+## Passing Bar
+
+The gate is satisfied when a clean checkout of jedit can run a documented
+command against a clean checkout or published artifact of Echo and produce a
+deterministic witness report proving:
+
+- generated package compatibility;
+- app-safe submission;
+- trusted-host ticking;
+- applied, rejected, or obstructed intent outcome;
+- bounded reading with `ReadingEnvelope` evidence;
+- retained receipt and reading evidence;
+- replay of the same result;
+- no application product nouns in Echo core.
+
+Until then, Echo remains pre-`v0.1.0`.

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -647,6 +647,7 @@ ECHO_WARP_WASM_DIR=/path/to/echo/crates/warp-wasm \
   node scripts/jedit-echo-witness.mjs --json
 ```
 
-The JSON includes command status and the current witness report. That report is
-still stack-witness-fixture shaped; it is not yet the final retained
+The JSON includes command status and the current witness report. That report now
+cites generated jedit contract metadata, but it is still
+stack-witness-fixture-backed execution; it is not yet the final retained
 jedit-owned contract replay proof.

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -12,6 +12,10 @@ the release shape: what must be true before Echo is reasonable to build with,
 what is already solid, what is still missing, and what explicitly belongs after
 `v0.1.0`.
 
+The active external release gate is
+`docs/design/v0.1.0-jedit-release-gate.md`: Echo `v0.1.0` is delayed until
+jedit works on Echo from the sibling jedit repository.
+
 The active filesystem lane for release-blocking cards is
 `docs/method/backlog/v0.1.0/`. Cards in that lane define the release bar; they
 move into `docs/method/backlog/asap/` only when they become the current pull.
@@ -35,7 +39,9 @@ evidence, and replay the result deterministically.
 ```
 
 This release is not "Echo is finished." It is the first version where Echo is a
-usable deterministic local contract host.
+usable deterministic local contract host. The concrete proof is no longer an
+Echo-only fixture: jedit must be able to use Echo for a real external
+contract-backed editing path before the release is cut.
 
 Echo `v0.1.0` is scoped to local deterministic contract hosting. It implements
 the local authored-boundary/runtime seam of WARP: compiled contract intents,
@@ -356,9 +362,9 @@ Remaining pieces:
 
 ### 8. External Consumer Proof
 
-Before calling Echo ready to build with, one serious consumer-shaped proof should
-exercise the generic path. This does not mean building the full `jedit` product
-inside Echo. It means proving:
+Before calling Echo ready to build with, one serious consumer-shaped proof must
+exercise the generic path from outside Echo. This does not mean building the
+full `jedit` product inside Echo. It means proving:
 
 ```text
 external contract shape
@@ -375,17 +381,17 @@ Implemented local pieces:
 
 - generic external-consumer-shaped fixture with mutation, QueryView reading,
   retained evidence, conflict posture, and replay;
-- serious hot-text-shaped fixture with document-edit-style mutation,
-  overlapping write conflict, bounded document-window QueryView reading, and
-  semantic retention;
-- no production `warp-core` API imports `jedit`, text, editor, rope, or buffer
-  nouns.
+- serious external-consumer fixture with non-trivial mutation, overlapping
+  write conflict, bounded QueryView reading, and semantic retention;
+- no production `warp-core` API imports application product nouns.
 
 Remaining pieces:
 
-- real application-owned generated package from outside Echo, preferably the
-  `jedit` contract package;
-- release-grade fixture documentation and quickstart integration.
+- real application-owned generated package from outside Echo, now specifically
+  the `jedit` contract package;
+- jedit proof that application code submits intent while trusted Echo host code
+  owns package installation, scheduler control, and until-idle policy;
+- release-grade fixture documentation and quickstart integration;
 - operations/readings serious enough to exercise bounded query, receipts, and
   retention.
 
@@ -410,7 +416,7 @@ Remaining pieces:
 | Durable accepted-submission recovery                  | Yes                          | Local persistence shell complete; host storage and crash protocol remain                                |
 | App-safe WASM, Node, and browser API                  | Yes, if shipping JS packages | Conditional on published artifact set                                                                   |
 | Reference trusted host loop                           | Yes                          | Local reference host/app boundary complete; product adapter and fault recovery polish remain            |
-| External consumer proof fixture                       | Yes                          | Serious in-repo fixture complete; real external package follow-through remains                          |
+| External consumer proof fixture                       | Yes                          | Serious in-repo fixture complete; real jedit-on-Echo proof is now the release gate                      |
 | Quickstart/docs that actually work                    | Yes                          | Initial executable local contract-host quickstart complete; product guide polish remains                |
 | Versioned contract/API compatibility                  | Yes                          | Local package-boundary checks complete; release automation and adapter reporting remain                 |
 | Versioned crates/packages/release notes               | Yes                          | Missing/release work                                                                                    |
@@ -429,8 +435,8 @@ The following work is important but should not block the first release:
 | Dynamic plugin loading                   | Static package install is enough for `v0.1.0`.                                   |
 | Streaming subscriptions                  | Polling/query/observe is enough initially.                                       |
 | Automatic retry                          | Retry must remain an explicit causal act. Defer helpers until policy is settled. |
-| Full `jedit` product integration         | Use a serious `jedit`-shaped proof, not the finished product.                    |
-| Graft live automation                    | Downstream consumer, not a core release blocker.                                 |
+| Full sibling application integration     | Use a real external release witness, not the finished product.                   |
+| Downstream automation                    | Downstream consumer work, not a core release blocker.                            |
 | Generic braid/counterfactual system      | Important WARP work, but not required for first app-host release.                |
 | Full social/speculative lane policy      | Paper-level lane policy is larger than local contract hosting.                   |
 | Durable fault provenance                 | Runtime-local quarantine is enough if documented honestly.                       |
@@ -461,6 +467,7 @@ The following work is important but should not block the first release:
 | Retention                | Artifacts, readings, and receipts load by hash and semantic coordinate.         |
 | Replay                   | Same package, submissions, and scheduler policy reproduce receipts/readings.    |
 | Docs                     | Quickstart commands pass on a clean checkout.                                   |
+| jedit release gate       | jedit repository runs the documented real Echo witness successfully.            |
 
 ## Developer Happy Path
 
@@ -591,7 +598,7 @@ reviewable and testable:
 5. Product-facing intent outcome API.
 6. Reference trusted runtime host loop.
 7. App-safe WASM, Node, and browser client surface, if publishing JS packages.
-8. External Wesley contract proof fixture.
+8. Real jedit-on-Echo release gate.
 9. Local replay/DIND proof for the app contract path.
 10. Release-grade quickstart.
 11. Error and obstruction taxonomy stabilization.
@@ -610,7 +617,7 @@ gaps.
 A `v0.1.0` release candidate exists when:
 
 - all Required Feature Clusters have merged tests;
-- the external consumer proof passes on a clean checkout;
+- the jedit-on-Echo release gate passes on clean Echo and jedit checkouts;
 - the quickstart is executable from scratch;
 - the authority-boundary audit is green;
 - the replay/DIND proof is green;
@@ -628,4 +635,6 @@ query bounded readings, retain evidence, and replay the result deterministically
 using documented, versioned APIs.
 ```
 
-That is the release bar: Echo is a usable deterministic local contract host.
+That is the general release bar. The concrete `v0.1.0` witness is jedit: Echo
+ships when jedit can do that from outside Echo without privileged tick
+authority.

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -646,3 +646,7 @@ checkout:
 ECHO_WARP_WASM_DIR=/path/to/echo/crates/warp-wasm \
   node scripts/jedit-echo-witness.mjs --json
 ```
+
+The JSON includes command status and the current witness report. That report is
+still stack-witness-fixture shaped; it is not yet the final retained
+jedit-owned contract replay proof.

--- a/docs/design/v0.1.0-release-plan.md
+++ b/docs/design/v0.1.0-release-plan.md
@@ -638,3 +638,11 @@ using documented, versioned APIs.
 That is the general release bar. The concrete `v0.1.0` witness is jedit: Echo
 ships when jedit can do that from outside Echo without privileged tick
 authority.
+
+The current agent-facing release witness should be run from the sibling jedit
+checkout:
+
+```sh
+ECHO_WARP_WASM_DIR=/path/to/echo/crates/warp-wasm \
+  node scripts/jedit-echo-witness.mjs --json
+```

--- a/docs/design/wasm-trusted-runtime-host-control-boundary.md
+++ b/docs/design/wasm-trusted-runtime-host-control-boundary.md
@@ -1,0 +1,97 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# WASM Trusted Runtime Host Control Boundary
+
+Status: local WASM authority boundary implemented.
+
+This packet records the low-level WASM host-control boundary needed by the
+`v0.1.0` browser and JavaScript release work. It is generic Echo runtime
+plumbing. It is not an application API and does not import application nouns
+into `warp-core` or `warp-wasm`.
+
+## Claim
+
+The raw WASM package has two distinct authority surfaces:
+
+```text
+application-facing surface
+-> dispatch_intent(...)
+-> observe(...)
+-> scheduler_status(...)
+
+trusted host/runtime-owner surface
+-> dispatch_control_intent_trusted(...)
+```
+
+Application dispatch still rejects reserved scheduler control envelopes. The
+trusted host export accepts packed `ControlIntentV1` envelopes only through a
+kernel installed as `TrustedKernelControlPort`.
+
+## Why This Exists
+
+The local Rust contract-host path already separates application submit/observe
+authority from trusted runtime tick authority. Browser and JavaScript release
+work needs the same split at the raw WASM package boundary.
+
+Without this split, an external application witness has only two bad options:
+
+- send scheduler `start` / `until_idle` control through app-facing intent
+  dispatch, which Echo correctly rejects; or
+- expose raw runtime owner power directly to application code.
+
+The correct shape is a trusted host adapter that owns the raw control export and
+hands application code only the app-safe surface.
+
+## Implemented Surface
+
+`warp-wasm` now provides:
+
+- `install_kernel(Box<dyn KernelPort>)` for app-only installed kernels;
+- `install_trusted_kernel(Box<dyn TrustedKernelControlPort>)` for trusted host
+  kernels;
+- `dispatch_intent(...)` / `dispatch_intent_cbor(...)`, which reject
+  `CONTROL_INTENT_V1_OP_ID`;
+- `dispatch_control_intent_trusted(...)` /
+  `dispatch_control_intent_trusted_cbor(...)`, which decode packed
+  `ControlIntentV1` and require a trusted installed kernel.
+
+The raw bundler package exports `dispatch_control_intent_trusted(...)` because
+host adapters need it. High-level application packages and facades must not
+re-export that function to untrusted application code.
+
+## Authority Boundary
+
+```text
+application code
+-> app-safe package facade
+-> dispatch_intent / observe / scheduler_status
+
+trusted host adapter
+-> raw WASM package
+-> dispatch_control_intent_trusted
+-> trusted runtime-owned scheduler control
+```
+
+The trusted export does not make application dispatch synchronous. It only gives
+the host/runtime owner a legal way to run Echo's scheduler lifecycle after
+application ingress has been submitted.
+
+## Evidence
+
+- `public_dispatch_rejects_packed_control_intent_start`
+- `public_dispatch_rejects_hand_built_reserved_control_op_id`
+- `public_optic_dispatch_rejects_hand_built_reserved_control_op_id`
+- `trusted_control_dispatches_packed_control_intent_start`
+- `trusted_control_is_unavailable_for_app_only_installed_kernel`
+- `trusted_control_rejects_non_control_intent_envelope`
+- `scripts/tests/warp_wasm_package_exports_test.sh`
+
+## Non-Goals
+
+- No application-controlled ticks.
+- No synchronous execution from app dispatch.
+- No product-specific operation names.
+- No high-level browser facade in this slice.
+- No production sandbox claim.
+- No wall-clock cadence semantics.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ Echo's live documentation centers on the runtime carrier, the retained witnesses
 - Worldlines, playback, and observation: [/spec/SPEC-0004-worldlines-playback-truthbus](/spec/SPEC-0004-worldlines-playback-truthbus)
 - Provenance payload and boundary records: [/spec/SPEC-0005-provenance-payload](/spec/SPEC-0005-provenance-payload)
 - WASM ABI contract: [/spec/SPEC-0009-wasm-abi](/spec/SPEC-0009-wasm-abi)
+- WASM trusted runtime host control: [/design/wasm-trusted-runtime-host-control-boundary](/design/wasm-trusted-runtime-host-control-boundary)
 - JS to canonical CBOR mapping: [/spec/js-cbor-mapping](/spec/js-cbor-mapping)
 - ABI golden vectors: [/spec/abi-golden-vectors](/spec/abi-golden-vectors)
 - WARP view protocol: [/spec/warp-view-protocol](/spec/warp-view-protocol)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Echo's live documentation centers on the runtime carrier, the retained witnesses
 - Local contract host quickstart: [/quickstart-local-contract-host](/quickstart-local-contract-host)
 - WARP optic implementation map: [/design/warp-optic-implementation-map](/design/warp-optic-implementation-map)
 - Echo v0.1.0 release plan: [/design/v0.1.0-release-plan](/design/v0.1.0-release-plan)
+- Echo v0.1.0 jedit release gate: [/design/v0.1.0-jedit-release-gate](/design/v0.1.0-jedit-release-gate)
 - Theory map: [/theory/THEORY](/theory/THEORY)
 - Current bearing: [/BEARING](/BEARING)
 - WARP core runtime: [/spec/warp-core](/spec/warp-core)

--- a/docs/method/backlog/bad-code/wasm-control-intent-authority-boundary.md
+++ b/docs/method/backlog/bad-code/wasm-control-intent-authority-boundary.md
@@ -3,11 +3,12 @@
 
 # WASM control intent authority boundary is too implicit
 
-Status: active follow-up. The immediate bug was fixed by making public
+Status: partially addressed. The immediate bug was fixed by making public
 application dispatch reject `CONTROL_INTENT_V1_OP_ID` before the kernel can
 run scheduler control. `WarpKernel::dispatch_intent(...)` also rejects the
 reserved control op id directly, while trusted runtime control now uses a
-separate `TrustedKernelControlPort` Rust host/runtime-owner path.
+separate `TrustedKernelControlPort` Rust host/runtime-owner path. The raw WASM
+package now exposes `dispatch_control_intent_trusted(...)` for host adapters.
 
 The remaining concern is product packaging and host architecture: browser
 adapters must not hand untrusted application code a raw privileged runtime
@@ -29,3 +30,7 @@ Acceptance criteria:
   control path to application code.
 - README, WASM ABI docs, and package docs describe the authority split
   consistently.
+
+Current design packet:
+
+- [`WASM Trusted Runtime Host Control Boundary`](../../../design/wasm-trusted-runtime-host-control-boundary.md)

--- a/docs/method/backlog/v0.1.0/PLATFORM_app-safe-client-surface.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_app-safe-client-surface.md
@@ -37,6 +37,8 @@ Application clients may not:
 - Published client packages expose only the app-safe surface.
 - Raw kernel objects or trusted control ports are not reachable from
   application JavaScript.
+- High-level browser/application facades do not re-export the raw
+  `dispatch_control_intent_trusted(...)` WASM host-control function.
 - Query observer helpers remain read-only.
 - Client examples do not call tick, step, start, or trusted runtime control.
 - The Rust/local API remains usable if JS/WASM packages are deferred.

--- a/docs/method/backlog/v0.1.0/PLATFORM_external-contract-proof-fixture.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_external-contract-proof-fixture.md
@@ -3,7 +3,7 @@
 
 # External Contract Proof Fixture
 
-Status: serious local fixture implemented; external package follow-through remains.
+Status: serious local fixture implemented; jedit release gate remains.
 
 Depends on:
 
@@ -16,10 +16,12 @@ Depends on:
 
 ## Why now
 
-The generic contract-host path needs one serious external consumer-shaped
-proof before Echo can claim `v0.1.0` buildability. `jedit` is the preferred
-shape because it pressures bounded readings, retained evidence, conflicts, and
-replay without letting Echo core import text-editor nouns.
+The generic contract-host path needs one serious external consumer proof before
+Echo can claim `v0.1.0` buildability. The in-repo external fixture proved
+the local mechanics. It is no longer enough for the release. The release gate is
+now a real `jedit` proof from the sibling repository because it pressures
+bounded readings, retained evidence, conflicts, replay, generated artifacts,
+and application ergonomics without letting Echo core import application nouns.
 
 ## What it should look like
 
@@ -36,8 +38,8 @@ external contract
 -> local replay proof
 ```
 
-The fixture may use text-like operations and readings, but the nouns remain in
-the external contract and generated payloads.
+The fixture may use application-shaped operations and readings, but the nouns
+remain in the external contract and generated payloads.
 
 ## Acceptance criteria
 
@@ -50,19 +52,35 @@ the external contract and generated payloads.
 - [x] At least one conflict, rejection, obstruction, or residual path is
       exercised.
 - [x] Local replay reproduces the generic fixture outcome.
-- [x] Echo core contains no `jedit`, text, rope, buffer, editor, or Graft APIs
-      outside generated fixture payloads.
+- [x] Echo core contains no application product APIs outside generated fixture
+      payloads.
 - [x] The fixture may declare retained tick/receipt obligations, but
       application code does not create ticks or `TickReceipt` values.
+- [ ] The sibling `jedit` repository can run the documented real Echo witness
+      against a clean Echo checkout or published artifact.
+- [ ] sibling application code submits intent without access to scheduler
+      control.
+- [ ] trusted Echo host code owns package installation, scheduler control,
+      until-idle policy, and fault recovery.
+- [ ] jedit observes an outcome and bounded reading with retained evidence.
+- [ ] jedit replay reproduces the same outcome and reading.
 
 ## Implemented local slice
 
 `external_consumer_contract_fixture_tests` adds a serious
-external-consumer-shaped hot-text fixture. The document/edit names live only in
-the test package. The fixture installs through the generic package boundary,
-submits through the app-facing host handle, resolves one overlapping edit as a
+external-consumer-shaped fixture. The application names live only in the test
+package. The fixture installs through the generic package boundary, submits
+through the app-facing host handle, resolves one overlapping mutation as a
 footprint conflict, observes a bounded query reading, and retains reading plus
 receipt evidence through semantic coordinates.
+
+## Remaining release gate
+
+The next proof must live in `~/git/jedit`, not as another `warp-core` fixture.
+The current opt-in jedit real-WASM witness is useful but stale: it still tries
+to send scheduler control through app-facing dispatch. Echo correctly rejects
+that as forbidden control intent. The fix is to update the jedit witness around
+the app/host split, not to grant application code tick authority.
 
 ## Non-goals
 
@@ -70,4 +88,4 @@ receipt evidence through semantic coordinates.
 - Do not author the `jedit` product contract inside Echo.
 - Do not make the fixture a privileged Echo ontology.
 - Do not add a special `jedit` ABI.
-- Do not implement Graft automation in Echo core.
+- Do not implement downstream automation in Echo core.

--- a/docs/method/backlog/v0.1.0/PLATFORM_jedit-real-echo-release-gate.md
+++ b/docs/method/backlog/v0.1.0/PLATFORM_jedit-real-echo-release-gate.md
@@ -1,0 +1,79 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# jedit Real Echo Release Gate
+
+Status: active release blocker.
+
+Depends on:
+
+- [External contract proof fixture](./PLATFORM_external-contract-proof-fixture.md)
+- [Reference trusted runtime host loop](./PLATFORM_reference-trusted-runtime-host-loop.md)
+- [App-safe client surface](./PLATFORM_app-safe-client-surface.md)
+
+Echo `v0.1.0` is blocked until jedit works on Echo from the sibling jedit
+repository.
+
+## Why now
+
+The in-repo external contract fixture proved the generic mechanics. It did not
+prove application ergonomics, cross-repo generated artifact use, real WASM or
+host packaging, or the product pressure of a serious external application.
+
+jedit is the release witness because it is external, product-shaped, and strict
+about keeping application nouns out of Echo core.
+
+## Required path
+
+```text
+sibling application-owned contract
+-> Wesley generated Echo runtime artifacts
+-> Echo installs a generic generated package
+-> application submits canonical intent
+-> trusted Echo host stages and ticks
+-> application observes intent outcome
+-> application queries bounded reading
+-> retained receipt and reading evidence can be inspected
+-> replay reproduces the result
+```
+
+## Acceptance criteria
+
+- [ ] A documented jedit command runs against a clean Echo checkout or
+      published Echo artifact.
+- [ ] The proof uses generated jedit/Wesley contract artifacts rather than a
+      second hand-authored protocol shape.
+- [ ] product capabilities remain application-side nouns; Echo core and Echo
+      package boundaries do not define or import them.
+- [ ] opaque read-basis tokens remain supporting app-safe tokens, not primary
+      runtime coordinates.
+- [ ] sibling application code does not access scheduler control.
+- [ ] scheduler `start`, `until_idle`, and fault recovery remain trusted host
+      authority.
+- [ ] at least one application mutation uses non-trivial vars.
+- [ ] at least one bounded reading returns product-shaped payload plus Echo
+      reading evidence.
+- [ ] at least one non-happy path is covered: unsupported operation/query,
+      lawful rejection, admission obstruction, residual reading, or missing
+      retention.
+- [ ] retained receipt and reading evidence can be loaded or inspected by
+      semantic coordinate.
+- [ ] replay reproduces the same outcome and reading.
+- [ ] Echo core contains no application product APIs.
+
+## Current blocker
+
+The existing jedit opt-in real Echo WASM witness still reflects an older model:
+it tries to carry scheduler control through app-facing dispatch. Current Echo
+correctly rejects that as forbidden control intent. The release work is to
+update the jedit witness around the app/host split, not to weaken Echo.
+
+## Non-goals
+
+- Do not build all of jedit.
+- Do not move application product nouns into Echo.
+- Do not grant application code tick authority.
+- Do not replace jedit's fake transport harness before the real witness is
+  ready.
+- Do not require full Continuum transport/import.
+- Do not require full observer-rights governance.

--- a/docs/method/backlog/v0.1.0/RELEASE_v0.1.0-release-candidate.md
+++ b/docs/method/backlog/v0.1.0/RELEASE_v0.1.0-release-candidate.md
@@ -11,6 +11,7 @@ Depends on:
 - [Release-grade quickstart](./DOCS_release-grade-quickstart.md)
 - [Authority boundary audit](./SECURITY_authority-boundary-audit.md)
 - [Versioned contract and API compatibility](./PLATFORM_versioned-contract-api-compatibility.md)
+- [jedit real Echo release gate](./PLATFORM_jedit-real-echo-release-gate.md)
 
 ## Why now
 
@@ -23,7 +24,7 @@ authority checks are merged. It should not be pulled until the remaining
 A `v0.1.0` release candidate exists when:
 
 - all Required Feature Clusters have merged tests;
-- the external consumer proof passes on a clean checkout;
+- the jedit-on-Echo release gate passes on clean Echo and jedit checkouts;
 - the quickstart is executable from scratch;
 - the authority-boundary audit is green;
 - the replay/DIND proof is green;

--- a/docs/spec/SPEC-0009-wasm-abi-v3.md
+++ b/docs/spec/SPEC-0009-wasm-abi-v3.md
@@ -14,6 +14,7 @@ ABI v3 makes three boundaries explicit:
 
 - `observe(request)` is the canonical generic world-state read export; neighborhood-specific read exports expose bounded site/core views.
 - `dispatch_intent(...)` is the public application intent ingress surface.
+- `dispatch_control_intent_trusted(...)` is the privileged host/runtime-owner control surface.
 - `scheduler_status()` is the read-only scheduler metadata export.
 
 Echo internals do not consume wall-clock time. All clocks in this ABI are
@@ -37,8 +38,11 @@ represents `Option<...>::None`.
   committed anything yet.
 
 Scheduler lifecycle requests are privileged runtime control, not application
-intents. Public application dispatch rejects the reserved control op id. There
-is no public `step(...)`, poll, or tick hook API in ABI v3.
+intents. Public application dispatch rejects the reserved control op id. The raw
+WASM package exposes `dispatch_control_intent_trusted(...)` for host/runtime
+owners; high-level application facades must not re-export it to untrusted
+application code. There is no public `step(...)`, poll, or application tick hook
+API in ABI v3.
 
 ## Architecture
 
@@ -50,7 +54,7 @@ is no public `step(...)`, poll, or tick hook API in ABI v3.
                     │  wasm-bindgen exports
 ┌───────────────────▼─────────────────────────────┐
 │              warp-wasm (boundary)                │
-│  thread_local RefCell<Option<Box<dyn KernelPort>>>│
+│  thread_local installed app/trusted kernel          │
 │  Encodes Result<T, AbiError> → CBOR envelope    │
 └───────────────────┬─────────────────────────────┘
                     │  KernelPort trait
@@ -65,18 +69,19 @@ is no public `step(...)`, poll, or tick hook API in ABI v3.
 All exports are `#[wasm_bindgen]` functions. Return types are CBOR-encoded
 `Uint8Array` unless noted otherwise.
 
-| Export                               | Signature              | Returns                        |
-| ------------------------------------ | ---------------------- | ------------------------------ |
-| `init()`                             | `() → Uint8Array`      | `HeadInfo` envelope            |
-| `dispatch_intent(bytes)`             | `(&[u8]) → Uint8Array` | `DispatchResponse` envelope    |
-| `observe(request)`                   | `(&[u8]) → Uint8Array` | `ObservationArtifact` envelope |
-| `observe_neighborhood_site(request)` | `(&[u8]) → Uint8Array` | `NeighborhoodSite` envelope    |
-| `observe_neighborhood_core(request)` | `(&[u8]) → Uint8Array` | `NeighborhoodCore` envelope    |
-| `scheduler_status()`                 | `() → Uint8Array`      | `SchedulerStatus` envelope     |
-| `get_registry_info()`                | `() → Uint8Array`      | `RegistryInfo` envelope        |
-| `get_codec_id()`                     | `() → JsValue`         | `string \| null`               |
-| `get_registry_version()`             | `() → JsValue`         | `string \| null`               |
-| `get_schema_sha256_hex()`            | `() → JsValue`         | `string \| null`               |
+| Export                                   | Signature              | Returns                        |
+| ---------------------------------------- | ---------------------- | ------------------------------ |
+| `init()`                                 | `() → Uint8Array`      | `HeadInfo` envelope            |
+| `dispatch_intent(bytes)`                 | `(&[u8]) → Uint8Array` | `DispatchResponse` envelope    |
+| `dispatch_control_intent_trusted(bytes)` | `(&[u8]) → Uint8Array` | `DispatchResponse` envelope    |
+| `observe(request)`                       | `(&[u8]) → Uint8Array` | `ObservationArtifact` envelope |
+| `observe_neighborhood_site(request)`     | `(&[u8]) → Uint8Array` | `NeighborhoodSite` envelope    |
+| `observe_neighborhood_core(request)`     | `(&[u8]) → Uint8Array` | `NeighborhoodCore` envelope    |
+| `scheduler_status()`                     | `() → Uint8Array`      | `SchedulerStatus` envelope     |
+| `get_registry_info()`                    | `() → Uint8Array`      | `RegistryInfo` envelope        |
+| `get_codec_id()`                         | `() → JsValue`         | `string \| null`               |
+| `get_registry_version()`                 | `() → JsValue`         | `string \| null`               |
+| `get_schema_sha256_hex()`                | `() → JsValue`         | `string \| null`               |
 
 Removed before or by ABI v3:
 

--- a/docs/spec/SPEC-0009-wasm-abi.md
+++ b/docs/spec/SPEC-0009-wasm-abi.md
@@ -7,7 +7,7 @@ _Define the current deterministic browser boundary for intent ingress, scheduler
 
 Legend: PLATFORM
 
-Current ABI version: 10
+Current ABI version: 11
 
 Depends on:
 
@@ -19,7 +19,8 @@ Depends on:
 
 The WASM boundary is where browser and host code meet the Echo runtime. It must be small, deterministic, and explicit about what kind of operation is crossing: intent admission, scheduler inspection, or observation.
 
-ABI version 10 keeps the export shape from version 9 and extends
+ABI version 11 keeps the application-facing export shape from version 10, adds
+an explicit trusted host-control export, and extends
 `DispatchResponse` with witnessed submission identity for accepted application
 ingress. Observation requests still name their observer plan, optional hosted
 observer instance, read budget, and rights posture explicitly. Observation
@@ -39,7 +40,7 @@ The hill: an agent can generate canonical CBOR, call one export, inspect an `ok`
 
 ## Decision 1: The ABI implements only the current epoch
 
-`ABI_VERSION` detects host/runtime mismatch. It does not promise compatibility with historical export shapes. Current exports are `init`, `dispatch_intent`, `observe`, `scheduler_status`, `get_registry_info`, `get_codec_id`, `get_registry_version`, and `get_schema_sha256_hex`.
+`ABI_VERSION` detects host/runtime mismatch. It does not promise compatibility with historical export shapes. Current exports are `init`, `dispatch_intent`, `dispatch_control_intent_trusted`, `observe`, `scheduler_status`, `get_registry_info`, `get_codec_id`, `get_registry_version`, and `get_schema_sha256_hex`.
 
 Removed exports stay removed: `step`, `snapshot_at`, `render_snapshot`, `execute_query`, `get_head`, and `drain_view_ops`.
 
@@ -57,6 +58,9 @@ the canonical `intent_id` and a witnessed `submission_id` plus
 `submission_generation`. The submission fields are intake/audit correlation
 metadata, not scheduler order, not worldline ticks, and not wall-clock time.
 Trusted runtime control responses do not carry application submission identity.
+The raw trusted host-control export is not an application API. High-level
+browser or JavaScript application facades must not re-export it to untrusted
+application code.
 
 ## Decision 3: Observation is the only public world-state read
 

--- a/scripts/tests/warp_wasm_package_exports_test.mjs
+++ b/scripts/tests/warp_wasm_package_exports_test.mjs
@@ -12,6 +12,7 @@ const WARP_WASM_MODULE_PATH = path.join(REPO_ROOT, 'crates', 'warp-wasm', 'pkg',
 const REQUIRED_BYTE_ABI_EXPORTS = Object.freeze([
   'init',
   'dispatch_intent',
+  'dispatch_control_intent_trusted',
   'observe',
   'scheduler_status',
   'get_codec_id',


### PR DESCRIPTION
## Summary
- expose trusted runtime host control from warp-wasm while keeping app dispatch app-safe
- record jedit as the v0.1.0 release gate and document the witness CLI/report flow
- update release-gate docs to cite generated jedit contract metadata without claiming final replay proof

## Validation
- cargo test -p warp-wasm --features engine trusted_control --lib
- cargo test -p warp-wasm --features engine control --lib
- cargo test -p warp-wasm --features engine --lib
- scripts/build-warp-wasm-package.sh
- scripts/tests/warp_wasm_package_exports_test.sh
- markdownlint + lint-dead-refs on touched docs
- pre-push cargo test -p warp-wasm --lib