### PR TITLE
docs: record jedit evidence replay audit

### DIFF
--- a/docs/design/v0.1.0-jedit-next-ten-slices.md
+++ b/docs/design/v0.1.0-jedit-next-ten-slices.md
@@ -91,6 +91,11 @@ Witness:
 - the fake harness remains green;
 - the real Echo witness remains opt-in and app/host split.
 
+Current implementation note: jedit now reports inline `QueryBytes` and
+`ReadingEnvelope` evidence and marks durable receipt/payload/envelope refs as
+`missing_retention`. That is the correct intermediate posture; it is not the
+final release-gate proof.
+
 ## Slice 3: Echo Retained Evidence Ref Surface Check
 
 Repository: `echo`
@@ -116,6 +121,11 @@ Witness:
 - focused ABI/WASM test proves retained refs are visible generically;
 - no jedit nouns are introduced into `warp-core` or `warp-wasm`;
 - app-safe retained evidence inspection does not expose trusted control.
+
+Current audit note: the current WASM witness exposes inline observation
+evidence, but not enough durable retained refs for jedit to satisfy the release
+gate. The next Echo-side cut should add or expose generic retained evidence
+references; it must not add editor/text nouns.
 
 ## Slice 4: jedit Adapter Consumes Echo Retained Refs
 
@@ -166,6 +176,11 @@ Witness:
 - `node scripts/jedit-echo-witness.mjs --json --replay` or equivalent;
 - same outcome/reading identity, or explicit replay obstruction;
 - no app-facing tick authority.
+
+Current implementation note: jedit can request replay posture with `--replay`
+and currently receives `durable_replay_unavailable` when the witness report
+lacks durable replay proof. That obstruction is honest and must be replaced by
+real replay evidence before `v0.1.0`.
 
 ## Slice 6: Echo Product-Facing Intent Outcome API Polish
 


### PR DESCRIPTION
## Summary
- record the current jedit witness evidence/replay audit in Echo's v0.1.0 jedit slice plan
- clarify that jedit currently reports inline observation evidence plus `missing_retention`
- clarify that `durable_replay_unavailable` is honest obstruction, not release-gate success

## Validation
- `git diff --check`
- `pnpm exec markdownlint-cli2 docs/design/v0.1.0-jedit-next-ten-slices.md`
- `cargo xtask lint-dead-refs --file docs/design/v0.1.0-jedit-next-ten-slices.md`
