### PR TITLE
feat(core): add causal WAL foundation and hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -572,6 +572,11 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
 
 ### Fixed
 
+- `echo-cli wal doctor` now inspects a real filesystem WAL root through
+  Echo's read-only filesystem WAL doctor instead of reporting a fresh empty
+  in-memory store. The command accepts an optional WAL root path, defaults to
+  the current directory, and the generated man pages cover the new `wal`
+  subcommand.
 - `warp-core` witnessed-submission persistence snapshots now fail closed when
   a submission lacks retained canonical envelope material instead of silently
   dropping replayed submissions from the host-persistable image.

--- a/crates/warp-cli/src/cli.rs
+++ b/crates/warp-cli/src/cli.rs
@@ -71,6 +71,20 @@ pub enum Commands {
         #[arg(long)]
         raw: bool,
     },
+
+    /// Inspect Echo WAL recovery posture without mutating storage.
+    Wal {
+        /// WAL inspection command.
+        #[command(subcommand)]
+        command: WalCommands,
+    },
+}
+
+/// WAL inspection subcommands.
+#[derive(Subcommand, Debug)]
+pub enum WalCommands {
+    /// Report read-only WAL recovery posture.
+    Doctor,
 }
 
 /// Output format selector.

--- a/crates/warp-cli/src/cli.rs
+++ b/crates/warp-cli/src/cli.rs
@@ -84,7 +84,11 @@ pub enum Commands {
 #[derive(Subcommand, Debug)]
 pub enum WalCommands {
     /// Report read-only WAL recovery posture.
-    Doctor,
+    Doctor {
+        /// Filesystem WAL root to inspect.
+        #[arg(default_value = ".")]
+        root: PathBuf,
+    },
 }
 
 /// Output format selector.
@@ -221,6 +225,17 @@ mod tests {
         match cli.command {
             Commands::Inspect { raw, .. } => assert!(raw),
             _ => panic!("expected Inspect command"),
+        }
+    }
+
+    #[test]
+    fn parse_wal_doctor_with_root() {
+        let cli = Cli::try_parse_from(["echo-cli", "wal", "doctor", "runtime.wal"]).unwrap();
+        match cli.command {
+            Commands::Wal {
+                command: WalCommands::Doctor { ref root },
+            } => assert_eq!(root, &PathBuf::from("runtime.wal")),
+            _ => panic!("expected Wal doctor command"),
         }
     }
 

--- a/crates/warp-cli/src/main.rs
+++ b/crates/warp-cli/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> Result<()> {
             raw,
         } => inspect::run(snapshot, tree, raw, &cli.format),
         Commands::Wal {
-            command: WalCommands::Doctor,
-        } => wal::doctor(&cli.format),
+            command: WalCommands::Doctor { ref root },
+        } => wal::doctor(root, &cli.format),
     }
 }

--- a/crates/warp-cli/src/main.rs
+++ b/crates/warp-cli/src/main.rs
@@ -23,9 +23,10 @@ mod cli;
 mod inspect;
 mod output;
 mod verify;
+mod wal;
 mod wsc_loader;
 
-use cli::{Cli, Commands};
+use cli::{Cli, Commands, WalCommands};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -44,5 +45,8 @@ fn main() -> Result<()> {
             tree,
             raw,
         } => inspect::run(snapshot, tree, raw, &cli.format),
+        Commands::Wal {
+            command: WalCommands::Doctor,
+        } => wal::doctor(&cli.format),
     }
 }

--- a/crates/warp-cli/src/wal.rs
+++ b/crates/warp-cli/src/wal.rs
@@ -2,9 +2,11 @@
 // © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
 //! `echo-cli wal` — read-only WAL inspection helpers.
 
+use std::path::Path;
+
 use anyhow::Result;
 use serde::Serialize;
-use warp_core::causal_wal::{doctor_in_memory_store, InMemoryWalStore, RecoveryTailPosture};
+use warp_core::causal_wal::{doctor_filesystem_store, RecoveryTailPosture};
 
 use crate::cli::OutputFormat;
 use crate::output::emit;
@@ -19,9 +21,8 @@ pub(crate) struct WalDoctorOutput {
 }
 
 /// Runs `echo-cli wal doctor`.
-pub(crate) fn doctor(format: &OutputFormat) -> Result<()> {
-    let store = InMemoryWalStore::new();
-    let report = doctor_in_memory_store(&store)?;
+pub(crate) fn doctor(root: &Path, format: &OutputFormat) -> Result<()> {
+    let report = doctor_filesystem_store(root)?;
     let output = WalDoctorOutput {
         posture: format!("{:?}", report.posture),
         tail_posture: tail_posture_label(report.tail_posture).to_owned(),
@@ -31,7 +32,8 @@ pub(crate) fn doctor(format: &OutputFormat) -> Result<()> {
         obstruction_count: report.recovery_certificate.obstruction_count,
     };
     let text = format!(
-        "echo-cli wal doctor\nPosture: {}\nTail: {}\nCommitted transactions replayed: {}\nObstructions: {}\n",
+        "echo-cli wal doctor\nRoot: {}\nPosture: {}\nTail: {}\nCommitted transactions replayed: {}\nObstructions: {}\n",
+        root.display(),
         output.posture,
         output.tail_posture,
         output.committed_transactions_replayed,

--- a/crates/warp-cli/src/wal.rs
+++ b/crates/warp-cli/src/wal.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! `echo-cli wal` — read-only WAL inspection helpers.
+
+use anyhow::Result;
+use serde::Serialize;
+use warp_core::causal_wal::{doctor_in_memory_store, InMemoryWalStore, RecoveryTailPosture};
+
+use crate::cli::OutputFormat;
+use crate::output::emit;
+
+/// Read-only WAL doctor JSON/text report.
+#[derive(Debug, Serialize)]
+pub(crate) struct WalDoctorOutput {
+    pub(crate) posture: String,
+    pub(crate) tail_posture: String,
+    pub(crate) committed_transactions_replayed: u64,
+    pub(crate) obstruction_count: u64,
+}
+
+/// Runs `echo-cli wal doctor`.
+pub(crate) fn doctor(format: &OutputFormat) -> Result<()> {
+    let store = InMemoryWalStore::new();
+    let report = doctor_in_memory_store(&store)?;
+    let output = WalDoctorOutput {
+        posture: format!("{:?}", report.posture),
+        tail_posture: tail_posture_label(report.tail_posture).to_owned(),
+        committed_transactions_replayed: report
+            .recovery_certificate
+            .committed_transactions_replayed,
+        obstruction_count: report.recovery_certificate.obstruction_count,
+    };
+    let text = format!(
+        "echo-cli wal doctor\nPosture: {}\nTail: {}\nCommitted transactions replayed: {}\nObstructions: {}\n",
+        output.posture,
+        output.tail_posture,
+        output.committed_transactions_replayed,
+        output.obstruction_count
+    );
+    let json = serde_json::to_value(&output)?;
+    emit(format, &text, &json)
+}
+
+fn tail_posture_label(posture: RecoveryTailPosture) -> &'static str {
+    match posture {
+        RecoveryTailPosture::Clean => "Clean",
+        RecoveryTailPosture::TruncatedAll => "TruncatedAll",
+        RecoveryTailPosture::TruncatedAfter(_) => "TruncatedAfter",
+        RecoveryTailPosture::WouldTruncateAll => "WouldTruncateAll",
+        RecoveryTailPosture::WouldTruncateAfter(_) => "WouldTruncateAfter",
+    }
+}

--- a/crates/warp-cli/tests/cli_integration.rs
+++ b/crates/warp-cli/tests/cli_integration.rs
@@ -75,7 +75,8 @@ fn help_shows_all_subcommands() {
         .stdout(predicate::str::contains("Echo developer CLI"))
         .stdout(predicate::str::contains("verify"))
         .stdout(predicate::str::contains("bench"))
-        .stdout(predicate::str::contains("inspect"));
+        .stdout(predicate::str::contains("inspect"))
+        .stdout(predicate::str::contains("wal"));
 }
 
 #[test]
@@ -147,6 +148,30 @@ fn inspect_help_lists_tree_flag() {
         .success()
         .stdout(predicate::str::contains("tree"))
         .stdout(predicate::str::contains("raw"));
+}
+
+#[test]
+fn wal_doctor_help_lists_read_only_doctor() {
+    echo_cli()
+        .args(["wal", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("doctor"));
+}
+
+#[test]
+fn wal_doctor_json_reports_read_only_empty_store() -> TestResult {
+    let assert = echo_cli()
+        .args(["--format", "json", "wal", "doctor"])
+        .assert()
+        .success();
+    let json: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
+
+    assert_eq!(json["posture"], "Recoverable");
+    assert_eq!(json["tail_posture"], "Clean");
+    assert_eq!(json["committed_transactions_replayed"], 0);
+    assert_eq!(json["obstruction_count"], 0);
+    Ok(())
 }
 
 #[test]

--- a/crates/warp-cli/tests/cli_integration.rs
+++ b/crates/warp-cli/tests/cli_integration.rs
@@ -13,6 +13,12 @@ use std::fs;
 use assert_cmd::cargo::cargo_bin;
 use predicates::prelude::*;
 use tempfile::TempDir;
+use warp_core::causal_wal::{
+    build_submission_acceptance_transaction, AffectedFrontier, AffectedFrontierKind,
+    FilesystemWalStore, Lsn, PayloadCodecId, PayloadSchemaId, SubmissionAcceptanceRecord,
+    WalAppendAuthority, WalDurabilityMode, WalSegmentId, WalStorePort, WalTransactionBuilder,
+    WalTransactionId, WalTransactionKind, WriterEpochId, WriterEpochRequest,
+};
 use warp_core::wsc::{build_one_warp_input, write_wsc_one_warp};
 use warp_core::{
     make_edge_id, make_node_id, make_type_id, make_warp_id, EdgeRecord, GraphStore, NodeRecord,
@@ -63,6 +69,76 @@ fn make_demo_wsc() -> TestResult<Vec<u8>> {
 fn write_demo_snapshot() -> TestResult<TempDir> {
     let temp = TempDir::new()?;
     fs::write(temp.path().join("state.wsc"), make_demo_wsc()?)?;
+    Ok(temp)
+}
+
+fn digest(label: &str) -> warp_core::Hash {
+    let mut out = [0_u8; 32];
+    for (index, byte) in label.bytes().enumerate() {
+        let rotate = match index % 8 {
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            3 => 3,
+            4 => 4,
+            5 => 5,
+            6 => 6,
+            _ => 7,
+        };
+        out[index % out.len()] = out[index % out.len()].wrapping_add(byte);
+        out[(index * 7) % out.len()] ^= byte.rotate_left(rotate);
+    }
+    out
+}
+
+fn writer_epoch_request() -> WriterEpochRequest {
+    WriterEpochRequest {
+        epoch_id: WriterEpochId::from_hash(digest("epoch")),
+        storage_fencing_token: digest("fencing"),
+        process_identity: digest("process"),
+        host_identity: digest("host"),
+        started_at_lsn: Lsn::from_raw(0),
+        previous_epoch_id: None,
+        previous_epoch_final_commit_digest: None,
+        lease_or_lock_evidence: digest("lease"),
+    }
+}
+
+fn filesystem_wal_with_committed_submission() -> TestResult<TempDir> {
+    let temp = TempDir::new()?;
+    let epoch = writer_epoch_request();
+    let mut store = FilesystemWalStore::open(temp.path(), WalSegmentId::from_raw(1))?;
+    store.acquire_writer_epoch(epoch.clone())?;
+    let transaction = build_submission_acceptance_transaction(
+        WalTransactionBuilder::new(
+            epoch.epoch_id,
+            WalSegmentId::from_raw(1),
+            WalTransactionId::from_hash(digest("transaction")),
+            WalTransactionKind::SubmissionIntake,
+            WalAppendAuthority::SubmissionIntake,
+            Lsn::from_raw(0),
+            digest("previous-frame"),
+            digest("previous-commit"),
+            WalDurabilityMode::Buffered,
+            PayloadCodecId::from_hash(digest("codec")),
+            PayloadSchemaId::from_hash(digest("schema")),
+            1,
+            1,
+            digest("domain"),
+        ),
+        SubmissionAcceptanceRecord {
+            submission_id: digest("submission"),
+            canonical_envelope_digest: digest("envelope"),
+            idempotency_key_digest: None,
+            acceptance_evidence_digest: digest("evidence"),
+        },
+        vec![AffectedFrontier {
+            kind: AffectedFrontierKind::SubmissionQueue,
+            before_digest: digest("frontier-before"),
+            after_digest: digest("frontier-after"),
+        }],
+    )?;
+    store.append_transaction(transaction)?;
     Ok(temp)
 }
 
@@ -170,6 +246,28 @@ fn wal_doctor_json_reports_read_only_empty_store() -> TestResult {
     assert_eq!(json["posture"], "Recoverable");
     assert_eq!(json["tail_posture"], "Clean");
     assert_eq!(json["committed_transactions_replayed"], 0);
+    assert_eq!(json["obstruction_count"], 0);
+    Ok(())
+}
+
+#[test]
+fn wal_doctor_json_reports_committed_filesystem_wal() -> TestResult {
+    let temp = filesystem_wal_with_committed_submission()?;
+    let assert = echo_cli()
+        .args([
+            "--format",
+            "json",
+            "wal",
+            "doctor",
+            temp.path().to_str().ok_or("temp path is not UTF-8")?,
+        ])
+        .assert()
+        .success();
+    let json: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)?;
+
+    assert_eq!(json["posture"], "Recoverable");
+    assert_eq!(json["tail_posture"], "Clean");
+    assert_eq!(json["committed_transactions_replayed"], 1);
     assert_eq!(json["obstruction_count"], 0);
     Ok(())
 }

--- a/crates/warp-cli/tests/golden/echo-cli-help.txt
+++ b/crates/warp-cli/tests/golden/echo-cli-help.txt
@@ -6,6 +6,7 @@ Commands:
   verify   Verify hash integrity of a WSC snapshot
   bench    Run benchmarks and format results
   inspect  Inspect a WSC snapshot
+  wal      Inspect Echo WAL recovery posture without mutating storage
 
 Options:
       --format <FORMAT>  Output format (text or json) [default: text]

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -14,7 +14,7 @@
 //! ```
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -29,7 +29,9 @@ const WAL_FRONTIERS_ROOT_DOMAIN: &[u8] = b"echo:causal_wal:frontiers_root:v1\0";
 const WAL_COMMIT_DOMAIN: &[u8] = b"echo:causal_wal:commit:v1\0";
 const WAL_HEADER_CHECKSUM_DOMAIN: &[u8] = b"echo:causal_wal:header_checksum:v1\0";
 const WAL_FRAME_CHECKSUM_DOMAIN: &[u8] = b"echo:causal_wal:frame_checksum:v1\0";
+const WAL_DISK_RECORD_DOMAIN: &[u8] = b"echo:causal_wal:disk_record:v1\0";
 const CHECKPOINT_FILE_MAGIC: &[u8; 8] = b"ECWALCP1";
+const WAL_SEGMENT_RECORD_MAGIC: &[u8; 8] = b"ECWALR1!";
 
 /// Current in-memory causal WAL version.
 pub const CAUSAL_WAL_VERSION: u16 = 1;
@@ -154,6 +156,20 @@ impl WalDurabilityMode {
             Self::Disabled => 5,
         }
     }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            1 => Ok(Self::StrictFilesystem),
+            2 => Ok(Self::StrictObjectStore),
+            3 => Ok(Self::Buffered),
+            4 => Ok(Self::ReadOnlyRecovery),
+            5 => Ok(Self::Disabled),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "WalDurabilityMode",
+                code,
+            }),
+        }
+    }
 }
 
 /// Authority plane allowed to record a WAL fact.
@@ -203,6 +219,20 @@ impl WalTransactionKind {
             }
             Self::RuntimePosture => WalAppendAuthority::RuntimeControl,
             Self::Checkpoint => WalAppendAuthority::Recovery,
+        }
+    }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            1 => Ok(Self::SubmissionIntake),
+            2 => Ok(Self::SchedulerTick),
+            3 => Ok(Self::RuntimePosture),
+            4 => Ok(Self::Checkpoint),
+            5 => Ok(Self::MaterializationOutbox),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "WalTransactionKind",
+                code,
+            }),
         }
     }
 }
@@ -296,6 +326,52 @@ impl WalRecordKind {
     pub fn obeys_recorded_not_committed_grammar(self) -> bool {
         !self.label().contains("Committed")
     }
+
+    fn code(self) -> u8 {
+        match self {
+            Self::SubmissionAcceptedRecorded => 1,
+            Self::SubmissionAcceptanceEvidenceRecorded => 2,
+            Self::RuntimeLawWitnessRecorded => 3,
+            Self::RuntimeAdmissionTicketIssued => 4,
+            Self::TicketedRuntimeIngressRecorded => 5,
+            Self::TickReceiptRecorded => 6,
+            Self::RuntimeStateDeltaRecorded => 7,
+            Self::ReceiptCorrelationRecorded => 8,
+            Self::ReadingEnvelopeRetained => 9,
+            Self::RetainedMaterialRefRecorded => 10,
+            Self::SchedulerFaultQuarantined => 11,
+            Self::TrustedRuntimeControlRecorded => 12,
+            Self::CheckpointPublicationRecorded => 13,
+            Self::MaterializationIntentRecorded => 14,
+            Self::MaterializationEffectObserved => 15,
+            Self::RecoveryPostureRecorded => 16,
+        }
+    }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            1 => Ok(Self::SubmissionAcceptedRecorded),
+            2 => Ok(Self::SubmissionAcceptanceEvidenceRecorded),
+            3 => Ok(Self::RuntimeLawWitnessRecorded),
+            4 => Ok(Self::RuntimeAdmissionTicketIssued),
+            5 => Ok(Self::TicketedRuntimeIngressRecorded),
+            6 => Ok(Self::TickReceiptRecorded),
+            7 => Ok(Self::RuntimeStateDeltaRecorded),
+            8 => Ok(Self::ReceiptCorrelationRecorded),
+            9 => Ok(Self::ReadingEnvelopeRetained),
+            10 => Ok(Self::RetainedMaterialRefRecorded),
+            11 => Ok(Self::SchedulerFaultQuarantined),
+            12 => Ok(Self::TrustedRuntimeControlRecorded),
+            13 => Ok(Self::CheckpointPublicationRecorded),
+            14 => Ok(Self::MaterializationIntentRecorded),
+            15 => Ok(Self::MaterializationEffectObserved),
+            16 => Ok(Self::RecoveryPostureRecorded),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "WalRecordKind",
+                code,
+            }),
+        }
+    }
 }
 
 /// Identity of the canonical payload codec.
@@ -345,6 +421,16 @@ impl WalCompressionKind {
             Self::None => 0,
         }
     }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            0 => Ok(Self::None),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "WalCompressionKind",
+                code,
+            }),
+        }
+    }
 }
 
 /// WAL payload revelation posture.
@@ -370,6 +456,20 @@ impl WalRedactionPosture {
             Self::RetainedRef => 3,
             Self::Encrypted => 4,
             Self::RedactedByPolicy => 5,
+        }
+    }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            1 => Ok(Self::Present),
+            2 => Ok(Self::DigestOnly),
+            3 => Ok(Self::RetainedRef),
+            4 => Ok(Self::Encrypted),
+            5 => Ok(Self::RedactedByPolicy),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "WalRedactionPosture",
+                code,
+            }),
         }
     }
 }
@@ -1868,6 +1968,892 @@ pub struct WalDoctorReport {
     pub tail_posture: RecoveryTailPosture,
 }
 
+/// Local filesystem WAL store backed by segment files.
+#[derive(Clone, Debug)]
+pub struct FilesystemWalStore {
+    root: PathBuf,
+    segment_id: WalSegmentId,
+    active_epoch: Option<WriterEpoch>,
+    closed_epochs: Vec<WriterEpoch>,
+    manifests: Vec<WalManifest>,
+}
+
+impl FilesystemWalStore {
+    /// Opens a filesystem WAL store rooted at `root`.
+    ///
+    /// Segment creation fsyncs the containing directory. Frame appends are
+    /// written to the active segment; commit flushing syncs the file and is the
+    /// durable ACK boundary for strict filesystem mode.
+    pub fn open(root: impl AsRef<Path>, segment_id: WalSegmentId) -> Result<Self, WalStoreError> {
+        let root = root.as_ref().to_path_buf();
+        fs::create_dir_all(&root)?;
+        let segment_path = segment_path(&root, segment_id);
+        if !segment_path.exists() {
+            File::create(&segment_path)?.sync_all()?;
+            sync_directory_store(&root)?;
+        }
+        Ok(Self {
+            root,
+            segment_id,
+            active_epoch: None,
+            closed_epochs: Vec::new(),
+            manifests: Vec::new(),
+        })
+    }
+
+    /// Returns the active segment path.
+    #[must_use]
+    pub fn segment_path(&self) -> PathBuf {
+        segment_path(&self.root, self.segment_id)
+    }
+
+    /// Returns the WAL root directory.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Appends and flushes a committed transaction.
+    pub fn append_transaction(
+        &mut self,
+        transaction: WalCommittedTransaction,
+    ) -> Result<(), WalStoreError> {
+        transaction.validate()?;
+        let epoch_id = transaction.commit.writer_epoch;
+        for frame in transaction.frames {
+            self.append_frame(epoch_id, frame)?;
+        }
+        self.flush_commit(epoch_id, transaction.commit)
+    }
+
+    /// Appends an uncommitted frame to simulate a torn transaction tail.
+    pub fn append_uncommitted_frame(
+        &mut self,
+        epoch_id: WriterEpochId,
+        frame: WalFrame,
+    ) -> Result<(), WalStoreError> {
+        self.append_frame(epoch_id, frame)
+    }
+}
+
+impl WalStorePort for FilesystemWalStore {
+    fn acquire_writer_epoch(
+        &mut self,
+        request: WriterEpochRequest,
+    ) -> Result<WriterEpoch, WalStoreError> {
+        if self.active_epoch.is_some() {
+            return Err(WalStoreError::WriterEpochAlreadyActive);
+        }
+        if let Some(previous_epoch_id) = request.previous_epoch_id {
+            if self
+                .closed_epochs
+                .iter()
+                .all(|epoch| epoch.epoch_id != previous_epoch_id)
+            {
+                return Err(WalStoreError::UnknownPreviousWriterEpoch);
+            }
+        }
+        let epoch = WriterEpoch {
+            epoch_id: request.epoch_id,
+            storage_fencing_token: request.storage_fencing_token,
+            process_identity: request.process_identity,
+            host_identity: request.host_identity,
+            started_at_lsn: request.started_at_lsn,
+            previous_epoch_id: request.previous_epoch_id,
+            previous_epoch_final_commit_digest: request.previous_epoch_final_commit_digest,
+            lease_or_lock_evidence: request.lease_or_lock_evidence,
+        };
+        self.active_epoch = Some(epoch.clone());
+        Ok(epoch)
+    }
+
+    fn append_frame(
+        &mut self,
+        epoch_id: WriterEpochId,
+        frame: WalFrame,
+    ) -> Result<(), WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id || frame.header.writer_epoch != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        frame.validate_integrity()?;
+        append_segment_record(&self.segment_path(), DiskWalRecord::Frame(&frame), false)
+    }
+
+    fn flush_commit(
+        &mut self,
+        epoch_id: WriterEpochId,
+        commit: WalTransactionCommit,
+    ) -> Result<(), WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id || commit.writer_epoch != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        append_segment_record(&self.segment_path(), DiskWalRecord::Commit(&commit), true)
+    }
+
+    fn read_frames(&self) -> Vec<WalFrame> {
+        match read_filesystem_segments(&self.root) {
+            Ok((frames, _, _)) => frames,
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn read_commits(&self) -> Vec<WalTransactionCommit> {
+        match read_filesystem_segments(&self.root) {
+            Ok((_, commits, _)) => commits,
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn seal_segment(
+        &mut self,
+        epoch_id: WriterEpochId,
+        segment_id: WalSegmentId,
+    ) -> Result<WalSegmentSeal, WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        let (frames, _, _) = read_segment_file(&segment_path(&self.root, segment_id))?;
+        let frame_refs = frames.iter().collect::<Vec<_>>();
+        let seal = WalSegmentSeal {
+            segment_id,
+            sealed_lsn: frames.iter().map(|frame| frame.header.lsn).max(),
+            segment_digest: segment_digest(segment_id, &frame_refs),
+        };
+        Ok(seal)
+    }
+
+    fn truncate_tail_after(&mut self, after_lsn: Lsn) -> Result<(), WalStoreError> {
+        rewrite_filesystem_segments_after_truncation(&self.root, after_lsn)
+    }
+
+    fn publish_manifest(
+        &mut self,
+        epoch_id: WriterEpochId,
+        manifest: WalManifest,
+    ) -> Result<(), WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        write_manifest_atomic(&self.root, &manifest)?;
+        self.manifests.push(manifest);
+        Ok(())
+    }
+
+    fn close_epoch(&mut self, epoch_id: WriterEpochId) -> Result<(), WalStoreError> {
+        let epoch = self
+            .active_epoch
+            .take()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if epoch.epoch_id != epoch_id {
+            self.active_epoch = Some(epoch);
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        self.closed_epochs.push(epoch);
+        Ok(())
+    }
+}
+
+/// Recovers committed transactions from filesystem WAL segments.
+pub fn recover_filesystem_store(
+    root: impl AsRef<Path>,
+    mode: RecoveryAccessMode,
+) -> Result<RecoveryScanReport, WalRecoveryError> {
+    let root = root.as_ref();
+    let (frames, commits, torn_tail) = read_filesystem_segments(root)?;
+    let mut report = recover_from_frames_and_commits(&frames, &commits, mode)?;
+    if torn_tail && matches!(report.tail_posture, RecoveryTailPosture::Clean) {
+        report.tail_posture = match mode {
+            RecoveryAccessMode::Writable => {
+                if let Some(lsn) = report.last_committed_lsn() {
+                    RecoveryTailPosture::TruncatedAfter(lsn)
+                } else {
+                    RecoveryTailPosture::TruncatedAll
+                }
+            }
+            RecoveryAccessMode::ReadOnly => {
+                if let Some(lsn) = report.last_committed_lsn() {
+                    RecoveryTailPosture::WouldTruncateAfter(lsn)
+                } else {
+                    RecoveryTailPosture::WouldTruncateAll
+                }
+            }
+        };
+    }
+    match (mode, report.tail_posture) {
+        (RecoveryAccessMode::Writable, RecoveryTailPosture::TruncatedAfter(lsn)) => {
+            rewrite_filesystem_segments_after_truncation(root, lsn)?;
+        }
+        (RecoveryAccessMode::Writable, RecoveryTailPosture::TruncatedAll) => {
+            clear_filesystem_segments(root)?;
+        }
+        _ => {}
+    }
+    Ok(report)
+}
+
+/// Runs a read-only WAL doctor over filesystem WAL segments.
+pub fn doctor_filesystem_store(
+    root: impl AsRef<Path>,
+) -> Result<WalDoctorReport, WalRecoveryError> {
+    let report = recover_filesystem_store(root, RecoveryAccessMode::ReadOnly)?;
+    let posture = match report.tail_posture {
+        RecoveryTailPosture::Clean => WalDoctorPosture::Recoverable,
+        RecoveryTailPosture::WouldTruncateAll | RecoveryTailPosture::WouldTruncateAfter(_) => {
+            WalDoctorPosture::RecoverableWithUncommittedTail
+        }
+        RecoveryTailPosture::TruncatedAll | RecoveryTailPosture::TruncatedAfter(_) => {
+            WalDoctorPosture::Obstructed
+        }
+    };
+    Ok(WalDoctorReport {
+        posture,
+        recovery_certificate: build_recovery_certificate(&report, None, 0, [0; 32], [0; 32]),
+        tail_posture: report.tail_posture,
+    })
+}
+
+/// Object-store read-after-write posture required by strict object storage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ObjectStoreReadAfterWritePosture {
+    /// The adapter proves read-after-write behavior for committed manifests.
+    Verified,
+    /// The adapter cannot prove read-after-write behavior.
+    Unverified,
+}
+
+/// Capability evidence for a strict object-store WAL adapter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ObjectStoreWalCapabilities {
+    /// Content-addressed object writes are used for segment/checkpoint bodies.
+    pub content_addressed_object_write: bool,
+    /// Object version or ETag evidence is verified.
+    pub verify_object_version: bool,
+    /// Manifest publication is conditional/compare-and-swap.
+    pub conditional_manifest_commit: bool,
+    /// Read-after-write posture.
+    pub read_after_write: ObjectStoreReadAfterWritePosture,
+}
+
+/// Object-store capability validation error.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ObjectStoreCapabilityError {
+    /// Strict object stores must write content-addressed objects.
+    #[error("strict object store requires content-addressed object writes")]
+    MissingContentAddressedObjectWrite,
+    /// Strict object stores must verify object version/ETag evidence.
+    #[error("strict object store requires object version verification")]
+    MissingObjectVersionVerification,
+    /// Strict object stores must publish manifests conditionally.
+    #[error("strict object store requires conditional manifest commit")]
+    MissingConditionalManifestCommit,
+    /// Strict object stores must prove read-after-write behavior.
+    #[error("strict object store requires verified read-after-write posture")]
+    MissingReadAfterWrite,
+}
+
+/// Validates strict object-store WAL adapter capabilities.
+pub fn validate_strict_object_store_capabilities(
+    capabilities: ObjectStoreWalCapabilities,
+) -> Result<(), ObjectStoreCapabilityError> {
+    if !capabilities.content_addressed_object_write {
+        return Err(ObjectStoreCapabilityError::MissingContentAddressedObjectWrite);
+    }
+    if !capabilities.verify_object_version {
+        return Err(ObjectStoreCapabilityError::MissingObjectVersionVerification);
+    }
+    if !capabilities.conditional_manifest_commit {
+        return Err(ObjectStoreCapabilityError::MissingConditionalManifestCommit);
+    }
+    if capabilities.read_after_write != ObjectStoreReadAfterWritePosture::Verified {
+        return Err(ObjectStoreCapabilityError::MissingReadAfterWrite);
+    }
+    Ok(())
+}
+
+/// Side-effect materialization intent recorded after committed authorization.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MaterializationIntentRecord {
+    /// Stable effect id.
+    pub effect_id: Hash,
+    /// Expected external artifact digest.
+    pub expected_artifact_digest: Hash,
+    /// Materialization intent digest.
+    pub materialization_intent_digest: Hash,
+    /// Idempotency token for replay.
+    pub idempotency_token: Hash,
+    /// Target metadata digest.
+    pub target_metadata_digest: Hash,
+}
+
+impl MaterializationIntentRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.effect_id);
+        push_hash(&mut out, &self.expected_artifact_digest);
+        push_hash(&mut out, &self.materialization_intent_digest);
+        push_hash(&mut out, &self.idempotency_token);
+        push_hash(&mut out, &self.target_metadata_digest);
+        out
+    }
+
+    /// Decodes a deterministic materialization intent payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let effect_id = cursor.read_hash()?;
+        let expected_artifact_digest = cursor.read_hash()?;
+        let materialization_intent_digest = cursor.read_hash()?;
+        let idempotency_token = cursor.read_hash()?;
+        let target_metadata_digest = cursor.read_hash()?;
+        cursor.finish()?;
+        Ok(Self {
+            effect_id,
+            expected_artifact_digest,
+            materialization_intent_digest,
+            idempotency_token,
+            target_metadata_digest,
+        })
+    }
+}
+
+/// Side-effect materialization observation recorded after external effect verification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MaterializationObservationRecord {
+    /// Stable effect id.
+    pub effect_id: Hash,
+    /// Observed external artifact digest.
+    pub observed_artifact_digest: Hash,
+    /// Observed metadata digest.
+    pub observed_metadata_digest: Hash,
+}
+
+impl MaterializationObservationRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.effect_id);
+        push_hash(&mut out, &self.observed_artifact_digest);
+        push_hash(&mut out, &self.observed_metadata_digest);
+        out
+    }
+
+    /// Decodes a deterministic materialization observation payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let effect_id = cursor.read_hash()?;
+        let observed_artifact_digest = cursor.read_hash()?;
+        let observed_metadata_digest = cursor.read_hash()?;
+        cursor.finish()?;
+        Ok(Self {
+            effect_id,
+            observed_artifact_digest,
+            observed_metadata_digest,
+        })
+    }
+}
+
+/// Existing external artifact evidence used for idempotent outbox replay.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExistingMaterializedArtifact {
+    /// Stable effect id.
+    pub effect_id: Hash,
+    /// Existing artifact digest.
+    pub artifact_digest: Hash,
+    /// Existing metadata digest.
+    pub metadata_digest: Hash,
+}
+
+/// Materialization replay posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MaterializationReplayPosture {
+    /// Effect is authorized but not observed.
+    Pending,
+    /// Effect has a committed observation.
+    AlreadyObserved,
+    /// External artifact already matches the authorized effect.
+    ExistingArtifactMatches,
+    /// External artifact exists but does not match authorization.
+    Obstructed,
+}
+
+/// Recovered materialization outbox entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MaterializationOutboxEntry {
+    /// Intent record.
+    pub intent: MaterializationIntentRecord,
+    /// Observation record, if committed.
+    pub observation: Option<MaterializationObservationRecord>,
+    /// Replay posture.
+    pub posture: MaterializationReplayPosture,
+}
+
+/// Builds a side-effect outbox transaction.
+pub fn build_materialization_outbox_transaction(
+    mut builder: WalTransactionBuilder,
+    intent: MaterializationIntentRecord,
+    observation: Option<MaterializationObservationRecord>,
+    affected_frontiers: Vec<AffectedFrontier>,
+) -> Result<WalCommittedTransaction, WalBuildError> {
+    builder.push_record(
+        WalRecordKind::MaterializationIntentRecorded,
+        intent.to_payload_bytes(),
+    )?;
+    if let Some(observation) = observation {
+        builder.push_record(
+            WalRecordKind::MaterializationEffectObserved,
+            observation.to_payload_bytes(),
+        )?;
+    }
+    builder.commit(affected_frontiers)
+}
+
+/// Recovers materialization outbox posture from committed WAL transactions.
+pub fn recover_materialization_outbox(
+    report: &RecoveryScanReport,
+    existing_artifacts: &BTreeMap<Hash, ExistingMaterializedArtifact>,
+) -> Result<BTreeMap<Hash, MaterializationOutboxEntry>, WalRecoveryIndexError> {
+    let mut intents = BTreeMap::new();
+    let mut observations = BTreeMap::new();
+    for transaction in &report.transactions {
+        for frame in &transaction.frames {
+            match frame.header.record_kind {
+                WalRecordKind::MaterializationIntentRecorded => {
+                    let intent = MaterializationIntentRecord::from_payload_bytes(
+                        &frame.payload.canonical_bytes,
+                    )?;
+                    intents.insert(intent.effect_id, intent);
+                }
+                WalRecordKind::MaterializationEffectObserved => {
+                    let observation = MaterializationObservationRecord::from_payload_bytes(
+                        &frame.payload.canonical_bytes,
+                    )?;
+                    observations.insert(observation.effect_id, observation);
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut outbox = BTreeMap::new();
+    for (effect_id, intent) in intents {
+        let observation = observations.get(&effect_id).copied();
+        let posture = if observation.is_some() {
+            MaterializationReplayPosture::AlreadyObserved
+        } else if let Some(existing) = existing_artifacts.get(&effect_id) {
+            if existing.artifact_digest == intent.expected_artifact_digest
+                && existing.metadata_digest == intent.target_metadata_digest
+            {
+                MaterializationReplayPosture::ExistingArtifactMatches
+            } else {
+                MaterializationReplayPosture::Obstructed
+            }
+        } else {
+            MaterializationReplayPosture::Pending
+        };
+        outbox.insert(
+            effect_id,
+            MaterializationOutboxEntry {
+                intent,
+                observation,
+                posture,
+            },
+        );
+    }
+    Ok(outbox)
+}
+
+/// Causal commit evidence source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CausalCommitEvidenceSource {
+    /// Evidence comes from Echo's WAL.
+    EchoWal,
+    /// Evidence comes from a validated Echo checkpoint.
+    EchoCheckpoint,
+    /// Evidence comes from an Echo recovery certificate.
+    EchoRecoveryCertificate,
+}
+
+/// Causal commit evidence posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CausalCommitEvidencePosture {
+    /// Commit evidence is present.
+    Present,
+    /// Commit evidence is unavailable.
+    Absent,
+    /// Commit evidence is obstructed.
+    Obstructed,
+}
+
+/// Host-neutral causal commit evidence projected for debuggers and operators.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CausalCommitEvidence {
+    /// Stable evidence id.
+    pub evidence_id: Hash,
+    /// Evidence posture.
+    pub posture: CausalCommitEvidencePosture,
+    /// Evidence source.
+    pub source: CausalCommitEvidenceSource,
+    /// Durability mode.
+    pub durability_mode: WalDurabilityMode,
+    /// Writer epoch.
+    pub writer_epoch: WriterEpochId,
+    /// Last LSN for the committed transaction.
+    pub lsn: Lsn,
+    /// Transaction id.
+    pub transaction_id: WalTransactionId,
+    /// Commit digest.
+    pub commit_digest: Hash,
+    /// Checkpoint digest, if one anchors the evidence.
+    pub checkpoint_digest: Option<Hash>,
+    /// Recovery certificate digest, if one anchors the evidence.
+    pub recovery_certificate_digest: Option<Hash>,
+    /// Obstruction digest, if obstructed.
+    pub obstruction_digest: Option<Hash>,
+}
+
+/// Projects host-neutral causal commit evidence from recovered WAL history.
+#[must_use]
+pub fn project_causal_commit_evidence(report: &RecoveryScanReport) -> Vec<CausalCommitEvidence> {
+    report
+        .transactions
+        .iter()
+        .map(|transaction| {
+            let evidence_id = causal_commit_evidence_id(&transaction.commit);
+            CausalCommitEvidence {
+                evidence_id,
+                posture: CausalCommitEvidencePosture::Present,
+                source: CausalCommitEvidenceSource::EchoWal,
+                durability_mode: transaction.commit.durability_mode,
+                writer_epoch: transaction.commit.writer_epoch,
+                lsn: transaction.commit.last_lsn,
+                transaction_id: transaction.commit.transaction_id,
+                commit_digest: transaction.commit.commit_digest,
+                checkpoint_digest: None,
+                recovery_certificate_digest: None,
+                obstruction_digest: None,
+            }
+        })
+        .collect()
+}
+
+/// Checks that live state and WAL replay produce the same recovered state.
+pub fn shadow_replay_matches(
+    live_state: &RecoveredState,
+    transactions: &[WalCommittedTransaction],
+) -> Result<bool, WalReplayError> {
+    let mut replayed = RecoveredState::default();
+    for transaction in transactions {
+        replayed = apply_committed_transaction(replayed, transaction)?;
+    }
+    Ok(&replayed == live_state)
+}
+
+/// WAL release readiness audit result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalReleaseReadinessReport {
+    /// `true` when all release-readiness gates are satisfied.
+    pub ready: bool,
+    /// Gate names that passed.
+    pub passed_gates: Vec<&'static str>,
+    /// Gate names that remain blocked.
+    pub blocked_gates: Vec<&'static str>,
+}
+
+/// Audits WAL release readiness from known gate booleans.
+#[must_use]
+pub fn audit_wal_release_readiness(gates: WalReleaseReadinessGates) -> WalReleaseReadinessReport {
+    let mut passed_gates = Vec::new();
+    let mut blocked_gates = Vec::new();
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "filesystem_adapter",
+        gates.filesystem_adapter,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "object_store_capability_gate",
+        gates.object_store_capability_gate,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "segment_repair",
+        gates.segment_repair,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "crash_matrix",
+        gates.crash_matrix,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "shadow_replay",
+        gates.shadow_replay,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "outbox",
+        gates.outbox,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "commit_evidence",
+        gates.commit_evidence,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "external_consumer_gate",
+        gates.external_consumer_gate,
+    );
+    let ready = blocked_gates.is_empty();
+    WalReleaseReadinessReport {
+        ready,
+        passed_gates,
+        blocked_gates,
+    }
+}
+
+/// WAL release readiness gate input.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WalReleaseReadinessGates {
+    /// Filesystem WAL adapter gate.
+    pub filesystem_adapter: bool,
+    /// Object-store capability gate.
+    pub object_store_capability_gate: bool,
+    /// Segment repair/truncation gate.
+    pub segment_repair: bool,
+    /// Crash matrix gate.
+    pub crash_matrix: bool,
+    /// Shadow replay gate.
+    pub shadow_replay: bool,
+    /// Side-effect outbox gate.
+    pub outbox: bool,
+    /// Causal commit evidence projection gate.
+    pub commit_evidence: bool,
+    /// External consumer recovery gate.
+    pub external_consumer_gate: bool,
+}
+
+enum DiskWalRecord<'a> {
+    Frame(&'a WalFrame),
+    Commit(&'a WalTransactionCommit),
+}
+
+fn append_segment_record(
+    path: &Path,
+    record: DiskWalRecord<'_>,
+    sync: bool,
+) -> Result<(), WalStoreError> {
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let (kind, payload) = match record {
+        DiskWalRecord::Frame(frame) => (1u8, encode_frame(frame)),
+        DiskWalRecord::Commit(commit) => (2u8, encode_commit(commit)),
+    };
+    let digest = disk_record_digest(kind, &payload);
+    file.write_all(WAL_SEGMENT_RECORD_MAGIC)?;
+    file.write_all(&[kind])?;
+    file.write_all(&len_u64(payload.len()).to_le_bytes())?;
+    file.write_all(&payload)?;
+    file.write_all(&digest)?;
+    if sync {
+        file.sync_all()?;
+    }
+    Ok(())
+}
+
+fn read_filesystem_segments(
+    root: &Path,
+) -> Result<(Vec<WalFrame>, Vec<WalTransactionCommit>, bool), WalStoreError> {
+    if !root.exists() {
+        return Ok((Vec::new(), Vec::new(), false));
+    }
+    let mut all_frames = Vec::new();
+    let mut all_commits = Vec::new();
+    let mut any_torn_tail = false;
+    for path in segment_paths(root)? {
+        let (frames, commits, torn_tail) = read_segment_file(&path)?;
+        all_frames.extend(frames);
+        all_commits.extend(commits);
+        any_torn_tail |= torn_tail;
+    }
+    all_frames.sort_by_key(|frame| frame.header.lsn);
+    all_commits.sort_by_key(|commit| commit.last_lsn);
+    Ok((all_frames, all_commits, any_torn_tail))
+}
+
+fn read_segment_file(
+    path: &Path,
+) -> Result<(Vec<WalFrame>, Vec<WalTransactionCommit>, bool), WalStoreError> {
+    let mut bytes = Vec::new();
+    File::open(path)?.read_to_end(&mut bytes)?;
+    let mut offset = 0usize;
+    let mut frames = Vec::new();
+    let mut commits = Vec::new();
+    let mut torn_tail = false;
+    while offset < bytes.len() {
+        let header_len = WAL_SEGMENT_RECORD_MAGIC.len() + 1 + 8;
+        let Some(header_end) = offset.checked_add(header_len) else {
+            torn_tail = true;
+            break;
+        };
+        if header_end > bytes.len() {
+            torn_tail = true;
+            break;
+        }
+        if bytes.get(offset..offset + WAL_SEGMENT_RECORD_MAGIC.len())
+            != Some(WAL_SEGMENT_RECORD_MAGIC.as_slice())
+        {
+            return Err(WalStoreError::SegmentRecordDigestMismatch);
+        }
+        offset += WAL_SEGMENT_RECORD_MAGIC.len();
+        let kind = bytes[offset];
+        offset += 1;
+        let mut len = [0; 8];
+        len.copy_from_slice(&bytes[offset..offset + 8]);
+        offset += 8;
+        let payload_len = match usize::try_from(u64::from_le_bytes(len)) {
+            Ok(value) => value,
+            Err(_) => return Err(WalStoreError::Decode(WalDecodeError::UnexpectedEof)),
+        };
+        let Some(payload_end) = offset.checked_add(payload_len) else {
+            torn_tail = true;
+            break;
+        };
+        let Some(digest_end) = payload_end.checked_add(32) else {
+            torn_tail = true;
+            break;
+        };
+        if digest_end > bytes.len() {
+            torn_tail = true;
+            break;
+        }
+        let payload = &bytes[offset..payload_end];
+        let digest = &bytes[payload_end..digest_end];
+        if digest != disk_record_digest(kind, payload) {
+            return Err(WalStoreError::SegmentRecordDigestMismatch);
+        }
+        match kind {
+            1 => frames.push(decode_frame(payload)?),
+            2 => commits.push(decode_commit(payload)?),
+            other => return Err(WalStoreError::UnknownDiskRecordKind(other)),
+        }
+        offset = digest_end;
+    }
+    Ok((frames, commits, torn_tail))
+}
+
+fn rewrite_filesystem_segments_after_truncation(
+    root: &Path,
+    after_lsn: Lsn,
+) -> Result<(), WalStoreError> {
+    let (frames, commits, _) = read_filesystem_segments(root)?;
+    let kept_frames = frames
+        .into_iter()
+        .filter(|frame| frame.header.lsn <= after_lsn)
+        .collect::<Vec<_>>();
+    let kept_commits = commits
+        .into_iter()
+        .filter(|commit| commit.last_lsn <= after_lsn)
+        .collect::<Vec<_>>();
+    rewrite_segment_records(root, &kept_frames, &kept_commits)
+}
+
+fn clear_filesystem_segments(root: &Path) -> Result<(), WalStoreError> {
+    rewrite_segment_records(root, &[], &[])
+}
+
+fn rewrite_segment_records(
+    root: &Path,
+    frames: &[WalFrame],
+    commits: &[WalTransactionCommit],
+) -> Result<(), WalStoreError> {
+    fs::create_dir_all(root)?;
+    for path in segment_paths(root)? {
+        fs::remove_file(path)?;
+    }
+    let path = segment_path(root, WalSegmentId::from_raw(1));
+    File::create(&path)?.sync_all()?;
+    for frame in frames {
+        append_segment_record(&path, DiskWalRecord::Frame(frame), false)?;
+    }
+    for commit in commits {
+        append_segment_record(&path, DiskWalRecord::Commit(commit), false)?;
+    }
+    File::options().append(true).open(&path)?.sync_all()?;
+    sync_directory_store(root)?;
+    Ok(())
+}
+
+fn segment_paths(root: &Path) -> Result<Vec<PathBuf>, WalStoreError> {
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("segment-"))
+            && path
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("ecwal"))
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+fn segment_path(root: &Path, segment_id: WalSegmentId) -> PathBuf {
+    root.join(format!("segment-{:020}.ecwal", segment_id.as_u64()))
+}
+
+fn write_manifest_atomic(root: &Path, manifest: &WalManifest) -> Result<(), WalStoreError> {
+    let path = root.join("manifest.ecwal");
+    let temp = root.join(".manifest.ecwal.tmp");
+    let mut bytes = Vec::new();
+    push_hash(&mut bytes, &manifest.manifest_digest);
+    push_optional_lsn(&mut bytes, manifest.last_committed_lsn);
+    push_optional_hash(&mut bytes, manifest.last_commit_digest);
+    bytes.extend_from_slice(&manifest.sealed_segment_count.to_le_bytes());
+    {
+        let mut file = File::create(&temp)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+    }
+    fs::rename(temp, path)?;
+    sync_directory_store(root)
+}
+
+fn sync_directory_store(path: &Path) -> Result<(), WalStoreError> {
+    File::open(path)?.sync_all()?;
+    Ok(())
+}
+
 /// Scans an in-memory store for recoverable transactions.
 pub fn recover_in_memory_store(
     store: &mut InMemoryWalStore,
@@ -2486,6 +3472,24 @@ pub enum WalStoreError {
     /// Validation failed.
     #[error(transparent)]
     Validation(#[from] WalValidationError),
+    /// Payload decode failed.
+    #[error(transparent)]
+    Decode(#[from] WalDecodeError),
+    /// Filesystem I/O failed.
+    #[error("WAL filesystem I/O failed: {0}")]
+    Io(String),
+    /// Segment record digest mismatch.
+    #[error("WAL segment record digest mismatch")]
+    SegmentRecordDigestMismatch,
+    /// Segment record kind was not recognized.
+    #[error("unknown WAL disk record kind {0}")]
+    UnknownDiskRecordKind(u8),
+}
+
+impl From<std::io::Error> for WalStoreError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error.to_string())
+    }
 }
 
 /// WAL recovery errors.
@@ -2534,6 +3538,9 @@ pub enum WalDecodeError {
         /// Unknown code.
         code: u8,
     },
+    /// Encoded frame failed embedded integrity validation.
+    #[error("encoded WAL frame failed embedded integrity validation")]
+    InvalidEmbeddedFrame,
 }
 
 /// WAL recovered index errors.
@@ -2730,6 +3737,179 @@ fn push_optional_hash(out: &mut Vec<u8>, hash: Option<Hash>) {
     }
 }
 
+fn push_optional_lsn(out: &mut Vec<u8>, lsn: Option<Lsn>) {
+    match lsn {
+        Some(lsn) => {
+            out.push(1);
+            out.extend_from_slice(&lsn.as_u64().to_le_bytes());
+        }
+        None => out.push(0),
+    }
+}
+
+fn encode_frame(frame: &WalFrame) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&frame.header.wal_version.to_le_bytes());
+    push_hash(&mut out, &frame.header.writer_epoch.as_hash());
+    out.extend_from_slice(&frame.header.segment_id.as_u64().to_le_bytes());
+    out.extend_from_slice(&frame.header.lsn.as_u64().to_le_bytes());
+    push_hash(&mut out, &frame.header.transaction_id.as_hash());
+    out.extend_from_slice(&frame.header.transaction_local_index.as_u32().to_le_bytes());
+    out.push(frame.header.record_kind.code());
+    out.extend_from_slice(&frame.header.payload_len.to_le_bytes());
+    push_hash(&mut out, &frame.header.payload_digest);
+    push_hash(&mut out, &frame.header.payload_codec_id.as_hash());
+    push_hash(&mut out, &frame.header.payload_schema_id.as_hash());
+    out.extend_from_slice(&frame.header.payload_schema_version.to_le_bytes());
+    out.extend_from_slice(&frame.header.canonical_encoding_version.to_le_bytes());
+    push_hash(&mut out, &frame.header.digest_domain);
+    out.push(frame.header.compression_kind.code());
+    out.push(frame.header.encryption_or_redaction_posture.code());
+    push_hash(&mut out, &frame.header.previous_frame_digest);
+    out.extend_from_slice(&frame.header.header_checksum.to_le_bytes());
+    out.extend_from_slice(&frame.payload.schema_version.to_le_bytes());
+    out.extend_from_slice(&len_u64(frame.payload.canonical_bytes.len()).to_le_bytes());
+    out.extend_from_slice(&frame.payload.canonical_bytes);
+    out.extend_from_slice(&frame.trailer.frame_checksum.to_le_bytes());
+    out
+}
+
+fn decode_frame(bytes: &[u8]) -> Result<WalFrame, WalDecodeError> {
+    let mut cursor = WalPayloadCursor::new(bytes);
+    let wal_version = cursor.read_u16()?;
+    let writer_epoch = WriterEpochId::from_hash(cursor.read_hash()?);
+    let segment_id = WalSegmentId::from_raw(cursor.read_u64()?);
+    let lsn = Lsn::from_raw(cursor.read_u64()?);
+    let transaction_id = WalTransactionId::from_hash(cursor.read_hash()?);
+    let transaction_local_index = TransactionLocalIndex::from_raw(cursor.read_u32()?);
+    let record_kind = WalRecordKind::from_code(cursor.read_u8()?)?;
+    let payload_len = cursor.read_u64()?;
+    let payload_digest = cursor.read_hash()?;
+    let payload_codec_id = PayloadCodecId::from_hash(cursor.read_hash()?);
+    let payload_schema_id = PayloadSchemaId::from_hash(cursor.read_hash()?);
+    let payload_schema_version = cursor.read_u16()?;
+    let canonical_encoding_version = cursor.read_u16()?;
+    let digest_domain = cursor.read_hash()?;
+    let compression_kind = WalCompressionKind::from_code(cursor.read_u8()?)?;
+    let encryption_or_redaction_posture = WalRedactionPosture::from_code(cursor.read_u8()?)?;
+    let previous_frame_digest = cursor.read_hash()?;
+    let header_checksum = cursor.read_u32()?;
+    let payload_schema_version_recorded = cursor.read_u16()?;
+    let canonical_bytes = cursor.read_vec()?;
+    let frame_checksum = cursor.read_u32()?;
+    cursor.finish()?;
+    let frame = WalFrame {
+        header: WalFrameHeader {
+            wal_version,
+            writer_epoch,
+            segment_id,
+            lsn,
+            transaction_id,
+            transaction_local_index,
+            record_kind,
+            payload_len,
+            payload_digest,
+            payload_codec_id,
+            payload_schema_id,
+            payload_schema_version,
+            canonical_encoding_version,
+            digest_domain,
+            compression_kind,
+            encryption_or_redaction_posture,
+            previous_frame_digest,
+            header_checksum,
+        },
+        payload: WalRecordPayload::new(
+            record_kind,
+            payload_schema_version_recorded,
+            canonical_bytes,
+        ),
+        trailer: WalFrameTrailer { frame_checksum },
+    };
+    frame
+        .validate_integrity()
+        .map_err(|_| WalDecodeError::InvalidEmbeddedFrame)?;
+    Ok(frame)
+}
+
+fn encode_commit(commit: &WalTransactionCommit) -> Vec<u8> {
+    let mut out = Vec::new();
+    push_hash(&mut out, &commit.writer_epoch.as_hash());
+    push_hash(&mut out, &commit.transaction_id.as_hash());
+    out.push(commit.transaction_kind.code());
+    out.extend_from_slice(&commit.first_lsn.as_u64().to_le_bytes());
+    out.extend_from_slice(&commit.last_lsn.as_u64().to_le_bytes());
+    out.extend_from_slice(&commit.record_count.to_le_bytes());
+    push_hash(&mut out, &commit.records_root);
+    push_hash(&mut out, &commit.affected_frontiers_root);
+    push_hash(&mut out, &commit.previous_committed_transaction_digest);
+    out.push(commit.durability_mode.code());
+    out.extend_from_slice(&commit.schema_version.to_le_bytes());
+    push_hash(&mut out, &commit.commit_digest);
+    out
+}
+
+fn decode_commit(bytes: &[u8]) -> Result<WalTransactionCommit, WalDecodeError> {
+    let mut cursor = WalPayloadCursor::new(bytes);
+    let writer_epoch = WriterEpochId::from_hash(cursor.read_hash()?);
+    let transaction_id = WalTransactionId::from_hash(cursor.read_hash()?);
+    let transaction_kind = WalTransactionKind::from_code(cursor.read_u8()?)?;
+    let first_lsn = Lsn::from_raw(cursor.read_u64()?);
+    let last_lsn = Lsn::from_raw(cursor.read_u64()?);
+    let record_count = cursor.read_u64()?;
+    let records_root = cursor.read_hash()?;
+    let affected_frontiers_root = cursor.read_hash()?;
+    let previous_committed_transaction_digest = cursor.read_hash()?;
+    let durability_mode = WalDurabilityMode::from_code(cursor.read_u8()?)?;
+    let schema_version = cursor.read_u16()?;
+    let commit_digest = cursor.read_hash()?;
+    cursor.finish()?;
+    Ok(WalTransactionCommit {
+        writer_epoch,
+        transaction_id,
+        transaction_kind,
+        first_lsn,
+        last_lsn,
+        record_count,
+        records_root,
+        affected_frontiers_root,
+        previous_committed_transaction_digest,
+        durability_mode,
+        schema_version,
+        commit_digest,
+    })
+}
+
+fn disk_record_digest(kind: u8, payload: &[u8]) -> Hash {
+    let mut h = blake3::Hasher::new();
+    h.update(WAL_DISK_RECORD_DOMAIN);
+    h.update(&[kind]);
+    h.update(&len_u64(payload.len()).to_le_bytes());
+    h.update(payload);
+    h.finalize().into()
+}
+
+fn causal_commit_evidence_id(commit: &WalTransactionCommit) -> Hash {
+    let mut h = blake3::Hasher::new();
+    h.update(b"echo:causal_wal:commit_evidence:v1\0");
+    h.update(&commit.transaction_id.as_hash());
+    h.update(&commit.commit_digest);
+    h.finalize().into()
+}
+
+fn push_gate(
+    passed: &mut Vec<&'static str>,
+    blocked: &mut Vec<&'static str>,
+    name: &'static str,
+    ok: bool,
+) {
+    if ok {
+        passed.push(name);
+    } else {
+        blocked.push(name);
+    }
+}
+
 struct WalPayloadCursor<'a> {
     bytes: &'a [u8],
     offset: usize,
@@ -2760,6 +3940,20 @@ impl<'a> WalPayloadCursor<'a> {
         out.copy_from_slice(bytes);
         self.offset = end;
         Ok(u16::from_le_bytes(out))
+    }
+
+    fn read_u32(&mut self) -> Result<u32, WalDecodeError> {
+        let end = self
+            .offset
+            .checked_add(4)
+            .ok_or(WalDecodeError::UnexpectedEof)?;
+        let Some(bytes) = self.bytes.get(self.offset..end) else {
+            return Err(WalDecodeError::UnexpectedEof);
+        };
+        let mut out = [0; 4];
+        out.copy_from_slice(bytes);
+        self.offset = end;
+        Ok(u32::from_le_bytes(out))
     }
 
     fn read_u64(&mut self) -> Result<u64, WalDecodeError> {
@@ -2799,6 +3993,19 @@ impl<'a> WalPayloadCursor<'a> {
                 code,
             }),
         }
+    }
+
+    fn read_vec(&mut self) -> Result<Vec<u8>, WalDecodeError> {
+        let len = usize::try_from(self.read_u64()?).map_err(|_| WalDecodeError::UnexpectedEof)?;
+        let end = self
+            .offset
+            .checked_add(len)
+            .ok_or(WalDecodeError::UnexpectedEof)?;
+        let Some(bytes) = self.bytes.get(self.offset..end) else {
+            return Err(WalDecodeError::UnexpectedEof);
+        };
+        self.offset = end;
+        Ok(bytes.to_vec())
     }
 
     fn finish(&self) -> Result<(), WalDecodeError> {

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -13,7 +13,10 @@
 //! History begins at WalTransactionCommit.
 //! ```
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -26,6 +29,7 @@ const WAL_FRONTIERS_ROOT_DOMAIN: &[u8] = b"echo:causal_wal:frontiers_root:v1\0";
 const WAL_COMMIT_DOMAIN: &[u8] = b"echo:causal_wal:commit:v1\0";
 const WAL_HEADER_CHECKSUM_DOMAIN: &[u8] = b"echo:causal_wal:header_checksum:v1\0";
 const WAL_FRAME_CHECKSUM_DOMAIN: &[u8] = b"echo:causal_wal:frame_checksum:v1\0";
+const CHECKPOINT_FILE_MAGIC: &[u8; 8] = b"ECWALCP1";
 
 /// Current in-memory causal WAL version.
 pub const CAUSAL_WAL_VERSION: u16 = 1;
@@ -1137,6 +1141,34 @@ pub struct RecoveryScanReport {
     pub tail_posture: RecoveryTailPosture,
 }
 
+impl RecoveryScanReport {
+    /// Returns the first committed LSN in the scan.
+    #[must_use]
+    pub fn first_committed_lsn(&self) -> Option<Lsn> {
+        self.transactions
+            .iter()
+            .map(|transaction| transaction.commit.first_lsn)
+            .min()
+    }
+
+    /// Returns the last committed LSN in the scan.
+    #[must_use]
+    pub fn last_committed_lsn(&self) -> Option<Lsn> {
+        self.transactions
+            .iter()
+            .map(|transaction| transaction.commit.last_lsn)
+            .max()
+    }
+
+    /// Returns the last committed transaction digest in replay order.
+    #[must_use]
+    pub fn last_commit_digest(&self) -> Option<Hash> {
+        self.transactions
+            .last()
+            .map(|transaction| transaction.commit.commit_digest)
+    }
+}
+
 /// Recovered committed transaction.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WalRecoveredTransaction {
@@ -1144,6 +1176,696 @@ pub struct WalRecoveredTransaction {
     pub commit: WalTransactionCommit,
     /// Transaction frames.
     pub frames: Vec<WalFrame>,
+}
+
+/// WAL submission acceptance record payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SubmissionAcceptanceRecord {
+    /// Stable submission id.
+    pub submission_id: Hash,
+    /// Canonical envelope digest accepted by Echo.
+    pub canonical_envelope_digest: Hash,
+    /// Optional explicit idempotency/dedupe key.
+    pub idempotency_key_digest: Option<Hash>,
+    /// Acceptance evidence digest returned to the caller after durable commit.
+    pub acceptance_evidence_digest: Hash,
+}
+
+impl SubmissionAcceptanceRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.submission_id);
+        push_hash(&mut out, &self.canonical_envelope_digest);
+        push_optional_hash(&mut out, self.idempotency_key_digest);
+        push_hash(&mut out, &self.acceptance_evidence_digest);
+        out
+    }
+
+    /// Decodes a deterministic submission acceptance payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let submission_id = cursor.read_hash()?;
+        let canonical_envelope_digest = cursor.read_hash()?;
+        let idempotency_key_digest = cursor.read_optional_hash()?;
+        let acceptance_evidence_digest = cursor.read_hash()?;
+        cursor.finish()?;
+        Ok(Self {
+            submission_id,
+            canonical_envelope_digest,
+            idempotency_key_digest,
+            acceptance_evidence_digest,
+        })
+    }
+}
+
+/// Scheduler-owned tick decision captured by a WAL receipt record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalTickDecision {
+    /// The scheduler applied the work.
+    Applied,
+    /// The scheduler lawfully rejected the work for a footprint conflict.
+    RejectedFootprintConflict,
+    /// The work is obstructed by retained material or runtime support posture.
+    Obstructed,
+}
+
+impl WalTickDecision {
+    fn code(self) -> u8 {
+        match self {
+            Self::Applied => 1,
+            Self::RejectedFootprintConflict => 2,
+            Self::Obstructed => 3,
+        }
+    }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            1 => Ok(Self::Applied),
+            2 => Ok(Self::RejectedFootprintConflict),
+            3 => Ok(Self::Obstructed),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "WalTickDecision",
+                code,
+            }),
+        }
+    }
+
+    /// Returns `true` when this decision is a lawful rejection, not a fault.
+    #[must_use]
+    pub const fn is_lawful_rejection(self) -> bool {
+        matches!(self, Self::RejectedFootprintConflict)
+    }
+}
+
+/// WAL tick receipt record payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TickReceiptRecord {
+    /// Submission decided by the receipt.
+    pub submission_id: Hash,
+    /// Admission ticket digest.
+    pub ticket_digest: Hash,
+    /// Tick receipt digest.
+    pub receipt_digest: Hash,
+    /// Scheduler decision.
+    pub decision: WalTickDecision,
+}
+
+impl TickReceiptRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.submission_id);
+        push_hash(&mut out, &self.ticket_digest);
+        push_hash(&mut out, &self.receipt_digest);
+        out.push(self.decision.code());
+        out
+    }
+
+    /// Decodes a deterministic tick receipt payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let submission_id = cursor.read_hash()?;
+        let ticket_digest = cursor.read_hash()?;
+        let receipt_digest = cursor.read_hash()?;
+        let decision = WalTickDecision::from_code(cursor.read_u8()?)?;
+        cursor.finish()?;
+        Ok(Self {
+            submission_id,
+            ticket_digest,
+            receipt_digest,
+            decision,
+        })
+    }
+}
+
+/// WAL receipt correlation record payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WalReceiptCorrelationRecord {
+    /// Submission correlated to the receipt.
+    pub submission_id: Hash,
+    /// Admission ticket digest.
+    pub ticket_digest: Hash,
+    /// Tick receipt digest.
+    pub receipt_digest: Hash,
+}
+
+impl WalReceiptCorrelationRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.submission_id);
+        push_hash(&mut out, &self.ticket_digest);
+        push_hash(&mut out, &self.receipt_digest);
+        out
+    }
+
+    /// Decodes a deterministic receipt correlation payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let submission_id = cursor.read_hash()?;
+        let ticket_digest = cursor.read_hash()?;
+        let receipt_digest = cursor.read_hash()?;
+        cursor.finish()?;
+        Ok(Self {
+            submission_id,
+            ticket_digest,
+            receipt_digest,
+        })
+    }
+}
+
+/// Retained material family referenced by committed WAL history.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RetainedMaterialKind {
+    /// Canonical submission payload material.
+    SubmissionPayload,
+    /// Tick receipt material.
+    TickReceipt,
+    /// Runtime state delta material.
+    RuntimeStateDelta,
+    /// Runtime control posture material.
+    RuntimeControl,
+    /// Reading payload material.
+    ReadingPayload,
+    /// Reading envelope material.
+    ReadingEnvelope,
+    /// Diagnostic-only material.
+    Diagnostic,
+}
+
+impl RetainedMaterialKind {
+    fn code(self) -> u8 {
+        match self {
+            Self::SubmissionPayload => 1,
+            Self::TickReceipt => 2,
+            Self::RuntimeStateDelta => 3,
+            Self::RuntimeControl => 4,
+            Self::ReadingPayload => 5,
+            Self::ReadingEnvelope => 6,
+            Self::Diagnostic => 7,
+        }
+    }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            1 => Ok(Self::SubmissionPayload),
+            2 => Ok(Self::TickReceipt),
+            3 => Ok(Self::RuntimeStateDelta),
+            4 => Ok(Self::RuntimeControl),
+            5 => Ok(Self::ReadingPayload),
+            6 => Ok(Self::ReadingEnvelope),
+            7 => Ok(Self::Diagnostic),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "RetainedMaterialKind",
+                code,
+            }),
+        }
+    }
+}
+
+/// Evidence posture for retained material and readings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvidenceMaterialPosture {
+    /// Material is present.
+    Present,
+    /// Material is hidden by revelation policy.
+    RedactedByPolicy,
+    /// Material is encrypted and the key is unavailable.
+    EncryptedKeyUnavailable,
+    /// Material is missing.
+    Missing,
+    /// Material is corrupt.
+    Corrupt,
+    /// Material is obstructed by causal/runtime posture.
+    Obstructed,
+}
+
+impl EvidenceMaterialPosture {
+    fn code(self) -> u8 {
+        match self {
+            Self::Present => 1,
+            Self::RedactedByPolicy => 2,
+            Self::EncryptedKeyUnavailable => 3,
+            Self::Missing => 4,
+            Self::Corrupt => 5,
+            Self::Obstructed => 6,
+        }
+    }
+
+    fn from_code(code: u8) -> Result<Self, WalDecodeError> {
+        match code {
+            1 => Ok(Self::Present),
+            2 => Ok(Self::RedactedByPolicy),
+            3 => Ok(Self::EncryptedKeyUnavailable),
+            4 => Ok(Self::Missing),
+            5 => Ok(Self::Corrupt),
+            6 => Ok(Self::Obstructed),
+            _ => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "EvidenceMaterialPosture",
+                code,
+            }),
+        }
+    }
+}
+
+/// WAL retained material reference payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RetainedMaterialRecord {
+    /// Material digest.
+    pub material_digest: Hash,
+    /// Semantic coordinate digest naming why the material matters.
+    pub semantic_coordinate_digest: Hash,
+    /// Material family.
+    pub kind: RetainedMaterialKind,
+    /// Material posture.
+    pub posture: EvidenceMaterialPosture,
+}
+
+impl RetainedMaterialRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.material_digest);
+        push_hash(&mut out, &self.semantic_coordinate_digest);
+        out.push(self.kind.code());
+        out.push(self.posture.code());
+        out
+    }
+
+    /// Decodes a deterministic retained material payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let material_digest = cursor.read_hash()?;
+        let semantic_coordinate_digest = cursor.read_hash()?;
+        let kind = RetainedMaterialKind::from_code(cursor.read_u8()?)?;
+        let posture = EvidenceMaterialPosture::from_code(cursor.read_u8()?)?;
+        cursor.finish()?;
+        Ok(Self {
+            material_digest,
+            semantic_coordinate_digest,
+            kind,
+            posture,
+        })
+    }
+}
+
+/// WAL reading reference payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadingRefRecord {
+    /// Reading identity digest.
+    pub reading_id: Hash,
+    /// Query or reading semantic coordinate digest.
+    pub semantic_coordinate_digest: Hash,
+    /// Retained payload digest.
+    pub payload_digest: Hash,
+    /// Retained envelope digest.
+    pub envelope_digest: Hash,
+    /// Reading evidence posture.
+    pub posture: EvidenceMaterialPosture,
+}
+
+impl ReadingRefRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.reading_id);
+        push_hash(&mut out, &self.semantic_coordinate_digest);
+        push_hash(&mut out, &self.payload_digest);
+        push_hash(&mut out, &self.envelope_digest);
+        out.push(self.posture.code());
+        out
+    }
+
+    /// Decodes a deterministic retained reading payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let reading_id = cursor.read_hash()?;
+        let semantic_coordinate_digest = cursor.read_hash()?;
+        let payload_digest = cursor.read_hash()?;
+        let envelope_digest = cursor.read_hash()?;
+        let posture = EvidenceMaterialPosture::from_code(cursor.read_u8()?)?;
+        cursor.finish()?;
+        Ok(Self {
+            reading_id,
+            semantic_coordinate_digest,
+            payload_digest,
+            envelope_digest,
+            posture,
+        })
+    }
+}
+
+/// Scope of a retained-material recovery obstruction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MissingMaterialScope {
+    /// One recovered submission is obstructed.
+    Submission,
+    /// A receipt or ticket correlation is obstructed.
+    ReceiptOrTicket,
+    /// Runtime recovery must fault globally.
+    RuntimeGlobal,
+    /// A retained reading is obstructed.
+    Reading,
+    /// Diagnostic material loss does not block causal recovery.
+    DiagnosticLoss,
+}
+
+/// Classifies the recovery scope for missing retained material.
+#[must_use]
+pub const fn missing_material_scope(kind: RetainedMaterialKind) -> MissingMaterialScope {
+    match kind {
+        RetainedMaterialKind::SubmissionPayload => MissingMaterialScope::Submission,
+        RetainedMaterialKind::TickReceipt => MissingMaterialScope::ReceiptOrTicket,
+        RetainedMaterialKind::RuntimeStateDelta | RetainedMaterialKind::RuntimeControl => {
+            MissingMaterialScope::RuntimeGlobal
+        }
+        RetainedMaterialKind::ReadingPayload | RetainedMaterialKind::ReadingEnvelope => {
+            MissingMaterialScope::Reading
+        }
+        RetainedMaterialKind::Diagnostic => MissingMaterialScope::DiagnosticLoss,
+    }
+}
+
+/// Recovered submission posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveredSubmissionPosture {
+    /// Submission was accepted and has no committed decision yet.
+    AcceptedPending,
+    /// Submission was decided as applied.
+    DecidedApplied,
+    /// Submission was lawfully rejected.
+    DecidedRejected,
+    /// Submission is obstructed.
+    Obstructed,
+    /// Recovery found a fault for this submission.
+    RecoveryFaulted,
+}
+
+/// Retry posture for a submitted id/envelope pair after recovery.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SubmissionRetryPosture {
+    /// No recovered acceptance exists for this submission id.
+    NotAccepted,
+    /// Same id and envelope recovered as accepted pending.
+    AlreadyAcceptedPending,
+    /// Same id and envelope recovered as decided applied.
+    AlreadyDecidedApplied,
+    /// Same id and envelope recovered as decided rejected.
+    AlreadyDecidedRejected,
+    /// Same id and envelope recovered as obstructed.
+    AlreadyObstructed,
+    /// Same id recovered with a different canonical envelope digest.
+    ConflictSameIdDifferentEnvelope,
+    /// New id with same envelope should be treated as a new submission unless
+    /// an explicit dedupe policy says otherwise.
+    NewSubmissionWithoutPolicyDedupe,
+}
+
+/// Recovered submission entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RecoveredSubmissionEntry {
+    /// Submission acceptance record.
+    pub acceptance: SubmissionAcceptanceRecord,
+    /// Current recovered posture.
+    pub posture: RecoveredSubmissionPosture,
+    /// Deciding receipt digest, if any.
+    pub receipt_digest: Option<Hash>,
+}
+
+/// Recovered submission index.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RecoveredSubmissionIndex {
+    submissions: BTreeMap<Hash, RecoveredSubmissionEntry>,
+    envelope_to_submissions: BTreeMap<Hash, BTreeSet<Hash>>,
+}
+
+impl RecoveredSubmissionIndex {
+    /// Returns a recovered submission entry.
+    #[must_use]
+    pub fn get(&self, submission_id: &Hash) -> Option<&RecoveredSubmissionEntry> {
+        self.submissions.get(submission_id)
+    }
+
+    /// Returns the number of recovered submissions.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.submissions.len()
+    }
+
+    /// Returns `true` when the index contains no submissions.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.submissions.is_empty()
+    }
+
+    /// Classifies retry posture for a submission id and canonical envelope.
+    #[must_use]
+    pub fn retry_posture(
+        &self,
+        submission_id: Hash,
+        canonical_envelope_digest: Hash,
+    ) -> SubmissionRetryPosture {
+        let Some(entry) = self.submissions.get(&submission_id) else {
+            if self
+                .envelope_to_submissions
+                .get(&canonical_envelope_digest)
+                .is_some_and(|ids| !ids.is_empty())
+            {
+                return SubmissionRetryPosture::NewSubmissionWithoutPolicyDedupe;
+            }
+            return SubmissionRetryPosture::NotAccepted;
+        };
+        if entry.acceptance.canonical_envelope_digest != canonical_envelope_digest {
+            return SubmissionRetryPosture::ConflictSameIdDifferentEnvelope;
+        }
+        match entry.posture {
+            RecoveredSubmissionPosture::AcceptedPending => {
+                SubmissionRetryPosture::AlreadyAcceptedPending
+            }
+            RecoveredSubmissionPosture::DecidedApplied => {
+                SubmissionRetryPosture::AlreadyDecidedApplied
+            }
+            RecoveredSubmissionPosture::DecidedRejected => {
+                SubmissionRetryPosture::AlreadyDecidedRejected
+            }
+            RecoveredSubmissionPosture::Obstructed
+            | RecoveredSubmissionPosture::RecoveryFaulted => {
+                SubmissionRetryPosture::AlreadyObstructed
+            }
+        }
+    }
+}
+
+/// Recovered receipt correlation index.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RecoveredReceiptIndex {
+    /// Receipt by submission id.
+    pub receipt_by_submission: BTreeMap<Hash, Hash>,
+    /// Receipt by admission ticket digest.
+    pub receipt_by_ticket: BTreeMap<Hash, Hash>,
+    /// Ticket by submission id.
+    pub ticket_by_submission: BTreeMap<Hash, Hash>,
+    /// Decisions by receipt digest.
+    pub decisions_by_receipt: BTreeMap<Hash, WalTickDecision>,
+}
+
+/// Recovered retained material and reading index.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RecoveredRetentionIndex {
+    /// Retained material by digest.
+    pub material_by_digest: BTreeMap<Hash, RetainedMaterialRecord>,
+    /// Retained material by semantic coordinate.
+    pub material_by_semantic_coordinate: BTreeMap<Hash, BTreeSet<Hash>>,
+    /// Retained reading by reading id.
+    pub reading_by_id: BTreeMap<Hash, ReadingRefRecord>,
+    /// Reading ids by semantic coordinate.
+    pub readings_by_semantic_coordinate: BTreeMap<Hash, BTreeSet<Hash>>,
+}
+
+/// Retained material obstruction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RetainedMaterialObstruction {
+    /// Missing or obstructed material digest.
+    pub material_digest: Hash,
+    /// Material kind.
+    pub kind: RetainedMaterialKind,
+    /// Recovery scope.
+    pub scope: MissingMaterialScope,
+    /// Evidence posture.
+    pub posture: EvidenceMaterialPosture,
+}
+
+/// WAL checkpoint record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckpointRecord {
+    /// Stable checkpoint id.
+    pub checkpoint_id: Hash,
+    /// Last included LSN.
+    pub last_included_lsn: Lsn,
+    /// Last included commit digest.
+    pub last_included_commit_digest: Hash,
+    /// Runtime state root.
+    pub state_root: Hash,
+    /// Rebuilt index root.
+    pub index_root: Hash,
+    /// Retained material root.
+    pub retained_material_root: Hash,
+    /// Checkpoint schema version.
+    pub schema_version: u16,
+    /// Digest of the WAL chain used to create the checkpoint.
+    pub created_from_wal_digest: Hash,
+}
+
+impl CheckpointRecord {
+    /// Computes the checkpoint digest.
+    #[must_use]
+    pub fn checkpoint_digest(&self) -> Hash {
+        let mut h = blake3::Hasher::new();
+        h.update(b"echo:causal_wal:checkpoint:v1\0");
+        h.update(&self.checkpoint_id);
+        h.update(&self.last_included_lsn.as_u64().to_le_bytes());
+        h.update(&self.last_included_commit_digest);
+        h.update(&self.state_root);
+        h.update(&self.index_root);
+        h.update(&self.retained_material_root);
+        h.update(&self.schema_version.to_le_bytes());
+        h.update(&self.created_from_wal_digest);
+        h.finalize().into()
+    }
+
+    /// Encodes the checkpoint as deterministic payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.checkpoint_id);
+        out.extend_from_slice(&self.last_included_lsn.as_u64().to_le_bytes());
+        push_hash(&mut out, &self.last_included_commit_digest);
+        push_hash(&mut out, &self.state_root);
+        push_hash(&mut out, &self.index_root);
+        push_hash(&mut out, &self.retained_material_root);
+        out.extend_from_slice(&self.schema_version.to_le_bytes());
+        push_hash(&mut out, &self.created_from_wal_digest);
+        out
+    }
+
+    /// Decodes a deterministic checkpoint payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let checkpoint_id = cursor.read_hash()?;
+        let last_included_lsn = Lsn::from_raw(cursor.read_u64()?);
+        let last_included_commit_digest = cursor.read_hash()?;
+        let state_root = cursor.read_hash()?;
+        let index_root = cursor.read_hash()?;
+        let retained_material_root = cursor.read_hash()?;
+        let schema_version = cursor.read_u16()?;
+        let created_from_wal_digest = cursor.read_hash()?;
+        cursor.finish()?;
+        Ok(Self {
+            checkpoint_id,
+            last_included_lsn,
+            last_included_commit_digest,
+            state_root,
+            index_root,
+            retained_material_root,
+            schema_version,
+            created_from_wal_digest,
+        })
+    }
+}
+
+/// WAL checkpoint publication record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckpointPublicationRecord {
+    /// Published checkpoint id.
+    pub checkpoint_id: Hash,
+    /// Published checkpoint digest.
+    pub checkpoint_digest: Hash,
+}
+
+impl CheckpointPublicationRecord {
+    /// Encodes the record as deterministic WAL payload bytes.
+    #[must_use]
+    pub fn to_payload_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_hash(&mut out, &self.checkpoint_id);
+        push_hash(&mut out, &self.checkpoint_digest);
+        out
+    }
+
+    /// Decodes a deterministic checkpoint publication payload.
+    pub fn from_payload_bytes(bytes: &[u8]) -> Result<Self, WalDecodeError> {
+        let mut cursor = WalPayloadCursor::new(bytes);
+        let checkpoint_id = cursor.read_hash()?;
+        let checkpoint_digest = cursor.read_hash()?;
+        cursor.finish()?;
+        Ok(Self {
+            checkpoint_id,
+            checkpoint_digest,
+        })
+    }
+}
+
+/// Checkpoint validation posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckpointValidationPosture {
+    /// Checkpoint validates and no publication record is required for use.
+    UsableWithoutPublicationRecord,
+    /// Checkpoint validates and publication evidence matches.
+    PublishedAndUsable,
+    /// Publication evidence exists but checkpoint material is missing.
+    PublishedCheckpointMaterialMissing,
+    /// Checkpoint does not validate against recovered WAL.
+    Invalid,
+}
+
+/// Recovery certificate produced after WAL recovery.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoveryCertificate {
+    /// Checkpoint digest used as replay base, if any.
+    pub checkpoint_used: Option<Hash>,
+    /// First scanned committed LSN.
+    pub first_lsn: Option<Lsn>,
+    /// Last scanned committed LSN.
+    pub last_lsn: Option<Lsn>,
+    /// Number of committed transactions replayed.
+    pub committed_transactions_replayed: u64,
+    /// Tail posture.
+    pub tail_posture: RecoveryTailPosture,
+    /// Obstruction count.
+    pub obstruction_count: u64,
+    /// Final frontier root.
+    pub recovered_frontier_root: Hash,
+    /// Final index root.
+    pub recovered_indexes_root: Hash,
+}
+
+/// Read-only WAL doctor posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalDoctorPosture {
+    /// WAL can be recovered from committed history.
+    Recoverable,
+    /// WAL is inspectable, but read-only mode detected a tail that would be
+    /// truncated by writable recovery.
+    RecoverableWithUncommittedTail,
+    /// WAL has a recovery obstruction.
+    Obstructed,
+}
+
+/// Read-only WAL doctor report.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalDoctorReport {
+    /// Doctor posture.
+    pub posture: WalDoctorPosture,
+    /// Recovery certificate.
+    pub recovery_certificate: RecoveryCertificate,
+    /// Tail posture.
+    pub tail_posture: RecoveryTailPosture,
 }
 
 /// Scans an in-memory store for recoverable transactions.
@@ -1210,6 +1932,381 @@ pub fn recover_from_frames_and_commits(
     Ok(RecoveryScanReport {
         transactions: recovered,
         tail_posture,
+    })
+}
+
+/// Builds a submission acceptance transaction.
+pub fn build_submission_acceptance_transaction(
+    mut builder: WalTransactionBuilder,
+    record: SubmissionAcceptanceRecord,
+    affected_frontiers: Vec<AffectedFrontier>,
+) -> Result<WalCommittedTransaction, WalBuildError> {
+    builder.push_record(
+        WalRecordKind::SubmissionAcceptedRecorded,
+        record.to_payload_bytes(),
+    )?;
+    builder.push_record(
+        WalRecordKind::SubmissionAcceptanceEvidenceRecorded,
+        record.acceptance_evidence_digest.to_vec(),
+    )?;
+    builder.commit(affected_frontiers)
+}
+
+/// Builds a scheduler-owned tick transaction.
+pub fn build_tick_transaction(
+    mut builder: WalTransactionBuilder,
+    receipt: TickReceiptRecord,
+    correlation: WalReceiptCorrelationRecord,
+    state_delta_digest: Hash,
+    affected_frontiers: Vec<AffectedFrontier>,
+) -> Result<WalCommittedTransaction, WalBuildError> {
+    builder.push_record(
+        WalRecordKind::TickReceiptRecorded,
+        receipt.to_payload_bytes(),
+    )?;
+    builder.push_record(
+        WalRecordKind::ReceiptCorrelationRecorded,
+        correlation.to_payload_bytes(),
+    )?;
+    builder.push_record(
+        WalRecordKind::RuntimeStateDeltaRecorded,
+        state_delta_digest.to_vec(),
+    )?;
+    builder.commit(affected_frontiers)
+}
+
+/// Builds a retained reading transaction.
+pub fn build_retained_reading_transaction(
+    mut builder: WalTransactionBuilder,
+    material: &[RetainedMaterialRecord],
+    reading: ReadingRefRecord,
+    affected_frontiers: Vec<AffectedFrontier>,
+) -> Result<WalCommittedTransaction, WalBuildError> {
+    for record in material {
+        builder.push_record(
+            WalRecordKind::RetainedMaterialRefRecorded,
+            record.to_payload_bytes(),
+        )?;
+    }
+    builder.push_record(
+        WalRecordKind::ReadingEnvelopeRetained,
+        reading.to_payload_bytes(),
+    )?;
+    builder.commit(affected_frontiers)
+}
+
+/// Builds a checkpoint publication transaction.
+pub fn build_checkpoint_publication_transaction(
+    mut builder: WalTransactionBuilder,
+    publication: CheckpointPublicationRecord,
+    affected_frontiers: Vec<AffectedFrontier>,
+) -> Result<WalCommittedTransaction, WalBuildError> {
+    builder.push_record(
+        WalRecordKind::CheckpointPublicationRecorded,
+        publication.to_payload_bytes(),
+    )?;
+    builder.commit(affected_frontiers)
+}
+
+/// Writes a checkpoint file through an atomic temp-file + rename protocol.
+///
+/// This is a local filesystem helper for checkpoint material, not causal
+/// history authority. A checkpoint remains a replay accelerator and must still
+/// validate against committed WAL history before recovery uses it.
+pub fn write_checkpoint_record_atomic(
+    path: impl AsRef<Path>,
+    checkpoint: &CheckpointRecord,
+) -> Result<(), WalCheckpointIoError> {
+    let path = path.as_ref();
+    let parent = path
+        .parent()
+        .ok_or(WalCheckpointIoError::MissingParentDirectory)?;
+    fs::create_dir_all(parent)?;
+    let temp_path = checkpoint_temp_path(path)?;
+    let bytes = checkpoint_file_bytes(checkpoint);
+    {
+        let mut file = File::create(&temp_path)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+    }
+    fs::rename(&temp_path, path)?;
+    sync_directory(parent)?;
+    Ok(())
+}
+
+/// Reads a checkpoint file written by [`write_checkpoint_record_atomic`].
+pub fn read_checkpoint_record(
+    path: impl AsRef<Path>,
+) -> Result<CheckpointRecord, WalCheckpointIoError> {
+    let mut bytes = Vec::new();
+    File::open(path.as_ref())?.read_to_end(&mut bytes)?;
+    parse_checkpoint_file_bytes(&bytes)
+}
+
+/// Recovers submission posture from committed WAL transactions.
+pub fn recover_submission_index(
+    report: &RecoveryScanReport,
+) -> Result<RecoveredSubmissionIndex, WalRecoveryIndexError> {
+    let mut index = RecoveredSubmissionIndex::default();
+    for transaction in &report.transactions {
+        for frame in &transaction.frames {
+            match frame.header.record_kind {
+                WalRecordKind::SubmissionAcceptedRecorded => {
+                    let record = SubmissionAcceptanceRecord::from_payload_bytes(
+                        &frame.payload.canonical_bytes,
+                    )?;
+                    if let Some(existing) = index.submissions.get(&record.submission_id) {
+                        if existing.acceptance.canonical_envelope_digest
+                            != record.canonical_envelope_digest
+                        {
+                            return Err(WalRecoveryIndexError::SubmissionEnvelopeConflict {
+                                submission_id: record.submission_id,
+                            });
+                        }
+                    }
+                    index
+                        .envelope_to_submissions
+                        .entry(record.canonical_envelope_digest)
+                        .or_default()
+                        .insert(record.submission_id);
+                    index.submissions.entry(record.submission_id).or_insert(
+                        RecoveredSubmissionEntry {
+                            acceptance: record,
+                            posture: RecoveredSubmissionPosture::AcceptedPending,
+                            receipt_digest: None,
+                        },
+                    );
+                }
+                WalRecordKind::TickReceiptRecorded => {
+                    let receipt =
+                        TickReceiptRecord::from_payload_bytes(&frame.payload.canonical_bytes)?;
+                    if let Some(entry) = index.submissions.get_mut(&receipt.submission_id) {
+                        entry.posture = match receipt.decision {
+                            WalTickDecision::Applied => RecoveredSubmissionPosture::DecidedApplied,
+                            WalTickDecision::RejectedFootprintConflict => {
+                                RecoveredSubmissionPosture::DecidedRejected
+                            }
+                            WalTickDecision::Obstructed => RecoveredSubmissionPosture::Obstructed,
+                        };
+                        entry.receipt_digest = Some(receipt.receipt_digest);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(index)
+}
+
+/// Recovers receipt correlations from committed WAL transactions.
+pub fn recover_receipt_index(
+    report: &RecoveryScanReport,
+) -> Result<RecoveredReceiptIndex, WalRecoveryIndexError> {
+    let mut index = RecoveredReceiptIndex::default();
+    for transaction in &report.transactions {
+        for frame in &transaction.frames {
+            match frame.header.record_kind {
+                WalRecordKind::TickReceiptRecorded => {
+                    let receipt =
+                        TickReceiptRecord::from_payload_bytes(&frame.payload.canonical_bytes)?;
+                    index
+                        .receipt_by_submission
+                        .insert(receipt.submission_id, receipt.receipt_digest);
+                    index
+                        .receipt_by_ticket
+                        .insert(receipt.ticket_digest, receipt.receipt_digest);
+                    index
+                        .ticket_by_submission
+                        .insert(receipt.submission_id, receipt.ticket_digest);
+                    index
+                        .decisions_by_receipt
+                        .insert(receipt.receipt_digest, receipt.decision);
+                }
+                WalRecordKind::ReceiptCorrelationRecorded => {
+                    let correlation = WalReceiptCorrelationRecord::from_payload_bytes(
+                        &frame.payload.canonical_bytes,
+                    )?;
+                    index
+                        .receipt_by_submission
+                        .insert(correlation.submission_id, correlation.receipt_digest);
+                    index
+                        .receipt_by_ticket
+                        .insert(correlation.ticket_digest, correlation.receipt_digest);
+                    index
+                        .ticket_by_submission
+                        .insert(correlation.submission_id, correlation.ticket_digest);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(index)
+}
+
+/// Recovers retained material and reading indexes from committed WAL transactions.
+pub fn recover_retention_index(
+    report: &RecoveryScanReport,
+) -> Result<RecoveredRetentionIndex, WalRecoveryIndexError> {
+    let mut index = RecoveredRetentionIndex::default();
+    for transaction in &report.transactions {
+        for frame in &transaction.frames {
+            match frame.header.record_kind {
+                WalRecordKind::RetainedMaterialRefRecorded => {
+                    let record =
+                        RetainedMaterialRecord::from_payload_bytes(&frame.payload.canonical_bytes)?;
+                    index
+                        .material_by_semantic_coordinate
+                        .entry(record.semantic_coordinate_digest)
+                        .or_default()
+                        .insert(record.material_digest);
+                    index
+                        .material_by_digest
+                        .insert(record.material_digest, record);
+                }
+                WalRecordKind::ReadingEnvelopeRetained => {
+                    let record =
+                        ReadingRefRecord::from_payload_bytes(&frame.payload.canonical_bytes)?;
+                    index
+                        .readings_by_semantic_coordinate
+                        .entry(record.semantic_coordinate_digest)
+                        .or_default()
+                        .insert(record.reading_id);
+                    index.reading_by_id.insert(record.reading_id, record);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(index)
+}
+
+/// Validates retained material references against an available material set.
+#[must_use]
+pub fn retained_material_obstructions(
+    index: &RecoveredRetentionIndex,
+    available_material: &BTreeSet<Hash>,
+) -> Vec<RetainedMaterialObstruction> {
+    let mut obstructions = Vec::new();
+    for record in index.material_by_digest.values() {
+        if record.posture != EvidenceMaterialPosture::Present
+            || !available_material.contains(&record.material_digest)
+        {
+            let posture = if record.posture == EvidenceMaterialPosture::Present {
+                EvidenceMaterialPosture::Missing
+            } else {
+                record.posture
+            };
+            obstructions.push(RetainedMaterialObstruction {
+                material_digest: record.material_digest,
+                kind: record.kind,
+                scope: missing_material_scope(record.kind),
+                posture,
+            });
+        }
+    }
+    obstructions
+}
+
+/// Recovers checkpoint publication records from committed WAL transactions.
+pub fn recover_checkpoint_publications(
+    report: &RecoveryScanReport,
+) -> Result<Vec<CheckpointPublicationRecord>, WalRecoveryIndexError> {
+    let mut publications = Vec::new();
+    for transaction in &report.transactions {
+        for frame in &transaction.frames {
+            if frame.header.record_kind == WalRecordKind::CheckpointPublicationRecorded {
+                publications.push(CheckpointPublicationRecord::from_payload_bytes(
+                    &frame.payload.canonical_bytes,
+                )?);
+            }
+        }
+    }
+    Ok(publications)
+}
+
+/// Evaluates whether a checkpoint may be used as a replay accelerator.
+#[must_use]
+pub fn validate_checkpoint_record(
+    checkpoint: &CheckpointRecord,
+    report: &RecoveryScanReport,
+    publications: &[CheckpointPublicationRecord],
+) -> CheckpointValidationPosture {
+    let Some(last_lsn) = report.last_committed_lsn() else {
+        return CheckpointValidationPosture::Invalid;
+    };
+    let Some(last_commit_digest) = report.last_commit_digest() else {
+        return CheckpointValidationPosture::Invalid;
+    };
+    if checkpoint.last_included_lsn > last_lsn
+        || checkpoint.last_included_commit_digest != last_commit_digest
+    {
+        return CheckpointValidationPosture::Invalid;
+    }
+    let checkpoint_digest = checkpoint.checkpoint_digest();
+    if publications.iter().any(|publication| {
+        publication.checkpoint_id == checkpoint.checkpoint_id
+            && publication.checkpoint_digest == checkpoint_digest
+    }) {
+        CheckpointValidationPosture::PublishedAndUsable
+    } else {
+        CheckpointValidationPosture::UsableWithoutPublicationRecord
+    }
+}
+
+/// Evaluates checkpoint publication evidence when checkpoint material may be absent.
+#[must_use]
+pub fn evaluate_checkpoint_publication(
+    publication: &CheckpointPublicationRecord,
+    checkpoint: Option<&CheckpointRecord>,
+    report: &RecoveryScanReport,
+) -> CheckpointValidationPosture {
+    let Some(checkpoint) = checkpoint else {
+        return CheckpointValidationPosture::PublishedCheckpointMaterialMissing;
+    };
+    validate_checkpoint_record(checkpoint, report, &[*publication])
+}
+
+/// Builds a recovery certificate from recovered committed history.
+#[must_use]
+pub fn build_recovery_certificate(
+    report: &RecoveryScanReport,
+    checkpoint_used: Option<Hash>,
+    obstruction_count: u64,
+    recovered_frontier_root: Hash,
+    recovered_indexes_root: Hash,
+) -> RecoveryCertificate {
+    RecoveryCertificate {
+        checkpoint_used,
+        first_lsn: report.first_committed_lsn(),
+        last_lsn: report.last_committed_lsn(),
+        committed_transactions_replayed: len_u64(report.transactions.len()),
+        tail_posture: report.tail_posture,
+        obstruction_count,
+        recovered_frontier_root,
+        recovered_indexes_root,
+    }
+}
+
+/// Runs a read-only WAL doctor over an in-memory store.
+pub fn doctor_in_memory_store(
+    store: &InMemoryWalStore,
+) -> Result<WalDoctorReport, WalRecoveryError> {
+    let frames = store.read_frames();
+    let commits = store.read_commits();
+    let report = recover_from_frames_and_commits(&frames, &commits, RecoveryAccessMode::ReadOnly)?;
+    let posture = match report.tail_posture {
+        RecoveryTailPosture::Clean => WalDoctorPosture::Recoverable,
+        RecoveryTailPosture::WouldTruncateAll | RecoveryTailPosture::WouldTruncateAfter(_) => {
+            WalDoctorPosture::RecoverableWithUncommittedTail
+        }
+        RecoveryTailPosture::TruncatedAll | RecoveryTailPosture::TruncatedAfter(_) => {
+            WalDoctorPosture::Obstructed
+        }
+    };
+    Ok(WalDoctorReport {
+        posture,
+        recovery_certificate: build_recovery_certificate(&report, None, 0, [0; 32], [0; 32]),
+        tail_posture: report.tail_posture,
     })
 }
 
@@ -1420,6 +2517,59 @@ pub enum WalReplayError {
     },
 }
 
+/// WAL payload decode errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalDecodeError {
+    /// Payload ended before the expected field could be decoded.
+    #[error("WAL payload ended early")]
+    UnexpectedEof,
+    /// Payload contained trailing bytes.
+    #[error("WAL payload contained trailing bytes")]
+    TrailingBytes,
+    /// Payload contained an unknown enum code.
+    #[error("unknown WAL enum code {code} for {enum_name}")]
+    UnknownEnumCode {
+        /// Enum name.
+        enum_name: &'static str,
+        /// Unknown code.
+        code: u8,
+    },
+}
+
+/// WAL recovered index errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalRecoveryIndexError {
+    /// Payload decode failed.
+    #[error(transparent)]
+    Decode(#[from] WalDecodeError),
+    /// Submission id was reused with a different canonical envelope digest.
+    #[error("submission id was reused with a different canonical envelope digest")]
+    SubmissionEnvelopeConflict {
+        /// Conflicting submission id.
+        submission_id: Hash,
+    },
+}
+
+/// Checkpoint file I/O errors.
+#[derive(Debug, Error)]
+pub enum WalCheckpointIoError {
+    /// Checkpoint path has no parent directory.
+    #[error("checkpoint path has no parent directory")]
+    MissingParentDirectory,
+    /// Checkpoint file magic is invalid.
+    #[error("invalid checkpoint file magic")]
+    InvalidMagic,
+    /// Checkpoint file digest does not match the checkpoint payload.
+    #[error("checkpoint file digest mismatch")]
+    DigestMismatch,
+    /// Checkpoint payload decode failed.
+    #[error(transparent)]
+    Decode(#[from] WalDecodeError),
+    /// Filesystem I/O failed.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
 /// WAL schema lint errors.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum WalSchemaLintError {
@@ -1564,6 +2714,160 @@ fn checksum32(domain: &[u8], bytes: &[u8]) -> u32 {
 fn update_len_prefixed(hasher: &mut blake3::Hasher, bytes: &[u8]) {
     hasher.update(&len_u64(bytes.len()).to_le_bytes());
     hasher.update(bytes);
+}
+
+fn push_hash(out: &mut Vec<u8>, hash: &Hash) {
+    out.extend_from_slice(hash);
+}
+
+fn push_optional_hash(out: &mut Vec<u8>, hash: Option<Hash>) {
+    match hash {
+        Some(hash) => {
+            out.push(1);
+            push_hash(out, &hash);
+        }
+        None => out.push(0),
+    }
+}
+
+struct WalPayloadCursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> WalPayloadCursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn read_u8(&mut self) -> Result<u8, WalDecodeError> {
+        let Some(value) = self.bytes.get(self.offset).copied() else {
+            return Err(WalDecodeError::UnexpectedEof);
+        };
+        self.offset += 1;
+        Ok(value)
+    }
+
+    fn read_u16(&mut self) -> Result<u16, WalDecodeError> {
+        let end = self
+            .offset
+            .checked_add(2)
+            .ok_or(WalDecodeError::UnexpectedEof)?;
+        let Some(bytes) = self.bytes.get(self.offset..end) else {
+            return Err(WalDecodeError::UnexpectedEof);
+        };
+        let mut out = [0; 2];
+        out.copy_from_slice(bytes);
+        self.offset = end;
+        Ok(u16::from_le_bytes(out))
+    }
+
+    fn read_u64(&mut self) -> Result<u64, WalDecodeError> {
+        let end = self
+            .offset
+            .checked_add(8)
+            .ok_or(WalDecodeError::UnexpectedEof)?;
+        let Some(bytes) = self.bytes.get(self.offset..end) else {
+            return Err(WalDecodeError::UnexpectedEof);
+        };
+        let mut out = [0; 8];
+        out.copy_from_slice(bytes);
+        self.offset = end;
+        Ok(u64::from_le_bytes(out))
+    }
+
+    fn read_hash(&mut self) -> Result<Hash, WalDecodeError> {
+        let end = self
+            .offset
+            .checked_add(32)
+            .ok_or(WalDecodeError::UnexpectedEof)?;
+        let Some(bytes) = self.bytes.get(self.offset..end) else {
+            return Err(WalDecodeError::UnexpectedEof);
+        };
+        let mut out = [0; 32];
+        out.copy_from_slice(bytes);
+        self.offset = end;
+        Ok(out)
+    }
+
+    fn read_optional_hash(&mut self) -> Result<Option<Hash>, WalDecodeError> {
+        match self.read_u8()? {
+            0 => Ok(None),
+            1 => self.read_hash().map(Some),
+            code => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "Option<Hash>",
+                code,
+            }),
+        }
+    }
+
+    fn finish(&self) -> Result<(), WalDecodeError> {
+        if self.offset == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(WalDecodeError::TrailingBytes)
+        }
+    }
+}
+
+fn checkpoint_temp_path(path: &Path) -> Result<PathBuf, WalCheckpointIoError> {
+    let file_name = path
+        .file_name()
+        .ok_or(WalCheckpointIoError::MissingParentDirectory)?;
+    let temp_name = format!(".{}.tmp", file_name.to_string_lossy());
+    Ok(path.with_file_name(temp_name))
+}
+
+fn checkpoint_file_bytes(checkpoint: &CheckpointRecord) -> Vec<u8> {
+    let payload = checkpoint.to_payload_bytes();
+    let digest = checkpoint.checkpoint_digest();
+    let mut out = Vec::new();
+    out.extend_from_slice(CHECKPOINT_FILE_MAGIC);
+    out.extend_from_slice(&len_u64(payload.len()).to_le_bytes());
+    out.extend_from_slice(&payload);
+    out.extend_from_slice(&digest);
+    out
+}
+
+fn parse_checkpoint_file_bytes(bytes: &[u8]) -> Result<CheckpointRecord, WalCheckpointIoError> {
+    if bytes.get(..CHECKPOINT_FILE_MAGIC.len()) != Some(CHECKPOINT_FILE_MAGIC.as_slice()) {
+        return Err(WalCheckpointIoError::InvalidMagic);
+    }
+    let mut offset = CHECKPOINT_FILE_MAGIC.len();
+    let len_end = offset.checked_add(8).ok_or(WalDecodeError::UnexpectedEof)?;
+    let Some(len_bytes) = bytes.get(offset..len_end) else {
+        return Err(WalCheckpointIoError::Decode(WalDecodeError::UnexpectedEof));
+    };
+    let mut payload_len = [0; 8];
+    payload_len.copy_from_slice(len_bytes);
+    offset = len_end;
+    let payload_len = usize::try_from(u64::from_le_bytes(payload_len))
+        .map_err(|_| WalDecodeError::UnexpectedEof)?;
+    let payload_end = offset
+        .checked_add(payload_len)
+        .ok_or(WalDecodeError::UnexpectedEof)?;
+    let Some(payload) = bytes.get(offset..payload_end) else {
+        return Err(WalCheckpointIoError::Decode(WalDecodeError::UnexpectedEof));
+    };
+    let digest_end = payload_end
+        .checked_add(32)
+        .ok_or(WalDecodeError::UnexpectedEof)?;
+    let Some(digest_bytes) = bytes.get(payload_end..digest_end) else {
+        return Err(WalCheckpointIoError::Decode(WalDecodeError::UnexpectedEof));
+    };
+    if digest_end != bytes.len() {
+        return Err(WalCheckpointIoError::Decode(WalDecodeError::TrailingBytes));
+    }
+    let checkpoint = CheckpointRecord::from_payload_bytes(payload)?;
+    if digest_bytes != checkpoint.checkpoint_digest() {
+        return Err(WalCheckpointIoError::DigestMismatch);
+    }
+    Ok(checkpoint)
+}
+
+fn sync_directory(path: &Path) -> Result<(), WalCheckpointIoError> {
+    File::open(path)?.sync_all()?;
+    Ok(())
 }
 
 fn len_u64(len: usize) -> u64 {

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -536,6 +536,12 @@ pub struct WriterEpoch {
     pub lease_or_lock_evidence: Hash,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct WriterEpochClosure {
+    final_lsn: Option<Lsn>,
+    final_commit_digest: Option<Hash>,
+}
+
 /// Canonical WAL record payload.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WalRecordPayload {
@@ -728,6 +734,12 @@ pub struct WalTransactionCommit {
 }
 
 impl WalTransactionCommit {
+    /// Computes the digest expected for the current commit fields.
+    #[must_use]
+    pub fn expected_digest(&self) -> Hash {
+        self.compute_digest()
+    }
+
     fn compute_digest(&self) -> Hash {
         let mut h = blake3::Hasher::new();
         h.update(WAL_COMMIT_DOMAIN);
@@ -762,6 +774,7 @@ impl WalCommittedTransaction {
     pub fn validate(&self) -> Result<(), WalValidationError> {
         validate_transaction_frames(&self.frames, &self.commit)?;
         validate_transaction_semantics(&self.frames, self.commit.transaction_kind)?;
+        validate_transaction_frontiers(&self.affected_frontiers, self.commit.transaction_kind)?;
         if affected_frontiers_root(&self.affected_frontiers) != self.commit.affected_frontiers_root
         {
             return Err(WalValidationError::AffectedFrontiersRootMismatch);
@@ -1002,6 +1015,57 @@ pub struct WriterEpochRequest {
     pub lease_or_lock_evidence: Hash,
 }
 
+fn validate_writer_epoch_request(
+    active_epoch: Option<&WriterEpoch>,
+    closed_epochs: &[WriterEpoch],
+    epoch_closures: &BTreeMap<WriterEpochId, WriterEpochClosure>,
+    request: WriterEpochRequest,
+) -> Result<WriterEpoch, WalStoreError> {
+    if active_epoch.is_some() {
+        return Err(WalStoreError::WriterEpochAlreadyActive);
+    }
+    match request.previous_epoch_id {
+        Some(previous_epoch_id) => {
+            let previous_epoch = closed_epochs
+                .iter()
+                .find(|epoch| epoch.epoch_id == previous_epoch_id)
+                .ok_or(WalStoreError::UnknownPreviousWriterEpoch)?;
+            let previous_closure = epoch_closures
+                .get(&previous_epoch_id)
+                .copied()
+                .unwrap_or_default();
+            if request.previous_epoch_final_commit_digest != previous_closure.final_commit_digest {
+                return Err(WalStoreError::WriterEpochFinalCommitDigestMismatch);
+            }
+            if let Some(final_lsn) = previous_closure.final_lsn {
+                if request.started_at_lsn <= final_lsn {
+                    return Err(WalStoreError::WriterEpochLsnRegression);
+                }
+            }
+            if request.storage_fencing_token == previous_epoch.storage_fencing_token
+                || request.lease_or_lock_evidence == previous_epoch.lease_or_lock_evidence
+            {
+                return Err(WalStoreError::WriterEpochFencingMismatch);
+            }
+        }
+        None => {
+            if !closed_epochs.is_empty() {
+                return Err(WalStoreError::WriterEpochChainGap);
+            }
+        }
+    }
+    Ok(WriterEpoch {
+        epoch_id: request.epoch_id,
+        storage_fencing_token: request.storage_fencing_token,
+        process_identity: request.process_identity,
+        host_identity: request.host_identity,
+        started_at_lsn: request.started_at_lsn,
+        previous_epoch_id: request.previous_epoch_id,
+        previous_epoch_final_commit_digest: request.previous_epoch_final_commit_digest,
+        lease_or_lock_evidence: request.lease_or_lock_evidence,
+    })
+}
+
 /// Segment seal result.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WalSegmentSeal {
@@ -1031,6 +1095,7 @@ pub struct WalManifest {
 pub struct InMemoryWalStore {
     active_epoch: Option<WriterEpoch>,
     closed_epochs: Vec<WriterEpoch>,
+    epoch_closures: BTreeMap<WriterEpochId, WriterEpochClosure>,
     frames: Vec<WalFrame>,
     commits: Vec<WalTransactionCommit>,
     sealed_segments: Vec<WalSegmentSeal>,
@@ -1076,28 +1141,12 @@ impl WalStorePort for InMemoryWalStore {
         &mut self,
         request: WriterEpochRequest,
     ) -> Result<WriterEpoch, WalStoreError> {
-        if self.active_epoch.is_some() {
-            return Err(WalStoreError::WriterEpochAlreadyActive);
-        }
-        if let Some(previous_epoch_id) = request.previous_epoch_id {
-            if self
-                .closed_epochs
-                .iter()
-                .all(|epoch| epoch.epoch_id != previous_epoch_id)
-            {
-                return Err(WalStoreError::UnknownPreviousWriterEpoch);
-            }
-        }
-        let epoch = WriterEpoch {
-            epoch_id: request.epoch_id,
-            storage_fencing_token: request.storage_fencing_token,
-            process_identity: request.process_identity,
-            host_identity: request.host_identity,
-            started_at_lsn: request.started_at_lsn,
-            previous_epoch_id: request.previous_epoch_id,
-            previous_epoch_final_commit_digest: request.previous_epoch_final_commit_digest,
-            lease_or_lock_evidence: request.lease_or_lock_evidence,
-        };
+        let epoch = validate_writer_epoch_request(
+            self.active_epoch.as_ref(),
+            &self.closed_epochs,
+            &self.epoch_closures,
+            request,
+        )?;
         self.active_epoch = Some(epoch.clone());
         Ok(epoch)
     }
@@ -1131,6 +1180,13 @@ impl WalStorePort for InMemoryWalStore {
         if active_epoch.epoch_id != epoch_id || commit.writer_epoch != epoch_id {
             return Err(WalStoreError::WriterEpochMismatch);
         }
+        self.epoch_closures.insert(
+            epoch_id,
+            WriterEpochClosure {
+                final_lsn: Some(commit.last_lsn),
+                final_commit_digest: Some(commit.commit_digest),
+            },
+        );
         self.commits.push(commit);
         Ok(())
     }
@@ -1201,6 +1257,7 @@ impl WalStorePort for InMemoryWalStore {
             self.active_epoch = Some(epoch);
             return Err(WalStoreError::WriterEpochMismatch);
         }
+        self.epoch_closures.entry(epoch_id).or_default();
         self.closed_epochs.push(epoch);
         Ok(())
     }
@@ -1975,6 +2032,7 @@ pub struct FilesystemWalStore {
     segment_id: WalSegmentId,
     active_epoch: Option<WriterEpoch>,
     closed_epochs: Vec<WriterEpoch>,
+    epoch_closures: BTreeMap<WriterEpochId, WriterEpochClosure>,
     manifests: Vec<WalManifest>,
 }
 
@@ -1997,6 +2055,7 @@ impl FilesystemWalStore {
             segment_id,
             active_epoch: None,
             closed_epochs: Vec::new(),
+            epoch_closures: BTreeMap::new(),
             manifests: Vec::new(),
         })
     }
@@ -2041,28 +2100,12 @@ impl WalStorePort for FilesystemWalStore {
         &mut self,
         request: WriterEpochRequest,
     ) -> Result<WriterEpoch, WalStoreError> {
-        if self.active_epoch.is_some() {
-            return Err(WalStoreError::WriterEpochAlreadyActive);
-        }
-        if let Some(previous_epoch_id) = request.previous_epoch_id {
-            if self
-                .closed_epochs
-                .iter()
-                .all(|epoch| epoch.epoch_id != previous_epoch_id)
-            {
-                return Err(WalStoreError::UnknownPreviousWriterEpoch);
-            }
-        }
-        let epoch = WriterEpoch {
-            epoch_id: request.epoch_id,
-            storage_fencing_token: request.storage_fencing_token,
-            process_identity: request.process_identity,
-            host_identity: request.host_identity,
-            started_at_lsn: request.started_at_lsn,
-            previous_epoch_id: request.previous_epoch_id,
-            previous_epoch_final_commit_digest: request.previous_epoch_final_commit_digest,
-            lease_or_lock_evidence: request.lease_or_lock_evidence,
-        };
+        let epoch = validate_writer_epoch_request(
+            self.active_epoch.as_ref(),
+            &self.closed_epochs,
+            &self.epoch_closures,
+            request,
+        )?;
         self.active_epoch = Some(epoch.clone());
         Ok(epoch)
     }
@@ -2095,6 +2138,13 @@ impl WalStorePort for FilesystemWalStore {
         if active_epoch.epoch_id != epoch_id || commit.writer_epoch != epoch_id {
             return Err(WalStoreError::WriterEpochMismatch);
         }
+        self.epoch_closures.insert(
+            epoch_id,
+            WriterEpochClosure {
+                final_lsn: Some(commit.last_lsn),
+                final_commit_digest: Some(commit.commit_digest),
+            },
+        );
         append_segment_record(&self.segment_path(), DiskWalRecord::Commit(&commit), true)
     }
 
@@ -2164,6 +2214,7 @@ impl WalStorePort for FilesystemWalStore {
             self.active_epoch = Some(epoch);
             return Err(WalStoreError::WriterEpochMismatch);
         }
+        self.epoch_closures.entry(epoch_id).or_default();
         self.closed_epochs.push(epoch);
         Ok(())
     }
@@ -2931,6 +2982,7 @@ pub fn recover_from_frames_and_commits(
     commits: &[WalTransactionCommit],
     mode: RecoveryAccessMode,
 ) -> Result<RecoveryScanReport, WalRecoveryError> {
+    validate_recovery_frame_order(frames)?;
     let mut recovered = Vec::new();
     let mut last_committed_lsn = None;
     for commit in commits {
@@ -2966,6 +3018,25 @@ pub fn recover_from_frames_and_commits(
         transactions: recovered,
         tail_posture,
     })
+}
+
+fn validate_recovery_frame_order(frames: &[WalFrame]) -> Result<(), WalValidationError> {
+    let mut sorted = frames.iter().collect::<Vec<_>>();
+    sorted.sort_by_key(|frame| frame.header.lsn);
+    let mut previous_lsn: Option<Lsn> = None;
+    for frame in sorted {
+        frame.validate_integrity()?;
+        if let Some(previous) = previous_lsn {
+            let expected = previous
+                .checked_next()
+                .ok_or(WalValidationError::LsnContinuityMismatch)?;
+            if frame.header.lsn != expected {
+                return Err(WalValidationError::LsnContinuityMismatch);
+            }
+        }
+        previous_lsn = Some(frame.header.lsn);
+    }
+    Ok(())
 }
 
 /// Builds a submission acceptance transaction.
@@ -3499,6 +3570,9 @@ pub enum WalValidationError {
     /// Commit digest mismatch.
     #[error("WAL transaction commit digest mismatch")]
     CommitDigestMismatch,
+    /// Affected frontier kind does not match transaction kind.
+    #[error("WAL transaction affected frontier kind mismatch")]
+    FrontierTransitionKindMismatch,
 }
 
 /// WAL store errors.
@@ -3516,6 +3590,18 @@ pub enum WalStoreError {
     /// Previous writer epoch is unknown.
     #[error("unknown previous WAL writer epoch")]
     UnknownPreviousWriterEpoch,
+    /// A new epoch omitted the previous closed epoch.
+    #[error("WAL writer epoch chain gap")]
+    WriterEpochChainGap,
+    /// Previous epoch final commit digest does not match the closed epoch.
+    #[error("WAL writer epoch final commit digest mismatch")]
+    WriterEpochFinalCommitDigestMismatch,
+    /// New epoch reuses or mismatches storage fencing evidence.
+    #[error("WAL writer epoch fencing mismatch")]
+    WriterEpochFencingMismatch,
+    /// New epoch starts at or before the previous closed epoch final LSN.
+    #[error("WAL writer epoch LSN regression")]
+    WriterEpochLsnRegression,
     /// Validation failed.
     #[error(transparent)]
     Validation(#[from] WalValidationError),
@@ -3724,6 +3810,44 @@ fn validate_transaction_semantics(
         }
     }
     Ok(())
+}
+
+fn validate_transaction_frontiers(
+    frontiers: &[AffectedFrontier],
+    transaction_kind: WalTransactionKind,
+) -> Result<(), WalValidationError> {
+    for frontier in frontiers {
+        if !frontier_kind_allowed_for_transaction(transaction_kind, frontier.kind) {
+            return Err(WalValidationError::FrontierTransitionKindMismatch);
+        }
+    }
+    Ok(())
+}
+
+fn frontier_kind_allowed_for_transaction(
+    transaction_kind: WalTransactionKind,
+    frontier_kind: AffectedFrontierKind,
+) -> bool {
+    match transaction_kind {
+        WalTransactionKind::SubmissionIntake => {
+            matches!(frontier_kind, AffectedFrontierKind::SubmissionQueue)
+        }
+        WalTransactionKind::SchedulerTick => matches!(
+            frontier_kind,
+            AffectedFrontierKind::RuntimeState
+                | AffectedFrontierKind::ReceiptIndex
+                | AffectedFrontierKind::ReadingIndex
+        ),
+        WalTransactionKind::RuntimePosture => {
+            matches!(frontier_kind, AffectedFrontierKind::RuntimeControl)
+        }
+        WalTransactionKind::Checkpoint => {
+            matches!(frontier_kind, AffectedFrontierKind::CheckpointIndex)
+        }
+        WalTransactionKind::MaterializationOutbox => {
+            matches!(frontier_kind, AffectedFrontierKind::ReceiptIndex)
+        }
+    }
 }
 
 fn records_root(frames: &[WalFrame]) -> Hash {

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -2025,6 +2025,21 @@ pub struct WalDoctorReport {
     pub tail_posture: RecoveryTailPosture,
 }
 
+impl WalDoctorReport {
+    /// Stable report field names for CLI/MCP adapters.
+    #[must_use]
+    pub const fn stable_field_names() -> &'static [&'static str] {
+        &[
+            "posture",
+            "tail_posture",
+            "committed_transactions_replayed",
+            "obstruction_count",
+            "recovered_frontier_root",
+            "recovered_indexes_root",
+        ]
+    }
+}
+
 /// Local filesystem WAL store backed by segment files.
 #[derive(Clone, Debug)]
 pub struct FilesystemWalStore {
@@ -2262,21 +2277,11 @@ pub fn recover_filesystem_store(
 pub fn doctor_filesystem_store(
     root: impl AsRef<Path>,
 ) -> Result<WalDoctorReport, WalRecoveryError> {
-    let report = recover_filesystem_store(root, RecoveryAccessMode::ReadOnly)?;
-    let posture = match report.tail_posture {
-        RecoveryTailPosture::Clean => WalDoctorPosture::Recoverable,
-        RecoveryTailPosture::WouldTruncateAll | RecoveryTailPosture::WouldTruncateAfter(_) => {
-            WalDoctorPosture::RecoverableWithUncommittedTail
-        }
-        RecoveryTailPosture::TruncatedAll | RecoveryTailPosture::TruncatedAfter(_) => {
-            WalDoctorPosture::Obstructed
-        }
+    let report = match recover_filesystem_store(root, RecoveryAccessMode::ReadOnly) {
+        Ok(report) => report,
+        Err(_) => return Ok(obstructed_doctor_report()),
     };
-    Ok(WalDoctorReport {
-        posture,
-        recovery_certificate: build_recovery_certificate(&report, None, 0, [0; 32], [0; 32]),
-        tail_posture: report.tail_posture,
-    })
+    Ok(doctor_report_from_scan(report, 0, [0; 32], [0; 32]))
 }
 
 /// Object-store read-after-write posture required by strict object storage.
@@ -2604,16 +2609,172 @@ pub fn project_causal_commit_evidence(report: &RecoveryScanReport) -> Vec<Causal
         .collect()
 }
 
+/// Projects explicit absent causal commit evidence.
+#[must_use]
+pub fn project_absent_causal_commit_evidence(
+    evidence_id: Hash,
+    durability_mode: WalDurabilityMode,
+) -> CausalCommitEvidence {
+    CausalCommitEvidence {
+        evidence_id,
+        posture: CausalCommitEvidencePosture::Absent,
+        source: CausalCommitEvidenceSource::EchoWal,
+        durability_mode,
+        writer_epoch: WriterEpochId::from_hash([0; 32]),
+        lsn: Lsn::from_raw(0),
+        transaction_id: WalTransactionId::from_hash([0; 32]),
+        commit_digest: [0; 32],
+        checkpoint_digest: None,
+        recovery_certificate_digest: None,
+        obstruction_digest: None,
+    }
+}
+
+/// Projects obstructed causal commit evidence for a known commit anchor.
+#[must_use]
+pub fn project_obstructed_causal_commit_evidence(
+    commit: &WalTransactionCommit,
+    obstruction_digest: Hash,
+) -> CausalCommitEvidence {
+    CausalCommitEvidence {
+        evidence_id: causal_commit_evidence_id(commit),
+        posture: CausalCommitEvidencePosture::Obstructed,
+        source: CausalCommitEvidenceSource::EchoWal,
+        durability_mode: commit.durability_mode,
+        writer_epoch: commit.writer_epoch,
+        lsn: commit.last_lsn,
+        transaction_id: commit.transaction_id,
+        commit_digest: commit.commit_digest,
+        checkpoint_digest: None,
+        recovery_certificate_digest: None,
+        obstruction_digest: Some(obstruction_digest),
+    }
+}
+
+/// Shadow replay mismatch classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShadowReplayMismatch {
+    /// Applied transaction count differs.
+    AppliedTransactionCount {
+        /// Live applied transaction count.
+        live: usize,
+        /// Replayed applied transaction count.
+        replayed: usize,
+    },
+    /// Applied transaction id differs at the first mismatching index.
+    AppliedTransaction {
+        /// First mismatching index.
+        index: usize,
+        /// Live transaction id.
+        live: WalTransactionId,
+        /// Replayed transaction id.
+        replayed: WalTransactionId,
+    },
+    /// Live state is missing a frontier present in replay.
+    MissingLiveFrontier {
+        /// Frontier kind.
+        kind: AffectedFrontierKind,
+    },
+    /// Replay state is missing a frontier present in live state.
+    MissingReplayedFrontier {
+        /// Frontier kind.
+        kind: AffectedFrontierKind,
+    },
+    /// Frontier digest differs.
+    FrontierDigest {
+        /// Frontier kind.
+        kind: AffectedFrontierKind,
+        /// Live frontier digest.
+        live: Hash,
+        /// Replayed frontier digest.
+        replayed: Hash,
+    },
+}
+
+/// Shadow replay comparison report.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShadowReplayReport {
+    /// `true` when live and replayed state match exactly.
+    pub matches: bool,
+    /// First mismatch, when present.
+    pub first_mismatch: Option<ShadowReplayMismatch>,
+    /// Replayed state produced from committed transactions.
+    pub replayed_state: RecoveredState,
+}
+
 /// Checks that live state and WAL replay produce the same recovered state.
 pub fn shadow_replay_matches(
     live_state: &RecoveredState,
     transactions: &[WalCommittedTransaction],
 ) -> Result<bool, WalReplayError> {
+    Ok(shadow_replay_report(live_state, transactions)?.matches)
+}
+
+/// Reports whether live state and WAL replay produce the same recovered state.
+pub fn shadow_replay_report(
+    live_state: &RecoveredState,
+    transactions: &[WalCommittedTransaction],
+) -> Result<ShadowReplayReport, WalReplayError> {
     let mut replayed = RecoveredState::default();
     for transaction in transactions {
         replayed = apply_committed_transaction(replayed, transaction)?;
     }
-    Ok(&replayed == live_state)
+    let first_mismatch = first_shadow_replay_mismatch(live_state, &replayed);
+    Ok(ShadowReplayReport {
+        matches: first_mismatch.is_none(),
+        first_mismatch,
+        replayed_state: replayed,
+    })
+}
+
+fn first_shadow_replay_mismatch(
+    live_state: &RecoveredState,
+    replayed_state: &RecoveredState,
+) -> Option<ShadowReplayMismatch> {
+    if live_state.applied_transactions.len() != replayed_state.applied_transactions.len() {
+        return Some(ShadowReplayMismatch::AppliedTransactionCount {
+            live: live_state.applied_transactions.len(),
+            replayed: replayed_state.applied_transactions.len(),
+        });
+    }
+    for (index, (live, replayed)) in live_state
+        .applied_transactions
+        .iter()
+        .zip(&replayed_state.applied_transactions)
+        .enumerate()
+    {
+        if live != replayed {
+            return Some(ShadowReplayMismatch::AppliedTransaction {
+                index,
+                live: *live,
+                replayed: *replayed,
+            });
+        }
+    }
+    let frontier_kinds = live_state
+        .frontiers
+        .keys()
+        .chain(replayed_state.frontiers.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    for kind in frontier_kinds {
+        match (
+            live_state.frontiers.get(&kind),
+            replayed_state.frontiers.get(&kind),
+        ) {
+            (Some(live), Some(replayed)) if live != replayed => {
+                return Some(ShadowReplayMismatch::FrontierDigest {
+                    kind,
+                    live: *live,
+                    replayed: *replayed,
+                });
+            }
+            (None, Some(_)) => return Some(ShadowReplayMismatch::MissingLiveFrontier { kind }),
+            (Some(_), None) => return Some(ShadowReplayMismatch::MissingReplayedFrontier { kind }),
+            _ => {}
+        }
+    }
+    None
 }
 
 /// WAL release readiness audit result.
@@ -3397,21 +3558,87 @@ pub fn doctor_in_memory_store(
 ) -> Result<WalDoctorReport, WalRecoveryError> {
     let frames = store.read_frames();
     let commits = store.read_commits();
-    let report = recover_from_frames_and_commits(&frames, &commits, RecoveryAccessMode::ReadOnly)?;
-    let posture = match report.tail_posture {
-        RecoveryTailPosture::Clean => WalDoctorPosture::Recoverable,
-        RecoveryTailPosture::WouldTruncateAll | RecoveryTailPosture::WouldTruncateAfter(_) => {
-            WalDoctorPosture::RecoverableWithUncommittedTail
-        }
-        RecoveryTailPosture::TruncatedAll | RecoveryTailPosture::TruncatedAfter(_) => {
-            WalDoctorPosture::Obstructed
+    let report =
+        match recover_from_frames_and_commits(&frames, &commits, RecoveryAccessMode::ReadOnly) {
+            Ok(report) => report,
+            Err(_) => return Ok(obstructed_doctor_report()),
+        };
+    Ok(doctor_report_from_scan(report, 0, [0; 32], [0; 32]))
+}
+
+/// Runs a read-only WAL doctor over an in-memory store and available material set.
+pub fn doctor_in_memory_store_with_materials(
+    store: &InMemoryWalStore,
+    available_material: &BTreeSet<Hash>,
+) -> Result<WalDoctorReport, WalRecoveryError> {
+    let frames = store.read_frames();
+    let commits = store.read_commits();
+    let report =
+        match recover_from_frames_and_commits(&frames, &commits, RecoveryAccessMode::ReadOnly) {
+            Ok(report) => report,
+            Err(_) => return Ok(obstructed_doctor_report()),
+        };
+    let retention = recover_retention_index(&report)?;
+    let obstruction_count = retained_material_obstructions(&retention, available_material)
+        .into_iter()
+        .filter(|obstruction| obstruction.scope != MissingMaterialScope::DiagnosticLoss)
+        .count();
+    Ok(doctor_report_from_scan(
+        report,
+        len_u64(obstruction_count),
+        [0; 32],
+        [0; 32],
+    ))
+}
+
+fn obstructed_doctor_report() -> WalDoctorReport {
+    WalDoctorReport {
+        posture: WalDoctorPosture::Obstructed,
+        recovery_certificate: RecoveryCertificate {
+            checkpoint_used: None,
+            first_lsn: None,
+            last_lsn: None,
+            committed_transactions_replayed: 0,
+            tail_posture: RecoveryTailPosture::Clean,
+            obstruction_count: 1,
+            recovered_frontier_root: [0; 32],
+            recovered_indexes_root: [0; 32],
+        },
+        tail_posture: RecoveryTailPosture::Clean,
+    }
+}
+
+fn doctor_report_from_scan(
+    report: RecoveryScanReport,
+    obstruction_count: u64,
+    recovered_frontier_root: Hash,
+    recovered_indexes_root: Hash,
+) -> WalDoctorReport {
+    let posture = if obstruction_count > 0 {
+        WalDoctorPosture::Obstructed
+    } else {
+        match report.tail_posture {
+            RecoveryTailPosture::Clean => WalDoctorPosture::Recoverable,
+            RecoveryTailPosture::WouldTruncateAll | RecoveryTailPosture::WouldTruncateAfter(_) => {
+                WalDoctorPosture::RecoverableWithUncommittedTail
+            }
+            RecoveryTailPosture::TruncatedAll | RecoveryTailPosture::TruncatedAfter(_) => {
+                WalDoctorPosture::Obstructed
+            }
         }
     };
-    Ok(WalDoctorReport {
+    let tail_posture = report.tail_posture;
+    WalDoctorReport {
         posture,
-        recovery_certificate: build_recovery_certificate(&report, None, 0, [0; 32], [0; 32]),
-        tail_posture: report.tail_posture,
-    })
+        recovery_certificate: build_recovery_certificate(
+            &report,
+            None,
+            obstruction_count,
+            recovered_frontier_root,
+            recovered_indexes_root,
+        ),
+        tail_posture,
+    }
 }
 
 /// Minimal recovered state used by the pure replay reducer.
@@ -3648,6 +3875,9 @@ pub enum WalRecoveryError {
     /// Store operation failed.
     #[error(transparent)]
     Store(#[from] WalStoreError),
+    /// Recovered index construction failed.
+    #[error(transparent)]
+    Index(#[from] WalRecoveryIndexError),
 }
 
 /// WAL replay errors.

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -1090,6 +1090,186 @@ pub struct WalManifest {
     pub sealed_segment_count: u64,
 }
 
+/// Canonical crashpoint execution posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalCrashpointExecution {
+    /// Crashpoint is simulated in-process by Rust fixtures.
+    SimulatedInProcess,
+    /// Crashpoint is reserved for a future process-kill runner.
+    ProcessKillFuture,
+}
+
+/// Canonical WAL crashpoint boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalCrashpointBoundary {
+    /// Submission intake boundary.
+    Submission,
+    /// Scheduler-owned tick boundary.
+    Tick,
+    /// Checkpoint publication boundary.
+    Checkpoint,
+    /// Retained material or side-effect materialization boundary.
+    Material,
+    /// Index publication boundary.
+    Index,
+    /// Future process-kill runner boundary.
+    Process,
+}
+
+/// Canonical crashpoint descriptor used by tests and future CLI/BATS runners.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WalCrashpointDescriptor {
+    /// Stable crashpoint name.
+    pub name: &'static str,
+    /// Boundary family.
+    pub boundary: WalCrashpointBoundary,
+    /// Execution posture.
+    pub execution: WalCrashpointExecution,
+}
+
+const WAL_CRASHPOINT_MANIFEST: &[WalCrashpointDescriptor] = &[
+    WalCrashpointDescriptor {
+        name: "submission.before_commit",
+        boundary: WalCrashpointBoundary::Submission,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "submission.after_commit_before_ack",
+        boundary: WalCrashpointBoundary::Submission,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "tick.before_commit",
+        boundary: WalCrashpointBoundary::Tick,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "tick.after_commit_before_publish",
+        boundary: WalCrashpointBoundary::Tick,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "checkpoint.before_rename",
+        boundary: WalCrashpointBoundary::Checkpoint,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "checkpoint.after_rename_before_publication",
+        boundary: WalCrashpointBoundary::Checkpoint,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "material.before_wal_reference",
+        boundary: WalCrashpointBoundary::Material,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "material.after_effect_before_observation",
+        boundary: WalCrashpointBoundary::Material,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "index.before_publish",
+        boundary: WalCrashpointBoundary::Index,
+        execution: WalCrashpointExecution::SimulatedInProcess,
+    },
+    WalCrashpointDescriptor {
+        name: "process.kill.after_wal_commit",
+        boundary: WalCrashpointBoundary::Process,
+        execution: WalCrashpointExecution::ProcessKillFuture,
+    },
+];
+
+/// Returns the canonical WAL crashpoint manifest.
+#[must_use]
+pub const fn wal_crashpoint_manifest() -> &'static [WalCrashpointDescriptor] {
+    WAL_CRASHPOINT_MANIFEST
+}
+
+/// Filesystem sync boundary evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FilesystemSyncBoundary {
+    /// Segment file was created and synced.
+    SegmentFileCreated,
+    /// Containing directory was synced after segment creation.
+    SegmentDirectorySynced,
+    /// Commit marker append synced the WAL segment file.
+    CommitFileSynced,
+    /// Manifest temp file was synced before rename.
+    ManifestTempFileSynced,
+    /// Containing directory was synced after manifest rename.
+    ManifestRenamedDirectorySynced,
+    /// Checkpoint temp file was synced before rename.
+    CheckpointTempFileSynced,
+    /// Containing directory was synced after checkpoint rename.
+    CheckpointRenamedDirectorySynced,
+}
+
+/// Filesystem sync evidence emitted by strict filesystem helpers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FilesystemSyncEvidence {
+    /// Sync boundary.
+    pub boundary: FilesystemSyncBoundary,
+    /// Segment id, when the boundary is segment-scoped.
+    pub segment_id: Option<WalSegmentId>,
+    /// Transaction id, when the boundary is commit-scoped.
+    pub transaction_id: Option<WalTransactionId>,
+}
+
+impl FilesystemSyncEvidence {
+    const fn segment(boundary: FilesystemSyncBoundary, segment_id: WalSegmentId) -> Self {
+        Self {
+            boundary,
+            segment_id: Some(segment_id),
+            transaction_id: None,
+        }
+    }
+
+    const fn transaction(
+        boundary: FilesystemSyncBoundary,
+        transaction_id: WalTransactionId,
+    ) -> Self {
+        Self {
+            boundary,
+            segment_id: None,
+            transaction_id: Some(transaction_id),
+        }
+    }
+
+    const fn unscoped(boundary: FilesystemSyncBoundary) -> Self {
+        Self {
+            boundary,
+            segment_id: None,
+            transaction_id: None,
+        }
+    }
+}
+
+/// Filesystem sync evidence validation error.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum FilesystemSyncEvidenceError {
+    /// Required sync evidence was missing.
+    #[error("strict filesystem WAL missing sync evidence for {0:?}")]
+    Missing(FilesystemSyncBoundary),
+}
+
+/// Validates strict filesystem sync evidence for required boundaries.
+pub fn validate_filesystem_strict_sync_evidence(
+    evidence: &[FilesystemSyncEvidence],
+    required: &[FilesystemSyncBoundary],
+) -> Result<(), FilesystemSyncEvidenceError> {
+    let present = evidence
+        .iter()
+        .map(|entry| entry.boundary)
+        .collect::<BTreeSet<_>>();
+    for boundary in required {
+        if !present.contains(boundary) {
+            return Err(FilesystemSyncEvidenceError::Missing(*boundary));
+        }
+    }
+    Ok(())
+}
+
 /// Deterministic in-memory WAL store.
 #[derive(Clone, Debug, Default)]
 pub struct InMemoryWalStore {
@@ -1589,6 +1769,40 @@ impl EvidenceMaterialPosture {
     }
 }
 
+/// Inspector-facing material posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MaterialInspectionPosture {
+    /// Material is available.
+    Present,
+    /// Material is intentionally hidden by policy.
+    PolicyHidden,
+    /// Material is encrypted and the key is unavailable.
+    EncryptedKeyUnavailable,
+    /// Material is missing from storage.
+    Missing,
+    /// Material bytes are corrupt.
+    Corrupt,
+    /// Material is blocked by runtime or causal posture.
+    Obstructed,
+}
+
+/// Converts retained material posture into an explicit inspector posture.
+#[must_use]
+pub const fn inspect_evidence_material_posture(
+    posture: EvidenceMaterialPosture,
+) -> MaterialInspectionPosture {
+    match posture {
+        EvidenceMaterialPosture::Present => MaterialInspectionPosture::Present,
+        EvidenceMaterialPosture::RedactedByPolicy => MaterialInspectionPosture::PolicyHidden,
+        EvidenceMaterialPosture::EncryptedKeyUnavailable => {
+            MaterialInspectionPosture::EncryptedKeyUnavailable
+        }
+        EvidenceMaterialPosture::Missing => MaterialInspectionPosture::Missing,
+        EvidenceMaterialPosture::Corrupt => MaterialInspectionPosture::Corrupt,
+        EvidenceMaterialPosture::Obstructed => MaterialInspectionPosture::Obstructed,
+    }
+}
+
 /// WAL retained material reference payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RetainedMaterialRecord {
@@ -2049,6 +2263,7 @@ pub struct FilesystemWalStore {
     closed_epochs: Vec<WriterEpoch>,
     epoch_closures: BTreeMap<WriterEpochId, WriterEpochClosure>,
     manifests: Vec<WalManifest>,
+    sync_evidence: Vec<FilesystemSyncEvidence>,
 }
 
 impl FilesystemWalStore {
@@ -2061,9 +2276,18 @@ impl FilesystemWalStore {
         let root = root.as_ref().to_path_buf();
         fs::create_dir_all(&root)?;
         let segment_path = segment_path(&root, segment_id);
+        let mut sync_evidence = Vec::new();
         if !segment_path.exists() {
             File::create(&segment_path)?.sync_all()?;
+            sync_evidence.push(FilesystemSyncEvidence::segment(
+                FilesystemSyncBoundary::SegmentFileCreated,
+                segment_id,
+            ));
             sync_directory_store(&root)?;
+            sync_evidence.push(FilesystemSyncEvidence::segment(
+                FilesystemSyncBoundary::SegmentDirectorySynced,
+                segment_id,
+            ));
         }
         Ok(Self {
             root,
@@ -2072,6 +2296,7 @@ impl FilesystemWalStore {
             closed_epochs: Vec::new(),
             epoch_closures: BTreeMap::new(),
             manifests: Vec::new(),
+            sync_evidence,
         })
     }
 
@@ -2085,6 +2310,12 @@ impl FilesystemWalStore {
     #[must_use]
     pub fn root(&self) -> &Path {
         &self.root
+    }
+
+    /// Returns strict filesystem sync evidence observed by this store.
+    #[must_use]
+    pub fn sync_evidence(&self) -> &[FilesystemSyncEvidence] {
+        &self.sync_evidence
     }
 
     /// Appends and flushes a committed transaction.
@@ -2160,7 +2391,13 @@ impl WalStorePort for FilesystemWalStore {
                 final_commit_digest: Some(commit.commit_digest),
             },
         );
-        append_segment_record(&self.segment_path(), DiskWalRecord::Commit(&commit), true)
+        let transaction_id = commit.transaction_id;
+        append_segment_record(&self.segment_path(), DiskWalRecord::Commit(&commit), true)?;
+        self.sync_evidence.push(FilesystemSyncEvidence::transaction(
+            FilesystemSyncBoundary::CommitFileSynced,
+            transaction_id,
+        ));
+        Ok(())
     }
 
     fn read_frames(&self) -> Vec<WalFrame> {
@@ -2216,6 +2453,12 @@ impl WalStorePort for FilesystemWalStore {
             return Err(WalStoreError::WriterEpochMismatch);
         }
         write_manifest_atomic(&self.root, &manifest)?;
+        self.sync_evidence.push(FilesystemSyncEvidence::unscoped(
+            FilesystemSyncBoundary::ManifestTempFileSynced,
+        ));
+        self.sync_evidence.push(FilesystemSyncEvidence::unscoped(
+            FilesystemSyncBoundary::ManifestRenamedDirectorySynced,
+        ));
         self.manifests.push(manifest);
         Ok(())
     }
@@ -2321,6 +2564,9 @@ pub enum ObjectStoreCapabilityError {
     /// Strict object stores must prove read-after-write behavior.
     #[error("strict object store requires verified read-after-write posture")]
     MissingReadAfterWrite,
+    /// Strict object stores must not overwrite manifests unconditionally.
+    #[error("strict object store manifest commit must be conditional compare-and-swap")]
+    UnconditionalManifestOverwrite,
 }
 
 /// Validates strict object-store WAL adapter capabilities.
@@ -2338,6 +2584,38 @@ pub fn validate_strict_object_store_capabilities(
     }
     if capabilities.read_after_write != ObjectStoreReadAfterWritePosture::Verified {
         return Err(ObjectStoreCapabilityError::MissingReadAfterWrite);
+    }
+    Ok(())
+}
+
+/// Object-store manifest commit mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ObjectStoreManifestCommitMode {
+    /// Manifest publication uses compare-and-swap against an expected previous digest.
+    ConditionalCompareAndSwap,
+    /// Manifest publication overwrites without an expected previous digest.
+    UnconditionalOverwrite,
+}
+
+/// Object-store manifest commit shape.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ObjectStoreManifestCommitShape {
+    /// Commit mode.
+    pub mode: ObjectStoreManifestCommitMode,
+    /// Expected previous manifest digest for compare-and-swap.
+    pub expected_previous_manifest_digest: Option<Hash>,
+    /// New manifest digest.
+    pub new_manifest_digest: Hash,
+}
+
+/// Validates the strict object-store manifest commit shape.
+pub fn validate_strict_object_store_manifest_commit(
+    shape: ObjectStoreManifestCommitShape,
+) -> Result<(), ObjectStoreCapabilityError> {
+    if shape.mode != ObjectStoreManifestCommitMode::ConditionalCompareAndSwap
+        || shape.expected_previous_manifest_digest.is_none()
+    {
+        return Err(ObjectStoreCapabilityError::UnconditionalManifestOverwrite);
     }
     Ok(())
 }
@@ -2820,6 +3098,12 @@ pub fn audit_wal_release_readiness(gates: WalReleaseReadinessGates) -> WalReleas
     push_gate(
         &mut passed_gates,
         &mut blocked_gates,
+        "crashpoint_manifest",
+        gates.crashpoint_manifest,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
         "shadow_replay",
         gates.shadow_replay,
     );
@@ -2834,6 +3118,42 @@ pub fn audit_wal_release_readiness(gates: WalReleaseReadinessGates) -> WalReleas
         &mut blocked_gates,
         "commit_evidence",
         gates.commit_evidence,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "wal_doctor",
+        gates.wal_doctor,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "semantic_validator",
+        gates.semantic_validator,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "filesystem_sync_evidence",
+        gates.filesystem_sync_evidence,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "object_store_manifest_negatives",
+        gates.object_store_manifest_negatives,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "security_redaction",
+        gates.security_redaction,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
+        "app_noun_guard",
+        gates.app_noun_guard,
     );
     push_gate(
         &mut passed_gates,
@@ -2860,12 +3180,26 @@ pub struct WalReleaseReadinessGates {
     pub segment_repair: bool,
     /// Crash matrix gate.
     pub crash_matrix: bool,
+    /// Crashpoint manifest gate.
+    pub crashpoint_manifest: bool,
     /// Shadow replay gate.
     pub shadow_replay: bool,
     /// Side-effect outbox gate.
     pub outbox: bool,
     /// Causal commit evidence projection gate.
     pub commit_evidence: bool,
+    /// WAL doctor/inspector gate.
+    pub wal_doctor: bool,
+    /// Semantic validator gate.
+    pub semantic_validator: bool,
+    /// Strict filesystem sync evidence gate.
+    pub filesystem_sync_evidence: bool,
+    /// Object-store manifest negative matrix gate.
+    pub object_store_manifest_negatives: bool,
+    /// Security and redaction posture gate.
+    pub security_redaction: bool,
+    /// No-app-nouns guard gate.
+    pub app_noun_guard: bool,
     /// External consumer recovery gate.
     pub external_consumer_gate: bool,
 }
@@ -3282,6 +3616,14 @@ pub fn write_checkpoint_record_atomic(
     path: impl AsRef<Path>,
     checkpoint: &CheckpointRecord,
 ) -> Result<(), WalCheckpointIoError> {
+    write_checkpoint_record_atomic_with_evidence(path, checkpoint).map(|_| ())
+}
+
+/// Writes a checkpoint file and returns strict filesystem sync evidence.
+pub fn write_checkpoint_record_atomic_with_evidence(
+    path: impl AsRef<Path>,
+    checkpoint: &CheckpointRecord,
+) -> Result<Vec<FilesystemSyncEvidence>, WalCheckpointIoError> {
     let path = path.as_ref();
     let parent = path
         .parent()
@@ -3296,7 +3638,10 @@ pub fn write_checkpoint_record_atomic(
     }
     fs::rename(&temp_path, path)?;
     sync_directory(parent)?;
-    Ok(())
+    Ok(vec![
+        FilesystemSyncEvidence::unscoped(FilesystemSyncBoundary::CheckpointTempFileSynced),
+        FilesystemSyncEvidence::unscoped(FilesystemSyncBoundary::CheckpointRenamedDirectorySynced),
+    ])
 }
 
 /// Reads a checkpoint file written by [`write_checkpoint_record_atomic`].

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -32,6 +32,7 @@ const WAL_FRAME_CHECKSUM_DOMAIN: &[u8] = b"echo:causal_wal:frame_checksum:v1\0";
 const WAL_DISK_RECORD_DOMAIN: &[u8] = b"echo:causal_wal:disk_record:v1\0";
 const CHECKPOINT_FILE_MAGIC: &[u8; 8] = b"ECWALCP1";
 const WAL_SEGMENT_RECORD_MAGIC: &[u8; 8] = b"ECWALR1!";
+const WAL_SEGMENTS_DIR: &str = "segments";
 
 /// Current in-memory causal WAL version.
 pub const CAUSAL_WAL_VERSION: u16 = 1;
@@ -1077,6 +1078,93 @@ pub struct WalSegmentSeal {
     pub segment_digest: Hash,
 }
 
+/// Segment placement family.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalSegmentPlacementKind {
+    /// Placement is derived from logical segment id.
+    CausalSegmentId,
+    /// Placement is derived from wall-clock bucketing.
+    WallClockPartition,
+}
+
+/// Segment placement policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WalSegmentPlacementPolicy {
+    /// Placement family.
+    pub kind: WalSegmentPlacementKind,
+    /// `true` if placement participates in authoritative WAL identity.
+    pub authoritative: bool,
+}
+
+/// Segment placement policy error.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalSegmentPlacementPolicyError {
+    /// Wall-clock placement cannot define authoritative WAL identity.
+    #[error("wall-clock WAL segment placement cannot be authoritative")]
+    WallClockPlacementCannotBeAuthoritative,
+}
+
+/// Validates a segment placement policy.
+pub fn validate_segment_placement_policy(
+    policy: WalSegmentPlacementPolicy,
+) -> Result<(), WalSegmentPlacementPolicyError> {
+    if policy.kind == WalSegmentPlacementKind::WallClockPartition && policy.authoritative {
+        return Err(WalSegmentPlacementPolicyError::WallClockPlacementCannotBeAuthoritative);
+    }
+    Ok(())
+}
+
+/// Segment id arithmetic error.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalSegmentIdError {
+    /// Segment id overflowed.
+    #[error("WAL segment id overflow")]
+    Overflow,
+}
+
+/// Returns the next logical segment id.
+pub fn next_segment_id(previous: Option<WalSegmentId>) -> Result<WalSegmentId, WalSegmentIdError> {
+    let Some(previous) = previous else {
+        return Ok(WalSegmentId::from_raw(1));
+    };
+    previous
+        .as_u64()
+        .checked_add(1)
+        .map(WalSegmentId::from_raw)
+        .ok_or(WalSegmentIdError::Overflow)
+}
+
+/// Segment manifest entry derived from logical identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalSegmentManifestEntry {
+    /// Logical segment id.
+    pub segment_id: WalSegmentId,
+    /// Canonical relative path.
+    pub relative_path: PathBuf,
+    /// Segment digest.
+    pub segment_digest: Hash,
+    /// First LSN included in the segment.
+    pub first_lsn: Option<Lsn>,
+    /// Last LSN included in the segment.
+    pub last_lsn: Option<Lsn>,
+}
+
+/// Builds a segment manifest entry from segment frames.
+#[must_use]
+pub fn segment_manifest_entry(
+    segment_id: WalSegmentId,
+    frames: &[WalFrame],
+) -> WalSegmentManifestEntry {
+    let frame_refs = frames.iter().collect::<Vec<_>>();
+    WalSegmentManifestEntry {
+        segment_id,
+        relative_path: canonical_segment_relative_path(segment_id),
+        segment_digest: segment_digest(segment_id, &frame_refs),
+        first_lsn: frames.iter().map(|frame| frame.header.lsn).min(),
+        last_lsn: frames.iter().map(|frame| frame.header.lsn).max(),
+    }
+}
+
 /// Published WAL manifest.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WalManifest {
@@ -1189,6 +1277,8 @@ pub const fn wal_crashpoint_manifest() -> &'static [WalCrashpointDescriptor] {
 /// Filesystem sync boundary evidence.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FilesystemSyncBoundary {
+    /// WAL root directory was synced after creating the segment namespace.
+    SegmentNamespaceDirectorySynced,
     /// Segment file was created and synced.
     SegmentFileCreated,
     /// Containing directory was synced after segment creation.
@@ -2275,15 +2365,24 @@ impl FilesystemWalStore {
     pub fn open(root: impl AsRef<Path>, segment_id: WalSegmentId) -> Result<Self, WalStoreError> {
         let root = root.as_ref().to_path_buf();
         fs::create_dir_all(&root)?;
+        let segments_dir = segments_dir(&root);
+        let segments_dir_existed = segments_dir.exists();
+        fs::create_dir_all(&segments_dir)?;
         let segment_path = segment_path(&root, segment_id);
         let mut sync_evidence = Vec::new();
+        if !segments_dir_existed {
+            sync_directory_store(&root)?;
+            sync_evidence.push(FilesystemSyncEvidence::unscoped(
+                FilesystemSyncBoundary::SegmentNamespaceDirectorySynced,
+            ));
+        }
         if !segment_path.exists() {
             File::create(&segment_path)?.sync_all()?;
             sync_evidence.push(FilesystemSyncEvidence::segment(
                 FilesystemSyncBoundary::SegmentFileCreated,
                 segment_id,
             ));
-            sync_directory_store(&root)?;
+            sync_directory_store(&segments_dir)?;
             sync_evidence.push(FilesystemSyncEvidence::segment(
                 FilesystemSyncBoundary::SegmentDirectorySynced,
                 segment_id,
@@ -3092,6 +3191,12 @@ pub fn audit_wal_release_readiness(gates: WalReleaseReadinessGates) -> WalReleas
     push_gate(
         &mut passed_gates,
         &mut blocked_gates,
+        "segment_layout_policy",
+        gates.segment_layout_policy,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
         "crash_matrix",
         gates.crash_matrix,
     );
@@ -3178,6 +3283,8 @@ pub struct WalReleaseReadinessGates {
     pub object_store_capability_gate: bool,
     /// Segment repair/truncation gate.
     pub segment_repair: bool,
+    /// Segment layout policy gate.
+    pub segment_layout_policy: bool,
     /// Crash matrix gate.
     pub crash_matrix: bool,
     /// Crashpoint manifest gate.
@@ -3338,6 +3445,7 @@ fn rewrite_segment_records(
     commits: &[WalTransactionCommit],
 ) -> Result<(), WalStoreError> {
     fs::create_dir_all(root)?;
+    fs::create_dir_all(segments_dir(root))?;
     for path in segment_paths(root)? {
         fs::remove_file(path)?;
     }
@@ -3356,19 +3464,24 @@ fn rewrite_segment_records(
 
 fn segment_paths(root: &Path) -> Result<Vec<PathBuf>, WalStoreError> {
     let mut paths = Vec::new();
-    for entry in fs::read_dir(root)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path
-            .file_stem()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.starts_with("segment-"))
-            && path
-                .extension()
-                .is_some_and(|extension| extension.eq_ignore_ascii_case("ecwal"))
-        {
-            let segment_id = parse_segment_id(&path)?;
-            paths.push((segment_id, path));
+    for scan_root in segment_scan_roots(root) {
+        if !scan_root.exists() {
+            continue;
+        }
+        for entry in fs::read_dir(scan_root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("segment-"))
+                && path
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("ecwal"))
+            {
+                let segment_id = parse_segment_id(&path)?;
+                paths.push((segment_id, path));
+            }
         }
     }
     paths.sort_by_key(|(segment_id, path)| (*segment_id, path.clone()));
@@ -3400,8 +3513,38 @@ fn segment_paths(root: &Path) -> Result<Vec<PathBuf>, WalStoreError> {
     Ok(paths.into_iter().map(|(_, path)| path).collect())
 }
 
+/// Returns the canonical segment path relative to the WAL root.
+#[must_use]
+pub fn canonical_segment_relative_path(segment_id: WalSegmentId) -> PathBuf {
+    PathBuf::from(WAL_SEGMENTS_DIR).join(segment_file_name(segment_id))
+}
+
+/// Returns the canonical segment path for a WAL root.
+#[must_use]
+pub fn canonical_segment_path(root: impl AsRef<Path>, segment_id: WalSegmentId) -> PathBuf {
+    root.as_ref()
+        .join(canonical_segment_relative_path(segment_id))
+}
+
 fn segment_path(root: &Path, segment_id: WalSegmentId) -> PathBuf {
-    root.join(format!("segment-{:020}.ecwal", segment_id.as_u64()))
+    canonical_segment_path(root, segment_id)
+}
+
+fn segments_dir(root: &Path) -> PathBuf {
+    root.join(WAL_SEGMENTS_DIR)
+}
+
+fn segment_scan_roots(root: &Path) -> Vec<PathBuf> {
+    let canonical = segments_dir(root);
+    if canonical.exists() {
+        vec![canonical, root.to_path_buf()]
+    } else {
+        vec![root.to_path_buf()]
+    }
+}
+
+fn segment_file_name(segment_id: WalSegmentId) -> String {
+    format!("segment-{:020}.ecwal", segment_id.as_u64())
 }
 
 fn parse_segment_id(path: &Path) -> Result<WalSegmentId, WalStoreError> {

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -1,0 +1,1581 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Echo-owned causal write-ahead log primitives.
+//!
+//! This module is the first in-memory foundation for the causal WAL described in
+//! `docs/design/causal-wal-end-to-end.md`. It deliberately stops short of
+//! filesystem durability and live scheduler integration. The core invariant is
+//! already enforced here:
+//!
+//! ```text
+//! Records are recorded.
+//! Transactions are committed.
+//! History begins at WalTransactionCommit.
+//! ```
+
+use std::collections::BTreeMap;
+
+use thiserror::Error;
+
+use crate::ident::Hash;
+
+const WAL_FRAME_DOMAIN: &[u8] = b"echo:causal_wal:frame:v1\0";
+const WAL_PAYLOAD_DOMAIN: &[u8] = b"echo:causal_wal:payload:v1\0";
+const WAL_RECORDS_ROOT_DOMAIN: &[u8] = b"echo:causal_wal:records_root:v1\0";
+const WAL_FRONTIERS_ROOT_DOMAIN: &[u8] = b"echo:causal_wal:frontiers_root:v1\0";
+const WAL_COMMIT_DOMAIN: &[u8] = b"echo:causal_wal:commit:v1\0";
+const WAL_HEADER_CHECKSUM_DOMAIN: &[u8] = b"echo:causal_wal:header_checksum:v1\0";
+const WAL_FRAME_CHECKSUM_DOMAIN: &[u8] = b"echo:causal_wal:frame_checksum:v1\0";
+
+/// Current in-memory causal WAL version.
+pub const CAUSAL_WAL_VERSION: u16 = 1;
+
+/// Logical sequence number assigned to a WAL frame.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Lsn(u64);
+
+impl Lsn {
+    /// Builds an LSN from its raw value.
+    pub const fn from_raw(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw LSN value.
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Returns the next LSN, or `None` on overflow.
+    pub fn checked_next(self) -> Option<Self> {
+        self.0.checked_add(1).map(Self)
+    }
+}
+
+/// Stable identifier for a WAL transaction.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WalTransactionId(Hash);
+
+impl WalTransactionId {
+    /// Builds a transaction id from a canonical digest.
+    pub const fn from_hash(hash: Hash) -> Self {
+        Self(hash)
+    }
+
+    /// Returns the canonical transaction id bytes.
+    pub const fn as_hash(self) -> Hash {
+        self.0
+    }
+}
+
+/// Stable identifier for a writer epoch.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WriterEpochId(Hash);
+
+impl WriterEpochId {
+    /// Builds an epoch id from a canonical digest.
+    pub const fn from_hash(hash: Hash) -> Self {
+        Self(hash)
+    }
+
+    /// Returns the canonical epoch id bytes.
+    pub const fn as_hash(self) -> Hash {
+        self.0
+    }
+}
+
+/// Stable identifier for a WAL segment.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WalSegmentId(u64);
+
+impl WalSegmentId {
+    /// Builds a segment id from its raw value.
+    pub const fn from_raw(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw segment id.
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+/// Position of a frame inside its transaction.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TransactionLocalIndex(u32);
+
+impl TransactionLocalIndex {
+    /// Builds a transaction-local frame index from its raw value.
+    pub const fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw transaction-local frame index.
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    /// Returns the next local index, or `None` on overflow.
+    pub fn checked_next(self) -> Option<Self> {
+        self.0.checked_add(1).map(Self)
+    }
+}
+
+/// Configured durability mode for a WAL transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalDurabilityMode {
+    /// File and directory sync semantics satisfy the ACK contract.
+    StrictFilesystem,
+    /// Object and manifest commit semantics satisfy the ACK contract.
+    StrictObjectStore,
+    /// Development or test mode only; not release durability.
+    Buffered,
+    /// Recover and inspect without appending or truncating.
+    ReadOnlyRecovery,
+    /// Process-local mode with no durable causal-history claim.
+    Disabled,
+}
+
+impl WalDurabilityMode {
+    fn code(self) -> u8 {
+        match self {
+            Self::StrictFilesystem => 1,
+            Self::StrictObjectStore => 2,
+            Self::Buffered => 3,
+            Self::ReadOnlyRecovery => 4,
+            Self::Disabled => 5,
+        }
+    }
+}
+
+/// Authority plane allowed to record a WAL fact.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalAppendAuthority {
+    /// Echo submission-intake authority.
+    SubmissionIntake,
+    /// Trusted scheduler/runtime authority.
+    TrustedScheduler,
+    /// Trusted runtime-control authority.
+    RuntimeControl,
+    /// Recovery authority.
+    Recovery,
+}
+
+/// First-cut transaction kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalTransactionKind {
+    /// Submission intake acceptance.
+    SubmissionIntake,
+    /// Scheduler-owned tick transaction.
+    SchedulerTick,
+    /// Runtime posture or control transaction.
+    RuntimePosture,
+    /// Checkpoint publication evidence.
+    Checkpoint,
+    /// Side-effect outbox transaction.
+    MaterializationOutbox,
+}
+
+impl WalTransactionKind {
+    fn code(self) -> u8 {
+        match self {
+            Self::SubmissionIntake => 1,
+            Self::SchedulerTick => 2,
+            Self::RuntimePosture => 3,
+            Self::Checkpoint => 4,
+            Self::MaterializationOutbox => 5,
+        }
+    }
+
+    fn required_authority(self) -> WalAppendAuthority {
+        match self {
+            Self::SubmissionIntake => WalAppendAuthority::SubmissionIntake,
+            Self::SchedulerTick | Self::MaterializationOutbox => {
+                WalAppendAuthority::TrustedScheduler
+            }
+            Self::RuntimePosture => WalAppendAuthority::RuntimeControl,
+            Self::Checkpoint => WalAppendAuthority::Recovery,
+        }
+    }
+}
+
+/// Causal WAL record kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WalRecordKind {
+    /// Echo accepted a canonical submission into semantic ingress history.
+    SubmissionAcceptedRecorded,
+    /// Echo recorded submission acceptance evidence.
+    SubmissionAcceptanceEvidenceRecorded,
+    /// Trusted runtime recorded a law witness.
+    RuntimeLawWitnessRecorded,
+    /// Trusted runtime issued runtime admission-ticket evidence.
+    RuntimeAdmissionTicketIssued,
+    /// Trusted runtime recorded ticketed runtime ingress.
+    TicketedRuntimeIngressRecorded,
+    /// Trusted scheduler recorded a tick receipt.
+    TickReceiptRecorded,
+    /// Trusted scheduler recorded a runtime state delta.
+    RuntimeStateDeltaRecorded,
+    /// Trusted scheduler recorded receipt-correlation index material.
+    ReceiptCorrelationRecorded,
+    /// Runtime recorded a retained reading envelope reference.
+    ReadingEnvelopeRetained,
+    /// Runtime recorded a durable retained-material reference.
+    RetainedMaterialRefRecorded,
+    /// Runtime recorded scoped scheduler-fault quarantine posture.
+    SchedulerFaultQuarantined,
+    /// Trusted runtime recorded runtime-control posture.
+    TrustedRuntimeControlRecorded,
+    /// Runtime recorded checkpoint publication evidence.
+    CheckpointPublicationRecorded,
+    /// Runtime recorded side-effect materialization intent.
+    MaterializationIntentRecorded,
+    /// Runtime recorded side-effect materialization observation.
+    MaterializationEffectObserved,
+    /// Runtime recorded recovery posture.
+    RecoveryPostureRecorded,
+}
+
+impl WalRecordKind {
+    /// Returns the canonical record kind label.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::SubmissionAcceptedRecorded => "SubmissionAcceptedRecorded",
+            Self::SubmissionAcceptanceEvidenceRecorded => "SubmissionAcceptanceEvidenceRecorded",
+            Self::RuntimeLawWitnessRecorded => "RuntimeLawWitnessRecorded",
+            Self::RuntimeAdmissionTicketIssued => "RuntimeAdmissionTicketIssued",
+            Self::TicketedRuntimeIngressRecorded => "TicketedRuntimeIngressRecorded",
+            Self::TickReceiptRecorded => "TickReceiptRecorded",
+            Self::RuntimeStateDeltaRecorded => "RuntimeStateDeltaRecorded",
+            Self::ReceiptCorrelationRecorded => "ReceiptCorrelationRecorded",
+            Self::ReadingEnvelopeRetained => "ReadingEnvelopeRetained",
+            Self::RetainedMaterialRefRecorded => "RetainedMaterialRefRecorded",
+            Self::SchedulerFaultQuarantined => "SchedulerFaultQuarantined",
+            Self::TrustedRuntimeControlRecorded => "TrustedRuntimeControlRecorded",
+            Self::CheckpointPublicationRecorded => "CheckpointPublicationRecorded",
+            Self::MaterializationIntentRecorded => "MaterializationIntentRecorded",
+            Self::MaterializationEffectObserved => "MaterializationEffectObserved",
+            Self::RecoveryPostureRecorded => "RecoveryPostureRecorded",
+        }
+    }
+
+    /// Returns the append authority required for this record kind.
+    pub const fn required_authority(self) -> WalAppendAuthority {
+        match self {
+            Self::SubmissionAcceptedRecorded | Self::SubmissionAcceptanceEvidenceRecorded => {
+                WalAppendAuthority::SubmissionIntake
+            }
+            Self::RuntimeLawWitnessRecorded
+            | Self::RuntimeAdmissionTicketIssued
+            | Self::TicketedRuntimeIngressRecorded
+            | Self::TickReceiptRecorded
+            | Self::RuntimeStateDeltaRecorded
+            | Self::ReceiptCorrelationRecorded
+            | Self::ReadingEnvelopeRetained
+            | Self::RetainedMaterialRefRecorded
+            | Self::MaterializationIntentRecorded
+            | Self::MaterializationEffectObserved => WalAppendAuthority::TrustedScheduler,
+            Self::SchedulerFaultQuarantined | Self::TrustedRuntimeControlRecorded => {
+                WalAppendAuthority::RuntimeControl
+            }
+            Self::CheckpointPublicationRecorded | Self::RecoveryPostureRecorded => {
+                WalAppendAuthority::Recovery
+            }
+        }
+    }
+
+    /// Returns `true` when the label obeys the recorded-not-committed grammar.
+    pub fn obeys_recorded_not_committed_grammar(self) -> bool {
+        !self.label().contains("Committed")
+    }
+}
+
+/// Identity of the canonical payload codec.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PayloadCodecId(Hash);
+
+impl PayloadCodecId {
+    /// Builds a codec id from a hash.
+    pub const fn from_hash(hash: Hash) -> Self {
+        Self(hash)
+    }
+
+    /// Returns the codec id bytes.
+    pub const fn as_hash(self) -> Hash {
+        self.0
+    }
+}
+
+/// Identity of the payload schema.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PayloadSchemaId(Hash);
+
+impl PayloadSchemaId {
+    /// Builds a schema id from a hash.
+    pub const fn from_hash(hash: Hash) -> Self {
+        Self(hash)
+    }
+
+    /// Returns the schema id bytes.
+    pub const fn as_hash(self) -> Hash {
+        self.0
+    }
+}
+
+/// WAL payload compression posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalCompressionKind {
+    /// Payload bytes are not compressed.
+    None,
+}
+
+impl WalCompressionKind {
+    fn code(self) -> u8 {
+        match self {
+            Self::None => 0,
+        }
+    }
+}
+
+/// WAL payload revelation posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalRedactionPosture {
+    /// Full payload bytes are present.
+    Present,
+    /// WAL carries digest-only evidence.
+    DigestOnly,
+    /// WAL carries retained-reference evidence.
+    RetainedRef,
+    /// Payload bytes are encrypted.
+    Encrypted,
+    /// Payload bytes are redacted by policy.
+    RedactedByPolicy,
+}
+
+impl WalRedactionPosture {
+    fn code(self) -> u8 {
+        match self {
+            Self::Present => 1,
+            Self::DigestOnly => 2,
+            Self::RetainedRef => 3,
+            Self::Encrypted => 4,
+            Self::RedactedByPolicy => 5,
+        }
+    }
+}
+
+/// Runtime frontier family affected by a transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AffectedFrontierKind {
+    /// Submission queue frontier.
+    SubmissionQueue,
+    /// Runtime state frontier.
+    RuntimeState,
+    /// Receipt/correlation frontier.
+    ReceiptIndex,
+    /// Reading/index frontier.
+    ReadingIndex,
+    /// Runtime control posture frontier.
+    RuntimeControl,
+    /// Checkpoint/index frontier.
+    CheckpointIndex,
+}
+
+impl AffectedFrontierKind {
+    fn code(self) -> u8 {
+        match self {
+            Self::SubmissionQueue => 1,
+            Self::RuntimeState => 2,
+            Self::ReceiptIndex => 3,
+            Self::ReadingIndex => 4,
+            Self::RuntimeControl => 5,
+            Self::CheckpointIndex => 6,
+        }
+    }
+}
+
+/// Digest transition for a frontier touched by a committed transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AffectedFrontier {
+    /// Frontier kind.
+    pub kind: AffectedFrontierKind,
+    /// Digest before the transaction.
+    pub before_digest: Hash,
+    /// Digest after the transaction.
+    pub after_digest: Hash,
+}
+
+/// Writer epoch metadata and storage fencing evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WriterEpoch {
+    /// Epoch id.
+    pub epoch_id: WriterEpochId,
+    /// Storage fencing token or lease token.
+    pub storage_fencing_token: Hash,
+    /// Process identity evidence.
+    pub process_identity: Hash,
+    /// Host identity evidence.
+    pub host_identity: Hash,
+    /// First LSN owned by the epoch.
+    pub started_at_lsn: Lsn,
+    /// Previous epoch id, if any.
+    pub previous_epoch_id: Option<WriterEpochId>,
+    /// Previous epoch final commit digest, if any.
+    pub previous_epoch_final_commit_digest: Option<Hash>,
+    /// Lease or lock evidence.
+    pub lease_or_lock_evidence: Hash,
+}
+
+/// Canonical WAL record payload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalRecordPayload {
+    /// Record kind.
+    pub kind: WalRecordKind,
+    /// Payload schema version.
+    pub schema_version: u16,
+    /// Canonical payload bytes.
+    pub canonical_bytes: Vec<u8>,
+}
+
+impl WalRecordPayload {
+    /// Creates a canonical payload.
+    pub fn new(kind: WalRecordKind, schema_version: u16, canonical_bytes: Vec<u8>) -> Self {
+        Self {
+            kind,
+            schema_version,
+            canonical_bytes,
+        }
+    }
+
+    /// Computes the domain-separated payload digest.
+    pub fn digest(&self) -> Hash {
+        let mut h = blake3::Hasher::new();
+        h.update(WAL_PAYLOAD_DOMAIN);
+        h.update(self.kind.label().as_bytes());
+        h.update(&self.schema_version.to_le_bytes());
+        update_len_prefixed(&mut h, &self.canonical_bytes);
+        h.finalize().into()
+    }
+}
+
+/// WAL frame header.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalFrameHeader {
+    /// WAL version.
+    pub wal_version: u16,
+    /// Writer epoch.
+    pub writer_epoch: WriterEpochId,
+    /// Segment id.
+    pub segment_id: WalSegmentId,
+    /// Frame LSN.
+    pub lsn: Lsn,
+    /// Transaction id.
+    pub transaction_id: WalTransactionId,
+    /// Frame index inside the transaction.
+    pub transaction_local_index: TransactionLocalIndex,
+    /// Record kind.
+    pub record_kind: WalRecordKind,
+    /// Payload byte length.
+    pub payload_len: u64,
+    /// Payload digest.
+    pub payload_digest: Hash,
+    /// Payload codec id.
+    pub payload_codec_id: PayloadCodecId,
+    /// Payload schema id.
+    pub payload_schema_id: PayloadSchemaId,
+    /// Payload schema version.
+    pub payload_schema_version: u16,
+    /// Canonical encoding version.
+    pub canonical_encoding_version: u16,
+    /// Digest domain id.
+    pub digest_domain: Hash,
+    /// Compression kind.
+    pub compression_kind: WalCompressionKind,
+    /// Encryption or redaction posture.
+    pub encryption_or_redaction_posture: WalRedactionPosture,
+    /// Previous frame digest.
+    pub previous_frame_digest: Hash,
+    /// Header checksum.
+    pub header_checksum: u32,
+}
+
+impl WalFrameHeader {
+    fn checksum_input(&self, include_checksum: bool) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&self.wal_version.to_le_bytes());
+        out.extend_from_slice(&self.writer_epoch.as_hash());
+        out.extend_from_slice(&self.segment_id.as_u64().to_le_bytes());
+        out.extend_from_slice(&self.lsn.as_u64().to_le_bytes());
+        out.extend_from_slice(&self.transaction_id.as_hash());
+        out.extend_from_slice(&self.transaction_local_index.as_u32().to_le_bytes());
+        out.extend_from_slice(self.record_kind.label().as_bytes());
+        out.extend_from_slice(&self.payload_len.to_le_bytes());
+        out.extend_from_slice(&self.payload_digest);
+        out.extend_from_slice(&self.payload_codec_id.as_hash());
+        out.extend_from_slice(&self.payload_schema_id.as_hash());
+        out.extend_from_slice(&self.payload_schema_version.to_le_bytes());
+        out.extend_from_slice(&self.canonical_encoding_version.to_le_bytes());
+        out.extend_from_slice(&self.digest_domain);
+        out.push(self.compression_kind.code());
+        out.push(self.encryption_or_redaction_posture.code());
+        out.extend_from_slice(&self.previous_frame_digest);
+        if include_checksum {
+            out.extend_from_slice(&self.header_checksum.to_le_bytes());
+        }
+        out
+    }
+
+    fn compute_checksum(&self) -> u32 {
+        checksum32(WAL_HEADER_CHECKSUM_DOMAIN, &self.checksum_input(false))
+    }
+}
+
+/// WAL frame trailer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalFrameTrailer {
+    /// Frame checksum over the header, payload, and payload digest.
+    pub frame_checksum: u32,
+}
+
+/// WAL frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalFrame {
+    /// Frame header.
+    pub header: WalFrameHeader,
+    /// Frame payload.
+    pub payload: WalRecordPayload,
+    /// Frame trailer.
+    pub trailer: WalFrameTrailer,
+}
+
+impl WalFrame {
+    /// Creates a frame and computes checksums.
+    pub fn new(mut header: WalFrameHeader, payload: WalRecordPayload) -> Self {
+        header.header_checksum = header.compute_checksum();
+        let frame_checksum = compute_frame_checksum(&header, &payload);
+        Self {
+            header,
+            payload,
+            trailer: WalFrameTrailer { frame_checksum },
+        }
+    }
+
+    /// Computes the frame digest.
+    pub fn digest(&self) -> Hash {
+        let mut h = blake3::Hasher::new();
+        h.update(WAL_FRAME_DOMAIN);
+        h.update(&self.header.checksum_input(true));
+        h.update(&self.payload.digest());
+        h.update(&self.trailer.frame_checksum.to_le_bytes());
+        h.finalize().into()
+    }
+
+    /// Validates checksums and payload/header alignment.
+    pub fn validate_integrity(&self) -> Result<(), WalValidationError> {
+        if self.payload.kind != self.header.record_kind {
+            return Err(WalValidationError::RecordKindMismatch);
+        }
+        if self.payload.digest() != self.header.payload_digest {
+            return Err(WalValidationError::PayloadDigestMismatch);
+        }
+        if self.header.compute_checksum() != self.header.header_checksum {
+            return Err(WalValidationError::HeaderChecksumMismatch);
+        }
+        if compute_frame_checksum(&self.header, &self.payload) != self.trailer.frame_checksum {
+            return Err(WalValidationError::FrameChecksumMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// WAL transaction commit marker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalTransactionCommit {
+    /// Writer epoch.
+    pub writer_epoch: WriterEpochId,
+    /// Transaction id.
+    pub transaction_id: WalTransactionId,
+    /// Transaction kind.
+    pub transaction_kind: WalTransactionKind,
+    /// First transaction frame LSN.
+    pub first_lsn: Lsn,
+    /// Last transaction frame LSN.
+    pub last_lsn: Lsn,
+    /// Number of records.
+    pub record_count: u64,
+    /// Root over transaction record frame digests.
+    pub records_root: Hash,
+    /// Root over affected frontier transitions.
+    pub affected_frontiers_root: Hash,
+    /// Previous committed transaction digest.
+    pub previous_committed_transaction_digest: Hash,
+    /// Durability mode.
+    pub durability_mode: WalDurabilityMode,
+    /// Commit schema version.
+    pub schema_version: u16,
+    /// Commit digest.
+    pub commit_digest: Hash,
+}
+
+impl WalTransactionCommit {
+    fn compute_digest(&self) -> Hash {
+        let mut h = blake3::Hasher::new();
+        h.update(WAL_COMMIT_DOMAIN);
+        h.update(&self.writer_epoch.as_hash());
+        h.update(&self.transaction_id.as_hash());
+        h.update(&[self.transaction_kind.code()]);
+        h.update(&self.first_lsn.as_u64().to_le_bytes());
+        h.update(&self.last_lsn.as_u64().to_le_bytes());
+        h.update(&self.record_count.to_le_bytes());
+        h.update(&self.records_root);
+        h.update(&self.affected_frontiers_root);
+        h.update(&self.previous_committed_transaction_digest);
+        h.update(&[self.durability_mode.code()]);
+        h.update(&self.schema_version.to_le_bytes());
+        h.finalize().into()
+    }
+}
+
+/// Committed WAL transaction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalCommittedTransaction {
+    /// Transaction frames.
+    pub frames: Vec<WalFrame>,
+    /// Affected frontiers.
+    pub affected_frontiers: Vec<AffectedFrontier>,
+    /// Commit marker.
+    pub commit: WalTransactionCommit,
+}
+
+impl WalCommittedTransaction {
+    /// Validates the transaction's structural and semantic commit invariants.
+    pub fn validate(&self) -> Result<(), WalValidationError> {
+        validate_transaction_frames(&self.frames, &self.commit)?;
+        validate_transaction_semantics(&self.frames, self.commit.transaction_kind)?;
+        if affected_frontiers_root(&self.affected_frontiers) != self.commit.affected_frontiers_root
+        {
+            return Err(WalValidationError::AffectedFrontiersRootMismatch);
+        }
+        if self.commit.compute_digest() != self.commit.commit_digest {
+            return Err(WalValidationError::CommitDigestMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Builder for a contiguous WAL transaction.
+#[derive(Clone, Debug)]
+pub struct WalTransactionBuilder {
+    writer_epoch: WriterEpochId,
+    segment_id: WalSegmentId,
+    transaction_id: WalTransactionId,
+    transaction_kind: WalTransactionKind,
+    authority: WalAppendAuthority,
+    next_lsn: Lsn,
+    next_local_index: TransactionLocalIndex,
+    previous_frame_digest: Hash,
+    previous_committed_transaction_digest: Hash,
+    durability_mode: WalDurabilityMode,
+    payload_codec_id: PayloadCodecId,
+    payload_schema_id: PayloadSchemaId,
+    payload_schema_version: u16,
+    canonical_encoding_version: u16,
+    digest_domain: Hash,
+    frames: Vec<WalFrame>,
+    closed: bool,
+}
+
+impl WalTransactionBuilder {
+    /// Creates a transaction builder.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        writer_epoch: WriterEpochId,
+        segment_id: WalSegmentId,
+        transaction_id: WalTransactionId,
+        transaction_kind: WalTransactionKind,
+        authority: WalAppendAuthority,
+        first_lsn: Lsn,
+        previous_frame_digest: Hash,
+        previous_committed_transaction_digest: Hash,
+        durability_mode: WalDurabilityMode,
+        payload_codec_id: PayloadCodecId,
+        payload_schema_id: PayloadSchemaId,
+        payload_schema_version: u16,
+        canonical_encoding_version: u16,
+        digest_domain: Hash,
+    ) -> Self {
+        Self {
+            writer_epoch,
+            segment_id,
+            transaction_id,
+            transaction_kind,
+            authority,
+            next_lsn: first_lsn,
+            next_local_index: TransactionLocalIndex::from_raw(0),
+            previous_frame_digest,
+            previous_committed_transaction_digest,
+            durability_mode,
+            payload_codec_id,
+            payload_schema_id,
+            payload_schema_version,
+            canonical_encoding_version,
+            digest_domain,
+            frames: Vec::new(),
+            closed: false,
+        }
+    }
+
+    /// Appends a record to the transaction.
+    pub fn push_record(
+        &mut self,
+        kind: WalRecordKind,
+        canonical_bytes: Vec<u8>,
+    ) -> Result<(), WalBuildError> {
+        if self.closed {
+            return Err(WalBuildError::TransactionClosed);
+        }
+        if kind.required_authority() != self.authority {
+            return Err(WalBuildError::WrongAppendAuthority {
+                record_kind: kind,
+                required: kind.required_authority(),
+                actual: self.authority,
+            });
+        }
+        let payload = WalRecordPayload::new(kind, self.payload_schema_version, canonical_bytes);
+        let payload_len = len_u64(payload.canonical_bytes.len());
+        let header = WalFrameHeader {
+            wal_version: CAUSAL_WAL_VERSION,
+            writer_epoch: self.writer_epoch,
+            segment_id: self.segment_id,
+            lsn: self.next_lsn,
+            transaction_id: self.transaction_id,
+            transaction_local_index: self.next_local_index,
+            record_kind: kind,
+            payload_len,
+            payload_digest: payload.digest(),
+            payload_codec_id: self.payload_codec_id,
+            payload_schema_id: self.payload_schema_id,
+            payload_schema_version: self.payload_schema_version,
+            canonical_encoding_version: self.canonical_encoding_version,
+            digest_domain: self.digest_domain,
+            compression_kind: WalCompressionKind::None,
+            encryption_or_redaction_posture: WalRedactionPosture::Present,
+            previous_frame_digest: self.previous_frame_digest,
+            header_checksum: 0,
+        };
+        let frame = WalFrame::new(header, payload);
+        self.previous_frame_digest = frame.digest();
+        self.next_lsn = self
+            .next_lsn
+            .checked_next()
+            .ok_or(WalBuildError::LsnOverflow)?;
+        self.next_local_index = self
+            .next_local_index
+            .checked_next()
+            .ok_or(WalBuildError::TransactionLocalIndexOverflow)?;
+        self.frames.push(frame);
+        Ok(())
+    }
+
+    /// Commits the transaction.
+    pub fn commit(
+        mut self,
+        affected_frontiers: Vec<AffectedFrontier>,
+    ) -> Result<WalCommittedTransaction, WalBuildError> {
+        if self.frames.is_empty() {
+            return Err(WalBuildError::EmptyTransaction);
+        }
+        self.closed = true;
+        let first_lsn = self
+            .frames
+            .first()
+            .map(|frame| frame.header.lsn)
+            .ok_or(WalBuildError::EmptyTransaction)?;
+        let last_lsn = self
+            .frames
+            .last()
+            .map(|frame| frame.header.lsn)
+            .ok_or(WalBuildError::EmptyTransaction)?;
+        let record_count = len_u64(self.frames.len());
+        let mut commit = WalTransactionCommit {
+            writer_epoch: self.writer_epoch,
+            transaction_id: self.transaction_id,
+            transaction_kind: self.transaction_kind,
+            first_lsn,
+            last_lsn,
+            record_count,
+            records_root: records_root(&self.frames),
+            affected_frontiers_root: affected_frontiers_root(&affected_frontiers),
+            previous_committed_transaction_digest: self.previous_committed_transaction_digest,
+            durability_mode: self.durability_mode,
+            schema_version: CAUSAL_WAL_VERSION,
+            commit_digest: [0; 32],
+        };
+        commit.commit_digest = commit.compute_digest();
+        let transaction = WalCommittedTransaction {
+            frames: self.frames,
+            affected_frontiers,
+            commit,
+        };
+        transaction.validate()?;
+        Ok(transaction)
+    }
+}
+
+/// WAL storage port.
+pub trait WalStorePort {
+    /// Acquires a writer epoch.
+    fn acquire_writer_epoch(
+        &mut self,
+        request: WriterEpochRequest,
+    ) -> Result<WriterEpoch, WalStoreError>;
+
+    /// Appends a frame.
+    fn append_frame(
+        &mut self,
+        epoch_id: WriterEpochId,
+        frame: WalFrame,
+    ) -> Result<(), WalStoreError>;
+
+    /// Flushes a transaction commit marker under the store's durability mode.
+    fn flush_commit(
+        &mut self,
+        epoch_id: WriterEpochId,
+        commit: WalTransactionCommit,
+    ) -> Result<(), WalStoreError>;
+
+    /// Reads the recorded frames.
+    fn read_frames(&self) -> Vec<WalFrame>;
+
+    /// Reads the flushed commit markers.
+    fn read_commits(&self) -> Vec<WalTransactionCommit>;
+
+    /// Seals a segment.
+    fn seal_segment(
+        &mut self,
+        epoch_id: WriterEpochId,
+        segment_id: WalSegmentId,
+    ) -> Result<WalSegmentSeal, WalStoreError>;
+
+    /// Truncates the uncommitted tail after the given LSN.
+    fn truncate_tail_after(&mut self, after_lsn: Lsn) -> Result<(), WalStoreError>;
+
+    /// Publishes a manifest.
+    fn publish_manifest(
+        &mut self,
+        epoch_id: WriterEpochId,
+        manifest: WalManifest,
+    ) -> Result<(), WalStoreError>;
+
+    /// Closes the writer epoch.
+    fn close_epoch(&mut self, epoch_id: WriterEpochId) -> Result<(), WalStoreError>;
+}
+
+/// Writer epoch acquisition request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WriterEpochRequest {
+    /// Epoch id.
+    pub epoch_id: WriterEpochId,
+    /// Storage fencing token.
+    pub storage_fencing_token: Hash,
+    /// Process identity.
+    pub process_identity: Hash,
+    /// Host identity.
+    pub host_identity: Hash,
+    /// Start LSN.
+    pub started_at_lsn: Lsn,
+    /// Previous epoch id.
+    pub previous_epoch_id: Option<WriterEpochId>,
+    /// Previous final commit digest.
+    pub previous_epoch_final_commit_digest: Option<Hash>,
+    /// Lease or lock evidence.
+    pub lease_or_lock_evidence: Hash,
+}
+
+/// Segment seal result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalSegmentSeal {
+    /// Sealed segment id.
+    pub segment_id: WalSegmentId,
+    /// Last sealed LSN.
+    pub sealed_lsn: Option<Lsn>,
+    /// Segment digest.
+    pub segment_digest: Hash,
+}
+
+/// Published WAL manifest.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalManifest {
+    /// Manifest digest.
+    pub manifest_digest: Hash,
+    /// Last committed LSN.
+    pub last_committed_lsn: Option<Lsn>,
+    /// Last commit digest.
+    pub last_commit_digest: Option<Hash>,
+    /// Number of sealed segments.
+    pub sealed_segment_count: u64,
+}
+
+/// Deterministic in-memory WAL store.
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryWalStore {
+    active_epoch: Option<WriterEpoch>,
+    closed_epochs: Vec<WriterEpoch>,
+    frames: Vec<WalFrame>,
+    commits: Vec<WalTransactionCommit>,
+    sealed_segments: Vec<WalSegmentSeal>,
+    manifests: Vec<WalManifest>,
+}
+
+impl InMemoryWalStore {
+    /// Creates an empty in-memory WAL store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends and flushes a committed transaction.
+    pub fn append_transaction(
+        &mut self,
+        transaction: WalCommittedTransaction,
+    ) -> Result<(), WalStoreError> {
+        transaction.validate()?;
+        let epoch_id = transaction.commit.writer_epoch;
+        for frame in transaction.frames {
+            self.append_frame(epoch_id, frame)?;
+        }
+        self.flush_commit(epoch_id, transaction.commit)
+    }
+
+    /// Appends a frame without a commit marker to simulate an uncommitted tail.
+    pub fn append_uncommitted_frame(
+        &mut self,
+        epoch_id: WriterEpochId,
+        frame: WalFrame,
+    ) -> Result<(), WalStoreError> {
+        self.append_frame(epoch_id, frame)
+    }
+
+    /// Returns published manifests.
+    pub fn manifests(&self) -> &[WalManifest] {
+        &self.manifests
+    }
+}
+
+impl WalStorePort for InMemoryWalStore {
+    fn acquire_writer_epoch(
+        &mut self,
+        request: WriterEpochRequest,
+    ) -> Result<WriterEpoch, WalStoreError> {
+        if self.active_epoch.is_some() {
+            return Err(WalStoreError::WriterEpochAlreadyActive);
+        }
+        if let Some(previous_epoch_id) = request.previous_epoch_id {
+            if self
+                .closed_epochs
+                .iter()
+                .all(|epoch| epoch.epoch_id != previous_epoch_id)
+            {
+                return Err(WalStoreError::UnknownPreviousWriterEpoch);
+            }
+        }
+        let epoch = WriterEpoch {
+            epoch_id: request.epoch_id,
+            storage_fencing_token: request.storage_fencing_token,
+            process_identity: request.process_identity,
+            host_identity: request.host_identity,
+            started_at_lsn: request.started_at_lsn,
+            previous_epoch_id: request.previous_epoch_id,
+            previous_epoch_final_commit_digest: request.previous_epoch_final_commit_digest,
+            lease_or_lock_evidence: request.lease_or_lock_evidence,
+        };
+        self.active_epoch = Some(epoch.clone());
+        Ok(epoch)
+    }
+
+    fn append_frame(
+        &mut self,
+        epoch_id: WriterEpochId,
+        frame: WalFrame,
+    ) -> Result<(), WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id || frame.header.writer_epoch != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        frame.validate_integrity()?;
+        self.frames.push(frame);
+        Ok(())
+    }
+
+    fn flush_commit(
+        &mut self,
+        epoch_id: WriterEpochId,
+        commit: WalTransactionCommit,
+    ) -> Result<(), WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id || commit.writer_epoch != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        self.commits.push(commit);
+        Ok(())
+    }
+
+    fn read_frames(&self) -> Vec<WalFrame> {
+        self.frames.clone()
+    }
+
+    fn read_commits(&self) -> Vec<WalTransactionCommit> {
+        self.commits.clone()
+    }
+
+    fn seal_segment(
+        &mut self,
+        epoch_id: WriterEpochId,
+        segment_id: WalSegmentId,
+    ) -> Result<WalSegmentSeal, WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        let segment_frames: Vec<&WalFrame> = self
+            .frames
+            .iter()
+            .filter(|frame| frame.header.segment_id == segment_id)
+            .collect();
+        let sealed_lsn = segment_frames.iter().map(|frame| frame.header.lsn).max();
+        let segment_digest = segment_digest(segment_id, &segment_frames);
+        let seal = WalSegmentSeal {
+            segment_id,
+            sealed_lsn,
+            segment_digest,
+        };
+        self.sealed_segments.push(seal.clone());
+        Ok(seal)
+    }
+
+    fn truncate_tail_after(&mut self, after_lsn: Lsn) -> Result<(), WalStoreError> {
+        self.frames.retain(|frame| frame.header.lsn <= after_lsn);
+        Ok(())
+    }
+
+    fn publish_manifest(
+        &mut self,
+        epoch_id: WriterEpochId,
+        manifest: WalManifest,
+    ) -> Result<(), WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        self.manifests.push(manifest);
+        Ok(())
+    }
+
+    fn close_epoch(&mut self, epoch_id: WriterEpochId) -> Result<(), WalStoreError> {
+        let epoch = self
+            .active_epoch
+            .take()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if epoch.epoch_id != epoch_id {
+            self.active_epoch = Some(epoch);
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        self.closed_epochs.push(epoch);
+        Ok(())
+    }
+}
+
+/// Recovery access mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryAccessMode {
+    /// Writable recovery may truncate incomplete tails after validation.
+    Writable,
+    /// Read-only recovery reports incomplete tails without mutating storage.
+    ReadOnly,
+}
+
+/// Recovery tail posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoveryTailPosture {
+    /// No uncommitted tail was present.
+    Clean,
+    /// Writable recovery truncated every frame because no committed
+    /// transaction was present.
+    TruncatedAll,
+    /// Writable recovery truncated after the given LSN.
+    TruncatedAfter(Lsn),
+    /// Read-only recovery would truncate every frame because no committed
+    /// transaction was present.
+    WouldTruncateAll,
+    /// Read-only recovery would truncate after the given LSN.
+    WouldTruncateAfter(Lsn),
+}
+
+/// Recovery scan report.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoveryScanReport {
+    /// Valid committed transactions.
+    pub transactions: Vec<WalRecoveredTransaction>,
+    /// Tail posture.
+    pub tail_posture: RecoveryTailPosture,
+}
+
+/// Recovered committed transaction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalRecoveredTransaction {
+    /// Commit marker.
+    pub commit: WalTransactionCommit,
+    /// Transaction frames.
+    pub frames: Vec<WalFrame>,
+}
+
+/// Scans an in-memory store for recoverable transactions.
+pub fn recover_in_memory_store(
+    store: &mut InMemoryWalStore,
+    mode: RecoveryAccessMode,
+) -> Result<RecoveryScanReport, WalRecoveryError> {
+    let frames = store.read_frames();
+    let commits = store.read_commits();
+    let report = recover_from_frames_and_commits(&frames, &commits, mode)?;
+    if let (RecoveryAccessMode::Writable, RecoveryTailPosture::TruncatedAfter(lsn)) =
+        (mode, report.tail_posture)
+    {
+        store.truncate_tail_after(lsn)?;
+    }
+    if (mode, report.tail_posture)
+        == (
+            RecoveryAccessMode::Writable,
+            RecoveryTailPosture::TruncatedAll,
+        )
+    {
+        store.frames.clear();
+    }
+    Ok(report)
+}
+
+/// Recovers committed transactions from frames and commit markers.
+pub fn recover_from_frames_and_commits(
+    frames: &[WalFrame],
+    commits: &[WalTransactionCommit],
+    mode: RecoveryAccessMode,
+) -> Result<RecoveryScanReport, WalRecoveryError> {
+    let mut recovered = Vec::new();
+    let mut last_committed_lsn = None;
+    for commit in commits {
+        let tx_frames: Vec<WalFrame> = frames
+            .iter()
+            .filter(|frame| {
+                frame.header.transaction_id == commit.transaction_id
+                    && frame.header.lsn >= commit.first_lsn
+                    && frame.header.lsn <= commit.last_lsn
+            })
+            .cloned()
+            .collect();
+        validate_transaction_frames(&tx_frames, commit)?;
+        recovered.push(WalRecoveredTransaction {
+            commit: commit.clone(),
+            frames: tx_frames,
+        });
+        last_committed_lsn = Some(commit.last_lsn);
+    }
+    let tail_exists = frames
+        .iter()
+        .any(|frame| last_committed_lsn.is_none_or(|lsn| frame.header.lsn > lsn));
+    let tail_posture = match (tail_exists, mode, last_committed_lsn) {
+        (false, _, _) => RecoveryTailPosture::Clean,
+        (true, RecoveryAccessMode::Writable, Some(lsn)) => RecoveryTailPosture::TruncatedAfter(lsn),
+        (true, RecoveryAccessMode::ReadOnly, Some(lsn)) => {
+            RecoveryTailPosture::WouldTruncateAfter(lsn)
+        }
+        (true, RecoveryAccessMode::Writable, None) => RecoveryTailPosture::TruncatedAll,
+        (true, RecoveryAccessMode::ReadOnly, None) => RecoveryTailPosture::WouldTruncateAll,
+    };
+    Ok(RecoveryScanReport {
+        transactions: recovered,
+        tail_posture,
+    })
+}
+
+/// Minimal recovered state used by the pure replay reducer.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RecoveredState {
+    /// Applied transaction ids in replay order.
+    pub applied_transactions: Vec<WalTransactionId>,
+    /// Current frontier digests by frontier kind.
+    pub frontiers: BTreeMap<AffectedFrontierKind, Hash>,
+}
+
+/// Applies a validated committed transaction to a recovered state.
+pub fn apply_committed_transaction(
+    mut before: RecoveredState,
+    transaction: &WalCommittedTransaction,
+) -> Result<RecoveredState, WalReplayError> {
+    transaction.validate()?;
+    for frontier in &transaction.affected_frontiers {
+        if let Some(current) = before.frontiers.get(&frontier.kind) {
+            if current != &frontier.before_digest {
+                return Err(WalReplayError::FrontierMismatch {
+                    kind: frontier.kind,
+                    expected: *current,
+                    actual: frontier.before_digest,
+                });
+            }
+        }
+        before
+            .frontiers
+            .insert(frontier.kind, frontier.after_digest);
+    }
+    before
+        .applied_transactions
+        .push(transaction.commit.transaction_id);
+    Ok(before)
+}
+
+/// Lints proposed WAL schema terms for app nouns and authority leaks.
+pub fn lint_wal_schema_terms<'a>(
+    terms: impl IntoIterator<Item = &'a str>,
+    forbidden_app_terms: &[&str],
+) -> Result<(), WalSchemaLintError> {
+    for term in terms {
+        for forbidden in forbidden_app_terms {
+            if term.contains(forbidden) {
+                return Err(WalSchemaLintError::ForbiddenAppNoun {
+                    term: term.to_owned(),
+                    forbidden: (*forbidden).to_owned(),
+                });
+            }
+        }
+        for forbidden in AUTHORITY_LEAK_TERMS {
+            if term.contains(forbidden) {
+                return Err(WalSchemaLintError::ForbiddenAuthorityLeak {
+                    term: term.to_owned(),
+                    forbidden: (*forbidden).to_owned(),
+                });
+            }
+        }
+        if term.contains("Committed") && term != "WalTransactionCommit" {
+            return Err(WalSchemaLintError::RecordNameImpliesCommit {
+                term: term.to_owned(),
+            });
+        }
+    }
+    Ok(())
+}
+
+const AUTHORITY_LEAK_TERMS: &[&str] = &[
+    "AppTick",
+    "ApplicationReceipt",
+    "ClientRuntimeControl",
+    "DocumentStateDelta",
+];
+
+/// WAL build errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalBuildError {
+    /// Transaction already closed.
+    #[error("WAL transaction is already closed")]
+    TransactionClosed,
+    /// Record requires a different append authority.
+    #[error(
+        "wrong append authority for {record_kind:?}: required {required:?}, actual {actual:?}"
+    )]
+    WrongAppendAuthority {
+        /// Record kind.
+        record_kind: WalRecordKind,
+        /// Required authority.
+        required: WalAppendAuthority,
+        /// Actual authority.
+        actual: WalAppendAuthority,
+    },
+    /// LSN overflow.
+    #[error("WAL LSN overflow")]
+    LsnOverflow,
+    /// Transaction-local index overflow.
+    #[error("WAL transaction-local index overflow")]
+    TransactionLocalIndexOverflow,
+    /// Empty transaction.
+    #[error("WAL transaction has no records")]
+    EmptyTransaction,
+    /// Validation failed.
+    #[error(transparent)]
+    Validation(#[from] WalValidationError),
+}
+
+/// WAL validation errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalValidationError {
+    /// Frame payload kind does not match header kind.
+    #[error("WAL frame record kind mismatch")]
+    RecordKindMismatch,
+    /// Payload digest mismatch.
+    #[error("WAL payload digest mismatch")]
+    PayloadDigestMismatch,
+    /// Header checksum mismatch.
+    #[error("WAL header checksum mismatch")]
+    HeaderChecksumMismatch,
+    /// Frame checksum mismatch.
+    #[error("WAL frame checksum mismatch")]
+    FrameChecksumMismatch,
+    /// Record kind does not match transaction kind authority.
+    #[error("WAL record kind authority does not match transaction kind")]
+    RecordAuthorityMismatch,
+    /// Transaction contains no frames.
+    #[error("WAL transaction contains no frames")]
+    EmptyTransaction,
+    /// Frame transaction id mismatch.
+    #[error("WAL frame transaction id mismatch")]
+    TransactionIdMismatch,
+    /// Frame writer epoch mismatch.
+    #[error("WAL frame writer epoch mismatch")]
+    WriterEpochMismatch,
+    /// Transaction local index mismatch.
+    #[error("WAL transaction local index mismatch")]
+    TransactionLocalIndexMismatch,
+    /// Transaction LSN continuity mismatch.
+    #[error("WAL transaction LSN continuity mismatch")]
+    LsnContinuityMismatch,
+    /// First LSN mismatch.
+    #[error("WAL transaction first LSN mismatch")]
+    FirstLsnMismatch,
+    /// Last LSN mismatch.
+    #[error("WAL transaction last LSN mismatch")]
+    LastLsnMismatch,
+    /// Record count mismatch.
+    #[error("WAL transaction record count mismatch")]
+    RecordCountMismatch,
+    /// Records root mismatch.
+    #[error("WAL transaction records root mismatch")]
+    RecordsRootMismatch,
+    /// Affected frontiers root mismatch.
+    #[error("WAL transaction affected frontiers root mismatch")]
+    AffectedFrontiersRootMismatch,
+    /// Commit digest mismatch.
+    #[error("WAL transaction commit digest mismatch")]
+    CommitDigestMismatch,
+}
+
+/// WAL store errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalStoreError {
+    /// A writer epoch is already active.
+    #[error("WAL writer epoch already active")]
+    WriterEpochAlreadyActive,
+    /// No writer epoch is active.
+    #[error("no active WAL writer epoch")]
+    NoActiveWriterEpoch,
+    /// Writer epoch mismatch.
+    #[error("WAL writer epoch mismatch")]
+    WriterEpochMismatch,
+    /// Previous writer epoch is unknown.
+    #[error("unknown previous WAL writer epoch")]
+    UnknownPreviousWriterEpoch,
+    /// Validation failed.
+    #[error(transparent)]
+    Validation(#[from] WalValidationError),
+}
+
+/// WAL recovery errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalRecoveryError {
+    /// Validation failed.
+    #[error(transparent)]
+    Validation(#[from] WalValidationError),
+    /// Store operation failed.
+    #[error(transparent)]
+    Store(#[from] WalStoreError),
+}
+
+/// WAL replay errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalReplayError {
+    /// Validation failed.
+    #[error(transparent)]
+    Validation(#[from] WalValidationError),
+    /// Frontier mismatch.
+    #[error("WAL replay frontier mismatch for {kind:?}")]
+    FrontierMismatch {
+        /// Frontier kind.
+        kind: AffectedFrontierKind,
+        /// Expected digest.
+        expected: Hash,
+        /// Actual digest.
+        actual: Hash,
+    },
+}
+
+/// WAL schema lint errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WalSchemaLintError {
+    /// Forbidden app noun.
+    #[error("WAL schema term {term:?} contains forbidden app noun {forbidden:?}")]
+    ForbiddenAppNoun {
+        /// Schema term.
+        term: String,
+        /// Forbidden noun.
+        forbidden: String,
+    },
+    /// Forbidden authority leak.
+    #[error("WAL schema term {term:?} contains forbidden authority leak {forbidden:?}")]
+    ForbiddenAuthorityLeak {
+        /// Schema term.
+        term: String,
+        /// Forbidden authority leak term.
+        forbidden: String,
+    },
+    /// Record kind name implies commit before transaction commit.
+    #[error("WAL schema term {term:?} implies commit outside WalTransactionCommit")]
+    RecordNameImpliesCommit {
+        /// Schema term.
+        term: String,
+    },
+}
+
+fn validate_transaction_frames(
+    frames: &[WalFrame],
+    commit: &WalTransactionCommit,
+) -> Result<(), WalValidationError> {
+    if frames.is_empty() {
+        return Err(WalValidationError::EmptyTransaction);
+    }
+    let first = frames.first().ok_or(WalValidationError::EmptyTransaction)?;
+    let last = frames.last().ok_or(WalValidationError::EmptyTransaction)?;
+    if first.header.lsn != commit.first_lsn {
+        return Err(WalValidationError::FirstLsnMismatch);
+    }
+    if last.header.lsn != commit.last_lsn {
+        return Err(WalValidationError::LastLsnMismatch);
+    }
+    if len_u64(frames.len()) != commit.record_count {
+        return Err(WalValidationError::RecordCountMismatch);
+    }
+    for (expected_index, frame) in frames.iter().enumerate() {
+        frame.validate_integrity()?;
+        if frame.header.transaction_id != commit.transaction_id {
+            return Err(WalValidationError::TransactionIdMismatch);
+        }
+        if frame.header.writer_epoch != commit.writer_epoch {
+            return Err(WalValidationError::WriterEpochMismatch);
+        }
+        if frame.header.transaction_local_index.as_u32() != len_u32(expected_index) {
+            return Err(WalValidationError::TransactionLocalIndexMismatch);
+        }
+        let expected_lsn = commit
+            .first_lsn
+            .as_u64()
+            .checked_add(len_u64(expected_index))
+            .map(Lsn::from_raw)
+            .ok_or(WalValidationError::LsnContinuityMismatch)?;
+        if frame.header.lsn != expected_lsn {
+            return Err(WalValidationError::LsnContinuityMismatch);
+        }
+    }
+    if records_root(frames) != commit.records_root {
+        return Err(WalValidationError::RecordsRootMismatch);
+    }
+    if commit.compute_digest() != commit.commit_digest {
+        return Err(WalValidationError::CommitDigestMismatch);
+    }
+    Ok(())
+}
+
+fn validate_transaction_semantics(
+    frames: &[WalFrame],
+    transaction_kind: WalTransactionKind,
+) -> Result<(), WalValidationError> {
+    let expected_authority = transaction_kind.required_authority();
+    for frame in frames {
+        if frame.header.record_kind.required_authority() != expected_authority {
+            return Err(WalValidationError::RecordAuthorityMismatch);
+        }
+    }
+    Ok(())
+}
+
+fn records_root(frames: &[WalFrame]) -> Hash {
+    let mut h = blake3::Hasher::new();
+    h.update(WAL_RECORDS_ROOT_DOMAIN);
+    h.update(&len_u64(frames.len()).to_le_bytes());
+    for frame in frames {
+        h.update(&frame.digest());
+    }
+    h.finalize().into()
+}
+
+fn affected_frontiers_root(frontiers: &[AffectedFrontier]) -> Hash {
+    let mut sorted = frontiers.to_vec();
+    sorted.sort_by_key(|frontier| frontier.kind);
+    let mut h = blake3::Hasher::new();
+    h.update(WAL_FRONTIERS_ROOT_DOMAIN);
+    h.update(&len_u64(sorted.len()).to_le_bytes());
+    for frontier in &sorted {
+        h.update(&[frontier.kind.code()]);
+        h.update(&frontier.before_digest);
+        h.update(&frontier.after_digest);
+    }
+    h.finalize().into()
+}
+
+fn compute_frame_checksum(header: &WalFrameHeader, payload: &WalRecordPayload) -> u32 {
+    let mut input = header.checksum_input(true);
+    input.extend_from_slice(&payload.digest());
+    input.extend_from_slice(&len_u64(payload.canonical_bytes.len()).to_le_bytes());
+    input.extend_from_slice(&payload.canonical_bytes);
+    checksum32(WAL_FRAME_CHECKSUM_DOMAIN, &input)
+}
+
+fn segment_digest(segment_id: WalSegmentId, frames: &[&WalFrame]) -> Hash {
+    let mut h = blake3::Hasher::new();
+    h.update(b"echo:causal_wal:segment:v1\0");
+    h.update(&segment_id.as_u64().to_le_bytes());
+    h.update(&len_u64(frames.len()).to_le_bytes());
+    for frame in frames {
+        h.update(&frame.digest());
+    }
+    h.finalize().into()
+}
+
+fn checksum32(domain: &[u8], bytes: &[u8]) -> u32 {
+    let mut h = blake3::Hasher::new();
+    h.update(domain);
+    h.update(bytes);
+    let digest = h.finalize();
+    let mut out = [0; 4];
+    out.copy_from_slice(&digest.as_bytes()[..4]);
+    u32::from_le_bytes(out)
+}
+
+fn update_len_prefixed(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+    hasher.update(&len_u64(bytes.len()).to_le_bytes());
+    hasher.update(bytes);
+}
+
+fn len_u64(len: usize) -> u64 {
+    match u64::try_from(len) {
+        Ok(value) => value,
+        Err(_) => u64::MAX,
+    }
+}
+
+fn len_u32(len: usize) -> u32 {
+    match u32::try_from(len) {
+        Ok(value) => value,
+        Err(_) => u32::MAX,
+    }
+}

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -2821,15 +2821,62 @@ fn segment_paths(root: &Path) -> Result<Vec<PathBuf>, WalStoreError> {
                 .extension()
                 .is_some_and(|extension| extension.eq_ignore_ascii_case("ecwal"))
         {
-            paths.push(path);
+            let segment_id = parse_segment_id(&path)?;
+            paths.push((segment_id, path));
         }
     }
-    paths.sort();
-    Ok(paths)
+    paths.sort_by_key(|(segment_id, path)| (*segment_id, path.clone()));
+    if let Some((first_segment_id, _)) = paths.first() {
+        let first_expected = WalSegmentId::from_raw(1);
+        if *first_segment_id != first_expected {
+            return Err(WalStoreError::SegmentGap {
+                expected: first_expected,
+                actual: *first_segment_id,
+            });
+        }
+    }
+    let mut previous_segment_id: Option<WalSegmentId> = None;
+    for (segment_id, _) in &paths {
+        if let Some(previous) = previous_segment_id {
+            let expected = WalSegmentId::from_raw(previous.as_u64() + 1);
+            if *segment_id == previous {
+                return Err(WalStoreError::DuplicateSegment(*segment_id));
+            }
+            if *segment_id != expected {
+                return Err(WalStoreError::SegmentGap {
+                    expected,
+                    actual: *segment_id,
+                });
+            }
+        }
+        previous_segment_id = Some(*segment_id);
+    }
+    Ok(paths.into_iter().map(|(_, path)| path).collect())
 }
 
 fn segment_path(root: &Path, segment_id: WalSegmentId) -> PathBuf {
     root.join(format!("segment-{:020}.ecwal", segment_id.as_u64()))
+}
+
+fn parse_segment_id(path: &Path) -> Result<WalSegmentId, WalStoreError> {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| WalStoreError::InvalidSegmentFileName(path.display().to_string()))?;
+    let Some(after_prefix) = name.strip_prefix("segment-") else {
+        return Err(WalStoreError::InvalidSegmentFileName(name.to_string()));
+    };
+    let digits = after_prefix
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>();
+    if digits.is_empty() {
+        return Err(WalStoreError::InvalidSegmentFileName(name.to_string()));
+    }
+    let raw = digits
+        .parse::<u64>()
+        .map_err(|_| WalStoreError::InvalidSegmentFileName(name.to_string()))?;
+    Ok(WalSegmentId::from_raw(raw))
 }
 
 fn write_manifest_atomic(root: &Path, manifest: &WalManifest) -> Result<(), WalStoreError> {
@@ -3484,6 +3531,20 @@ pub enum WalStoreError {
     /// Segment record kind was not recognized.
     #[error("unknown WAL disk record kind {0}")]
     UnknownDiskRecordKind(u8),
+    /// Segment filename could not be parsed.
+    #[error("invalid WAL segment filename {0}")]
+    InvalidSegmentFileName(String),
+    /// Segment ids are not contiguous.
+    #[error("WAL segment gap: expected {expected:?}, found {actual:?}")]
+    SegmentGap {
+        /// Expected segment id.
+        expected: WalSegmentId,
+        /// Actual segment id.
+        actual: WalSegmentId,
+    },
+    /// Multiple segment files claim the same segment id.
+    #[error("duplicate WAL segment id {0:?}")]
+    DuplicateSegment(WalSegmentId),
 }
 
 impl From<std::io::Error> for WalStoreError {

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -1149,6 +1149,19 @@ pub struct WalSegmentManifestEntry {
     pub last_lsn: Option<Lsn>,
 }
 
+/// Filesystem manifest validation report.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalManifestValidationReport {
+    /// Manifest loaded from disk.
+    pub manifest: WalManifest,
+    /// Number of segment files observed.
+    pub segment_count: u64,
+    /// Last committed LSN observed in segments.
+    pub last_committed_lsn: Option<Lsn>,
+    /// Last commit digest observed in segments.
+    pub last_commit_digest: Option<Hash>,
+}
+
 /// Builds a segment manifest entry from segment frames.
 #[must_use]
 pub fn segment_manifest_entry(
@@ -1174,7 +1187,7 @@ pub struct WalManifest {
     pub last_committed_lsn: Option<Lsn>,
     /// Last commit digest.
     pub last_commit_digest: Option<Hash>,
-    /// Number of sealed segments.
+    /// Number of segment files covered by the manifest.
     pub sealed_segment_count: u64,
 }
 
@@ -2405,6 +2418,12 @@ impl FilesystemWalStore {
         segment_path(&self.root, self.segment_id)
     }
 
+    /// Returns the active logical segment id.
+    #[must_use]
+    pub const fn active_segment_id(&self) -> WalSegmentId {
+        self.segment_id
+    }
+
     /// Returns the WAL root directory.
     #[must_use]
     pub fn root(&self) -> &Path {
@@ -2438,6 +2457,41 @@ impl FilesystemWalStore {
     ) -> Result<(), WalStoreError> {
         self.append_frame(epoch_id, frame)
     }
+
+    /// Seals the active segment and starts the next canonical segment.
+    pub fn rotate_segment(
+        &mut self,
+        epoch_id: WriterEpochId,
+    ) -> Result<WalSegmentSeal, WalStoreError> {
+        let active_epoch = self
+            .active_epoch
+            .as_ref()
+            .ok_or(WalStoreError::NoActiveWriterEpoch)?;
+        if active_epoch.epoch_id != epoch_id {
+            return Err(WalStoreError::WriterEpochMismatch);
+        }
+        let current_segment_id = self.segment_id;
+        ensure_segment_has_no_uncommitted_tail(&self.root, current_segment_id)?;
+        let seal = self.seal_segment(epoch_id, current_segment_id)?;
+        let next_segment_id = next_segment_id(Some(current_segment_id))
+            .map_err(|_| WalStoreError::SegmentIdOverflow)?;
+        let next_segment_path = segment_path(&self.root, next_segment_id);
+        if next_segment_path.exists() {
+            return Err(WalStoreError::DuplicateSegment(next_segment_id));
+        }
+        File::create(&next_segment_path)?.sync_all()?;
+        self.sync_evidence.push(FilesystemSyncEvidence::segment(
+            FilesystemSyncBoundary::SegmentFileCreated,
+            next_segment_id,
+        ));
+        sync_directory_store(&segments_dir(&self.root))?;
+        self.sync_evidence.push(FilesystemSyncEvidence::segment(
+            FilesystemSyncBoundary::SegmentDirectorySynced,
+            next_segment_id,
+        ));
+        self.segment_id = next_segment_id;
+        Ok(seal)
+    }
 }
 
 impl WalStorePort for FilesystemWalStore {
@@ -2466,6 +2520,12 @@ impl WalStorePort for FilesystemWalStore {
             .ok_or(WalStoreError::NoActiveWriterEpoch)?;
         if active_epoch.epoch_id != epoch_id || frame.header.writer_epoch != epoch_id {
             return Err(WalStoreError::WriterEpochMismatch);
+        }
+        if frame.header.segment_id != self.segment_id {
+            return Err(WalStoreError::SegmentMismatch {
+                expected: self.segment_id,
+                actual: frame.header.segment_id,
+            });
         }
         frame.validate_integrity()?;
         append_segment_record(&self.segment_path(), DiskWalRecord::Frame(&frame), false)
@@ -2624,6 +2684,62 @@ pub fn doctor_filesystem_store(
         Err(_) => return Ok(obstructed_doctor_report()),
     };
     Ok(doctor_report_from_scan(report, 0, [0; 32], [0; 32]))
+}
+
+/// Reads the published filesystem WAL manifest, if present.
+pub fn read_filesystem_manifest(
+    root: impl AsRef<Path>,
+) -> Result<Option<WalManifest>, WalStoreError> {
+    let path = root.as_ref().join("manifest.ecwal");
+    if !path.exists() {
+        return Ok(None);
+    }
+    read_manifest_file(&path).map(Some)
+}
+
+/// Validates the published filesystem WAL manifest against segment contents.
+pub fn validate_filesystem_manifest(
+    root: impl AsRef<Path>,
+) -> Result<WalManifestValidationReport, WalStoreError> {
+    let root = root.as_ref();
+    let manifest = read_filesystem_manifest(root)?.ok_or(WalStoreError::MissingManifest)?;
+    let segment_count = len_u64(segment_paths(root)?.len());
+    let (frames, commits, torn_tail) = read_filesystem_segments(root)?;
+    if torn_tail {
+        return Err(WalStoreError::ManifestCannotValidateUncommittedTail);
+    }
+    let last_committed_lsn = commits.iter().map(|commit| commit.last_lsn).max();
+    if frames
+        .iter()
+        .any(|frame| last_committed_lsn.is_none_or(|lsn| frame.header.lsn > lsn))
+    {
+        return Err(WalStoreError::ManifestCannotValidateUncommittedTail);
+    }
+    let last_commit_digest = commits.last().map(|commit| commit.commit_digest);
+    if manifest.sealed_segment_count != segment_count {
+        return Err(WalStoreError::ManifestSegmentCountMismatch {
+            expected: segment_count,
+            actual: manifest.sealed_segment_count,
+        });
+    }
+    if manifest.last_committed_lsn != last_committed_lsn {
+        return Err(WalStoreError::ManifestLastCommittedLsnMismatch {
+            expected: last_committed_lsn,
+            actual: manifest.last_committed_lsn,
+        });
+    }
+    if manifest.last_commit_digest != last_commit_digest {
+        return Err(WalStoreError::ManifestLastCommitDigestMismatch {
+            expected: last_commit_digest,
+            actual: manifest.last_commit_digest,
+        });
+    }
+    Ok(WalManifestValidationReport {
+        manifest,
+        segment_count,
+        last_committed_lsn,
+        last_commit_digest,
+    })
 }
 
 /// Object-store read-after-write posture required by strict object storage.
@@ -3197,6 +3313,12 @@ pub fn audit_wal_release_readiness(gates: WalReleaseReadinessGates) -> WalReleas
     push_gate(
         &mut passed_gates,
         &mut blocked_gates,
+        "segment_manifest_validation",
+        gates.segment_manifest_validation,
+    );
+    push_gate(
+        &mut passed_gates,
+        &mut blocked_gates,
         "crash_matrix",
         gates.crash_matrix,
     );
@@ -3285,6 +3407,8 @@ pub struct WalReleaseReadinessGates {
     pub segment_repair: bool,
     /// Segment layout policy gate.
     pub segment_layout_policy: bool,
+    /// Segment manifest validation gate.
+    pub segment_manifest_validation: bool,
     /// Crash matrix gate.
     pub crash_matrix: bool,
     /// Crashpoint manifest gate.
@@ -3417,6 +3541,24 @@ fn read_segment_file(
         offset = digest_end;
     }
     Ok((frames, commits, torn_tail))
+}
+
+fn ensure_segment_has_no_uncommitted_tail(
+    root: &Path,
+    segment_id: WalSegmentId,
+) -> Result<(), WalStoreError> {
+    let (frames, commits, torn_tail) = read_segment_file(&segment_path(root, segment_id))?;
+    if torn_tail {
+        return Err(WalStoreError::SegmentHasUncommittedTail(segment_id));
+    }
+    let last_committed_lsn = commits.iter().map(|commit| commit.last_lsn).max();
+    if frames
+        .iter()
+        .any(|frame| last_committed_lsn.is_none_or(|lsn| frame.header.lsn > lsn))
+    {
+        return Err(WalStoreError::SegmentHasUncommittedTail(segment_id));
+    }
+    Ok(())
 }
 
 fn rewrite_filesystem_segments_after_truncation(
@@ -3568,14 +3710,40 @@ fn parse_segment_id(path: &Path) -> Result<WalSegmentId, WalStoreError> {
     Ok(WalSegmentId::from_raw(raw))
 }
 
-fn write_manifest_atomic(root: &Path, manifest: &WalManifest) -> Result<(), WalStoreError> {
-    let path = root.join("manifest.ecwal");
-    let temp = root.join(".manifest.ecwal.tmp");
+fn encode_manifest(manifest: &WalManifest) -> Vec<u8> {
     let mut bytes = Vec::new();
     push_hash(&mut bytes, &manifest.manifest_digest);
     push_optional_lsn(&mut bytes, manifest.last_committed_lsn);
     push_optional_hash(&mut bytes, manifest.last_commit_digest);
     bytes.extend_from_slice(&manifest.sealed_segment_count.to_le_bytes());
+    bytes
+}
+
+fn decode_manifest(bytes: &[u8]) -> Result<WalManifest, WalDecodeError> {
+    let mut cursor = WalPayloadCursor::new(bytes);
+    let manifest_digest = cursor.read_hash()?;
+    let last_committed_lsn = cursor.read_optional_lsn()?;
+    let last_commit_digest = cursor.read_optional_hash()?;
+    let sealed_segment_count = cursor.read_u64()?;
+    cursor.finish()?;
+    Ok(WalManifest {
+        manifest_digest,
+        last_committed_lsn,
+        last_commit_digest,
+        sealed_segment_count,
+    })
+}
+
+fn read_manifest_file(path: &Path) -> Result<WalManifest, WalStoreError> {
+    let mut bytes = Vec::new();
+    File::open(path)?.read_to_end(&mut bytes)?;
+    decode_manifest(&bytes).map_err(WalStoreError::Decode)
+}
+
+fn write_manifest_atomic(root: &Path, manifest: &WalManifest) -> Result<(), WalStoreError> {
+    let path = root.join("manifest.ecwal");
+    let temp = root.join(".manifest.ecwal.tmp");
+    let bytes = encode_manifest(manifest);
     {
         let mut file = File::create(&temp)?;
         file.write_all(&bytes)?;
@@ -4346,6 +4514,50 @@ pub enum WalStoreError {
     /// Multiple segment files claim the same segment id.
     #[error("duplicate WAL segment id {0:?}")]
     DuplicateSegment(WalSegmentId),
+    /// Frame segment id does not match the active segment.
+    #[error("WAL segment mismatch: expected {expected:?}, found {actual:?}")]
+    SegmentMismatch {
+        /// Expected active segment id.
+        expected: WalSegmentId,
+        /// Actual frame segment id.
+        actual: WalSegmentId,
+    },
+    /// Segment rotation would overflow logical segment identity.
+    #[error("WAL segment id overflow")]
+    SegmentIdOverflow,
+    /// Segment contains an uncommitted tail and cannot be sealed.
+    #[error("WAL segment {0:?} has an uncommitted tail")]
+    SegmentHasUncommittedTail(WalSegmentId),
+    /// Published filesystem manifest is missing.
+    #[error("filesystem WAL manifest is missing")]
+    MissingManifest,
+    /// Published filesystem manifest segment count does not match segments.
+    #[error("filesystem WAL manifest segment count mismatch: expected {expected}, found {actual}")]
+    ManifestSegmentCountMismatch {
+        /// Expected scanned segment count.
+        expected: u64,
+        /// Actual manifest segment count.
+        actual: u64,
+    },
+    /// Published filesystem manifest last committed LSN does not match segments.
+    #[error("filesystem WAL manifest last committed LSN mismatch")]
+    ManifestLastCommittedLsnMismatch {
+        /// Expected scanned last committed LSN.
+        expected: Option<Lsn>,
+        /// Actual manifest last committed LSN.
+        actual: Option<Lsn>,
+    },
+    /// Published filesystem manifest last commit digest does not match segments.
+    #[error("filesystem WAL manifest last commit digest mismatch")]
+    ManifestLastCommitDigestMismatch {
+        /// Expected scanned last commit digest.
+        expected: Option<Hash>,
+        /// Actual manifest last commit digest.
+        actual: Option<Hash>,
+    },
+    /// Manifest cannot validate while segments contain an uncommitted tail.
+    #[error("filesystem WAL manifest cannot validate an uncommitted tail")]
+    ManifestCannotValidateUncommittedTail,
 }
 
 impl From<std::io::Error> for WalStoreError {
@@ -4893,6 +5105,17 @@ impl<'a> WalPayloadCursor<'a> {
             1 => self.read_hash().map(Some),
             code => Err(WalDecodeError::UnknownEnumCode {
                 enum_name: "Option<Hash>",
+                code,
+            }),
+        }
+    }
+
+    fn read_optional_lsn(&mut self) -> Result<Option<Lsn>, WalDecodeError> {
+        match self.read_u8()? {
+            0 => Ok(None),
+            1 => self.read_u64().map(|raw| Some(Lsn::from_raw(raw))),
+            code => Err(WalDecodeError::UnknownEnumCode {
+                enum_name: "Option<Lsn>",
                 code,
             }),
         }

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod wsc;
 mod admission;
 mod attachment;
 mod causal_facts;
+pub mod causal_wal;
 mod clock;
 mod cmd;
 mod constants;

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -338,6 +338,7 @@ pub use tick_patch::{
 #[cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
 pub use trusted_runtime_host::{
     TrustedRuntimeApp, TrustedRuntimeHost, TrustedRuntimeHostError, TrustedRuntimeHostRunReport,
+    TrustedRuntimeWal, TrustedRuntimeWalError,
 };
 pub use tx::TxId;
 pub use warp_state::{WarpInstance, WarpState};

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -10,6 +10,14 @@
 use thiserror::Error;
 
 use crate::{
+    causal_wal::{
+        build_submission_acceptance_transaction, AffectedFrontier, AffectedFrontierKind,
+        InMemoryWalStore, Lsn, PayloadCodecId, PayloadSchemaId, SubmissionAcceptanceRecord,
+        WalAppendAuthority, WalBuildError, WalCommittedTransaction, WalDurabilityMode,
+        WalRecordKind, WalSegmentId, WalStoreError, WalStorePort, WalTransactionBuilder,
+        WalTransactionCommit, WalTransactionId, WalTransactionKind, WriterEpochId,
+        WriterEpochRequest,
+    },
     Engine, IngressEnvelope, InstalledContractPackage, InstalledContractPackageError,
     InstalledContractPackageRecord, IntentOutcome, IntentSubmissionHandle, ObservationArtifact,
     ObservationError, ObservationRequest, ObservationService, OpticAdmissionTicket,
@@ -17,6 +25,8 @@ use crate::{
     TicketedRuntimeIngressAuthority, TicketedRuntimeIngressDisposition, WorldlineRuntime,
 };
 use crate::{Hash, HistoryError};
+
+const TRUSTED_RUNTIME_WAL_DOMAIN: &[u8] = b"echo:trusted-runtime-wal:v1\0";
 
 /// Error returned by the reference trusted host loop.
 #[derive(Debug, Error)]
@@ -26,13 +36,36 @@ pub enum TrustedRuntimeHostError {
     Provenance(#[from] HistoryError),
     /// Scheduler/runtime work failed.
     #[error("trusted runtime host runtime error: {0}")]
-    Runtime(#[from] RuntimeError),
+    Runtime(Box<RuntimeError>),
+    /// The app used the WAL-backed ACK path before a runtime WAL was configured.
+    #[error("trusted runtime host runtime WAL is unavailable")]
+    RuntimeWalUnavailable,
+    /// Runtime WAL append or build failed.
+    #[error("trusted runtime host WAL error: {0}")]
+    Wal(#[from] TrustedRuntimeWalError),
     /// The host reached its caller-supplied scheduler-pass bound before idling.
     #[error("trusted runtime host exceeded scheduler pass limit: {max_scheduler_passes}")]
     SchedulerPassLimitExceeded {
         /// Maximum scheduler passes the caller allowed.
         max_scheduler_passes: u64,
     },
+}
+
+impl From<RuntimeError> for TrustedRuntimeHostError {
+    fn from(error: RuntimeError) -> Self {
+        Self::Runtime(Box::new(error))
+    }
+}
+
+/// Error returned by the trusted runtime WAL adapter.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TrustedRuntimeWalError {
+    /// WAL transaction construction failed before storage append.
+    #[error("trusted runtime WAL transaction build error: {0}")]
+    Build(#[from] WalBuildError),
+    /// WAL storage failed before durable acknowledgement.
+    #[error("trusted runtime WAL store error: {0}")]
+    Store(#[from] WalStoreError),
 }
 
 /// Summary returned after a trusted host runs the scheduler until idle.
@@ -53,6 +86,7 @@ pub struct TrustedRuntimeHost {
     runtime: WorldlineRuntime,
     provenance: ProvenanceService,
     engine: Engine,
+    runtime_wal: Option<TrustedRuntimeWal>,
 }
 
 impl TrustedRuntimeHost {
@@ -68,6 +102,7 @@ impl TrustedRuntimeHost {
             runtime,
             provenance,
             engine,
+            runtime_wal: None,
         })
     }
 
@@ -82,6 +117,7 @@ impl TrustedRuntimeHost {
             runtime,
             provenance,
             engine,
+            runtime_wal: None,
         }
     }
 
@@ -107,6 +143,32 @@ impl TrustedRuntimeHost {
     #[must_use]
     pub fn engine(&self) -> &Engine {
         &self.engine
+    }
+
+    /// Enables the in-memory WAL adapter used by the reference host tests.
+    ///
+    /// This adapter proves the ACK ordering contract and recovery indexes. It
+    /// is not a strict filesystem durability adapter.
+    ///
+    /// # Errors
+    ///
+    /// Returns a WAL error when the writer epoch cannot be acquired.
+    pub fn enable_in_memory_runtime_wal(&mut self) -> Result<(), TrustedRuntimeHostError> {
+        self.runtime_wal = Some(TrustedRuntimeWal::new_in_memory()?);
+        Ok(())
+    }
+
+    /// Returns the configured runtime WAL adapter, if any, as read-only
+    /// evidence.
+    #[must_use]
+    pub fn runtime_wal(&self) -> Option<&TrustedRuntimeWal> {
+        self.runtime_wal.as_ref()
+    }
+
+    /// Replaces the runtime WAL adapter for targeted host tests.
+    #[cfg(any(test, feature = "host_test"))]
+    pub fn replace_runtime_wal_for_test(&mut self, runtime_wal: TrustedRuntimeWal) {
+        self.runtime_wal = Some(runtime_wal);
     }
 
     /// Returns the app-facing surface. This surface can submit and observe, but
@@ -200,6 +262,192 @@ impl TrustedRuntimeHost {
     }
 }
 
+/// Minimal trusted-runtime WAL adapter for ACK-boundary integration tests.
+#[derive(Clone, Debug)]
+pub struct TrustedRuntimeWal {
+    store: InMemoryWalStore,
+    writer_epoch: WriterEpochId,
+    segment_id: WalSegmentId,
+    next_lsn: Lsn,
+    previous_frame_digest: Hash,
+    previous_committed_transaction_digest: Hash,
+    durability_mode: WalDurabilityMode,
+    payload_codec_id: PayloadCodecId,
+    payload_schema_id: PayloadSchemaId,
+    digest_domain: Hash,
+    submission_frontier_digest: Hash,
+}
+
+impl TrustedRuntimeWal {
+    /// Builds a WAL adapter backed by an in-memory store.
+    pub fn new_in_memory() -> Result<Self, TrustedRuntimeWalError> {
+        Self::new_in_memory_at_lsn(Lsn::from_raw(0))
+    }
+
+    fn new_in_memory_at_lsn(next_lsn: Lsn) -> Result<Self, TrustedRuntimeWalError> {
+        let mut store = InMemoryWalStore::new();
+        let writer_epoch = WriterEpochId::from_hash(trusted_runtime_wal_digest("writer-epoch"));
+        store.acquire_writer_epoch(WriterEpochRequest {
+            epoch_id: writer_epoch,
+            storage_fencing_token: trusted_runtime_wal_digest("fencing-token"),
+            process_identity: trusted_runtime_wal_digest("process"),
+            host_identity: trusted_runtime_wal_digest("host"),
+            started_at_lsn: next_lsn,
+            previous_epoch_id: None,
+            previous_epoch_final_commit_digest: None,
+            lease_or_lock_evidence: trusted_runtime_wal_digest("lease"),
+        })?;
+        Ok(Self {
+            store,
+            writer_epoch,
+            segment_id: WalSegmentId::from_raw(1),
+            next_lsn,
+            previous_frame_digest: trusted_runtime_wal_digest("previous-frame:genesis"),
+            previous_committed_transaction_digest: trusted_runtime_wal_digest(
+                "previous-commit:genesis",
+            ),
+            durability_mode: WalDurabilityMode::Buffered,
+            payload_codec_id: PayloadCodecId::from_hash(trusted_runtime_wal_digest(
+                "payload-codec",
+            )),
+            payload_schema_id: PayloadSchemaId::from_hash(trusted_runtime_wal_digest(
+                "payload-schema",
+            )),
+            digest_domain: trusted_runtime_wal_digest("digest-domain"),
+            submission_frontier_digest: trusted_runtime_wal_digest("submission-frontier:genesis"),
+        })
+    }
+
+    /// Returns committed WAL markers recorded by the adapter.
+    #[must_use]
+    pub fn commits(&self) -> Vec<WalTransactionCommit> {
+        self.store.read_commits()
+    }
+
+    /// Returns committed WAL frames recorded by the adapter.
+    #[must_use]
+    pub fn frames(&self) -> Vec<crate::causal_wal::WalFrame> {
+        self.store.read_frames()
+    }
+
+    /// Returns a clone of the underlying in-memory store for recovery tests.
+    #[must_use]
+    pub fn cloned_store(&self) -> InMemoryWalStore {
+        self.store.clone()
+    }
+
+    /// Returns the number of committed submission-intake transactions.
+    #[must_use]
+    pub fn submission_acceptance_count(&self) -> usize {
+        self.store
+            .read_commits()
+            .into_iter()
+            .filter(|commit| commit.transaction_kind == WalTransactionKind::SubmissionIntake)
+            .count()
+    }
+
+    fn has_submission_acceptance(
+        &self,
+        submission_id: Hash,
+        canonical_envelope_digest: Hash,
+    ) -> bool {
+        self.store.read_frames().into_iter().any(|frame| {
+            if frame.header.record_kind != WalRecordKind::SubmissionAcceptedRecorded {
+                return false;
+            }
+            SubmissionAcceptanceRecord::from_payload_bytes(&frame.payload.canonical_bytes)
+                .is_ok_and(|record| {
+                    record.submission_id == submission_id
+                        && record.canonical_envelope_digest == canonical_envelope_digest
+                })
+        })
+    }
+
+    fn record_submission_acceptance(
+        &mut self,
+        envelope: &IngressEnvelope,
+        handle: IntentSubmissionHandle,
+    ) -> Result<WalTransactionCommit, TrustedRuntimeWalError> {
+        let record = SubmissionAcceptanceRecord {
+            submission_id: handle.submission_id,
+            canonical_envelope_digest: envelope.ingress_id(),
+            idempotency_key_digest: None,
+            acceptance_evidence_digest: acceptance_evidence_digest(handle),
+        };
+        let next_submission_frontier =
+            submission_frontier_digest(self.submission_frontier_digest, record);
+        let transaction = build_submission_acceptance_transaction(
+            self.builder(
+                WalTransactionKind::SubmissionIntake,
+                WalAppendAuthority::SubmissionIntake,
+                WalTransactionId::from_hash(submission_transaction_digest(handle, record)),
+            ),
+            record,
+            vec![AffectedFrontier {
+                kind: AffectedFrontierKind::SubmissionQueue,
+                before_digest: self.submission_frontier_digest,
+                after_digest: next_submission_frontier,
+            }],
+        )?;
+        let commit = self.append_transaction(transaction)?;
+        self.submission_frontier_digest = next_submission_frontier;
+        Ok(commit)
+    }
+
+    fn append_transaction(
+        &mut self,
+        transaction: WalCommittedTransaction,
+    ) -> Result<WalTransactionCommit, TrustedRuntimeWalError> {
+        let last_frame_digest = transaction.frames.last().map_or(
+            self.previous_frame_digest,
+            crate::causal_wal::WalFrame::digest,
+        );
+        let next_lsn = transaction
+            .commit
+            .last_lsn
+            .checked_next()
+            .ok_or(WalBuildError::LsnOverflow)?;
+        let commit = transaction.commit.clone();
+        self.store.append_transaction(transaction)?;
+        self.next_lsn = next_lsn;
+        self.previous_frame_digest = last_frame_digest;
+        self.previous_committed_transaction_digest = commit.commit_digest;
+        Ok(commit)
+    }
+
+    fn builder(
+        &self,
+        kind: WalTransactionKind,
+        authority: WalAppendAuthority,
+        transaction_id: WalTransactionId,
+    ) -> WalTransactionBuilder {
+        WalTransactionBuilder::new(
+            self.writer_epoch,
+            self.segment_id,
+            transaction_id,
+            kind,
+            authority,
+            self.next_lsn,
+            self.previous_frame_digest,
+            self.previous_committed_transaction_digest,
+            self.durability_mode,
+            self.payload_codec_id,
+            self.payload_schema_id,
+            1,
+            1,
+            self.digest_domain,
+        )
+    }
+}
+
+#[cfg(any(test, feature = "host_test"))]
+impl TrustedRuntimeWal {
+    /// Builds an in-memory WAL at a caller-supplied LSN for overflow tests.
+    pub fn new_in_memory_at_lsn_for_test(next_lsn: Lsn) -> Result<Self, TrustedRuntimeWalError> {
+        Self::new_in_memory_at_lsn(next_lsn)
+    }
+}
+
 /// App-facing handle for a trusted local runtime host.
 ///
 /// This type intentionally exposes no scheduler control, package installation,
@@ -219,6 +467,45 @@ impl TrustedRuntimeApp<'_> {
         envelope: IngressEnvelope,
     ) -> Result<IntentSubmissionHandle, RuntimeError> {
         self.host.runtime.submit_app_intent(envelope)
+    }
+
+    /// Submits canonical intent material and returns only after the configured
+    /// runtime WAL has committed the acceptance transaction.
+    ///
+    /// This is the ACK-boundary path for hosts that have configured a runtime
+    /// WAL. It does not tick, stage ticketed ingress, install packages, or
+    /// expose WAL append authority to the application.
+    ///
+    /// # Errors
+    ///
+    /// Returns an explicit host error if no WAL is configured, if runtime intake
+    /// rejects the submission, or if WAL commit fails. On WAL failure, the
+    /// in-memory runtime intake mutation is rolled back before the error is
+    /// returned.
+    pub fn submit_intent_with_runtime_wal_ack(
+        &mut self,
+        envelope: IngressEnvelope,
+    ) -> Result<IntentSubmissionHandle, TrustedRuntimeHostError> {
+        if self.host.runtime_wal.is_none() {
+            return Err(TrustedRuntimeHostError::RuntimeWalUnavailable);
+        }
+
+        let before_runtime = self.host.runtime.clone();
+        let handle = self.host.runtime.submit_app_intent(envelope.clone())?;
+        let Some(runtime_wal) = self.host.runtime_wal.as_mut() else {
+            self.host.runtime = before_runtime;
+            return Err(TrustedRuntimeHostError::RuntimeWalUnavailable);
+        };
+        if handle.duplicate
+            && runtime_wal.has_submission_acceptance(handle.submission_id, envelope.ingress_id())
+        {
+            return Ok(handle);
+        }
+        if let Err(error) = runtime_wal.record_submission_acceptance(&envelope, handle) {
+            self.host.runtime = before_runtime;
+            return Err(error.into());
+        }
+        Ok(handle)
     }
 
     /// Observes the product-facing outcome for one witnessed submission.
@@ -254,4 +541,50 @@ fn provenance_from_runtime(
         provenance.register_worldline(*worldline_id, frontier.state())?;
     }
     Ok(provenance)
+}
+
+fn trusted_runtime_wal_digest(label: &str) -> Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(TRUSTED_RUNTIME_WAL_DOMAIN);
+    hasher.update(label.as_bytes());
+    hasher.finalize().into()
+}
+
+fn acceptance_evidence_digest(handle: IntentSubmissionHandle) -> Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(TRUSTED_RUNTIME_WAL_DOMAIN);
+    hasher.update(b"acceptance-evidence");
+    hasher.update(&handle.ingress_id);
+    hasher.update(handle.head_key.worldline_id.as_bytes());
+    hasher.update(handle.head_key.head_id.as_bytes());
+    hasher.update(&handle.submission_id);
+    hasher.update(&handle.submission_generation.as_u64().to_le_bytes());
+    hasher.update(&[u8::from(handle.duplicate)]);
+    hasher.finalize().into()
+}
+
+fn submission_transaction_digest(
+    handle: IntentSubmissionHandle,
+    record: SubmissionAcceptanceRecord,
+) -> Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(TRUSTED_RUNTIME_WAL_DOMAIN);
+    hasher.update(b"submission-transaction");
+    hasher.update(&handle.submission_id);
+    hasher.update(&handle.ingress_id);
+    hasher.update(&handle.submission_generation.as_u64().to_le_bytes());
+    hasher.update(&record.canonical_envelope_digest);
+    hasher.update(&record.acceptance_evidence_digest);
+    hasher.finalize().into()
+}
+
+fn submission_frontier_digest(previous: Hash, record: SubmissionAcceptanceRecord) -> Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(TRUSTED_RUNTIME_WAL_DOMAIN);
+    hasher.update(b"submission-frontier");
+    hasher.update(&previous);
+    hasher.update(&record.submission_id);
+    hasher.update(&record.canonical_envelope_digest);
+    hasher.update(&record.acceptance_evidence_digest);
+    hasher.finalize().into()
 }

--- a/crates/warp-core/tests/causal_wal_hardening_tests.rs
+++ b/crates/warp-core/tests/causal_wal_hardening_tests.rs
@@ -5,14 +5,16 @@
 use warp_core::causal_wal::{
     apply_committed_transaction, audit_wal_release_readiness,
     build_materialization_outbox_transaction, build_retained_reading_transaction,
-    build_submission_acceptance_transaction, build_tick_transaction, doctor_filesystem_store,
-    doctor_in_memory_store, doctor_in_memory_store_with_materials, evaluate_checkpoint_publication,
-    inspect_evidence_material_posture, project_absent_causal_commit_evidence,
+    build_submission_acceptance_transaction, build_tick_transaction,
+    canonical_segment_relative_path, doctor_filesystem_store, doctor_in_memory_store,
+    doctor_in_memory_store_with_materials, evaluate_checkpoint_publication,
+    inspect_evidence_material_posture, next_segment_id, project_absent_causal_commit_evidence,
     project_causal_commit_evidence, project_obstructed_causal_commit_evidence,
     read_checkpoint_record, recover_filesystem_store, recover_from_frames_and_commits,
     recover_materialization_outbox, recover_receipt_index, recover_retention_index,
-    recover_submission_index, retained_material_obstructions, shadow_replay_matches,
-    shadow_replay_report, validate_checkpoint_record, validate_filesystem_strict_sync_evidence,
+    recover_submission_index, retained_material_obstructions, segment_manifest_entry,
+    shadow_replay_matches, shadow_replay_report, validate_checkpoint_record,
+    validate_filesystem_strict_sync_evidence, validate_segment_placement_policy,
     validate_strict_object_store_capabilities, validate_strict_object_store_manifest_commit,
     wal_crashpoint_manifest, write_checkpoint_record_atomic,
     write_checkpoint_record_atomic_with_evidence, AffectedFrontier, AffectedFrontierKind,
@@ -29,9 +31,10 @@ use warp_core::causal_wal::{
     WalAppendAuthority, WalBuildError, WalCommittedTransaction, WalCrashpointBoundary,
     WalCrashpointExecution, WalDoctorPosture, WalDoctorReport, WalDurabilityMode, WalManifest,
     WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryError, WalReleaseReadinessGates,
-    WalReplayError, WalSegmentId, WalStoreError, WalStorePort, WalTickDecision,
-    WalTransactionBuilder, WalTransactionId, WalTransactionKind, WalValidationError, WriterEpochId,
-    WriterEpochRequest,
+    WalReplayError, WalSegmentId, WalSegmentIdError, WalSegmentPlacementKind,
+    WalSegmentPlacementPolicy, WalSegmentPlacementPolicyError, WalStoreError, WalStorePort,
+    WalTickDecision, WalTransactionBuilder, WalTransactionId, WalTransactionKind,
+    WalValidationError, WriterEpochId, WriterEpochRequest,
 };
 use warp_core::Hash;
 
@@ -1847,10 +1850,22 @@ fn filesystem_segment_creation_syncs_directory() {
     must_ok(validate_filesystem_strict_sync_evidence(
         fixture.store.sync_evidence(),
         &[
+            FilesystemSyncBoundary::SegmentNamespaceDirectorySynced,
             FilesystemSyncBoundary::SegmentFileCreated,
             FilesystemSyncBoundary::SegmentDirectorySynced,
         ],
     ));
+}
+
+#[test]
+fn filesystem_segment_namespace_creation_syncs_root_directory() {
+    let fixture = WalHardeningFixture::new("sync-segment-namespace");
+
+    assert!(fixture.store.sync_evidence().iter().any(|entry| {
+        entry.boundary == FilesystemSyncBoundary::SegmentNamespaceDirectorySynced
+            && entry.segment_id.is_none()
+            && entry.transaction_id.is_none()
+    }));
 }
 
 #[test]
@@ -2083,6 +2098,7 @@ fn wal_hardening_gate_passes_when_all_categories_are_green() {
         filesystem_adapter: true,
         object_store_capability_gate: true,
         segment_repair: true,
+        segment_layout_policy: true,
         crash_matrix: true,
         crashpoint_manifest: true,
         shadow_replay: true,
@@ -2099,4 +2115,187 @@ fn wal_hardening_gate_passes_when_all_categories_are_green() {
 
     assert!(report.ready);
     assert!(report.blocked_gates.is_empty());
+}
+
+#[test]
+fn canonical_segment_path_uses_logical_segments_directory() {
+    assert_eq!(
+        canonical_segment_relative_path(WalSegmentId::from_raw(1)),
+        PathBuf::from("segments").join("segment-00000000000000000001.ecwal")
+    );
+}
+
+#[test]
+fn wall_clock_segment_placement_cannot_be_authoritative() {
+    let error = must_err(
+        validate_segment_placement_policy(WalSegmentPlacementPolicy {
+            kind: WalSegmentPlacementKind::WallClockPartition,
+            authoritative: true,
+        }),
+        "wall-clock placement must not be authoritative",
+    );
+
+    assert_eq!(
+        error,
+        WalSegmentPlacementPolicyError::WallClockPlacementCannotBeAuthoritative
+    );
+}
+
+#[test]
+fn wall_clock_segment_placement_may_be_non_authoritative() {
+    must_ok(validate_segment_placement_policy(
+        WalSegmentPlacementPolicy {
+            kind: WalSegmentPlacementKind::WallClockPartition,
+            authoritative: false,
+        },
+    ));
+}
+
+#[test]
+fn recovery_scans_canonical_segments_directory() {
+    let mut fixture = WalHardeningFixture::new("layout-canonical-scan");
+    fixture.append_submission("layout-canonical-scan", Lsn::from_raw(0));
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(report.transactions.len(), 1);
+    assert!(fixture
+        .store
+        .segment_path()
+        .starts_with(fixture.root.join("segments")));
+}
+
+#[test]
+fn legacy_flat_segment_scan_remains_readable() {
+    let mut fixture = WalHardeningFixture::new("layout-legacy-source");
+    fixture.append_submission("layout-legacy-source", Lsn::from_raw(0));
+    let segment_bytes = fixture.segment_bytes();
+    let legacy_root = temp_wal_root("layout-legacy-target");
+    must_ok(fs::write(
+        legacy_root.join(segment_file_name(1)),
+        segment_bytes,
+    ));
+
+    let report = must_ok(recover_filesystem_store(
+        &legacy_root,
+        RecoveryAccessMode::ReadOnly,
+    ));
+
+    assert_eq!(report.transactions.len(), 1);
+}
+
+#[test]
+fn segment_gap_in_canonical_directory_blocks_recovery() {
+    let fixture = WalHardeningFixture::new("layout-gap");
+    must_ok(fs::write(
+        fixture.root.join("segments").join(segment_file_name(3)),
+        b"gap-segment",
+    ));
+
+    let error = must_err(
+        fixture.recover_read_only(),
+        "canonical segment gap should block recovery",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Store(WalStoreError::SegmentGap {
+            expected,
+            actual
+        }) if expected == WalSegmentId::from_raw(2) && actual == WalSegmentId::from_raw(3)
+    ));
+}
+
+#[test]
+fn duplicate_segment_id_across_layouts_blocks_recovery() {
+    let fixture = WalHardeningFixture::new("layout-duplicate");
+    must_ok(fs::write(
+        fixture.root.join(segment_file_name(1)),
+        b"legacy-duplicate",
+    ));
+
+    let error = must_err(
+        fixture.recover_read_only(),
+        "duplicate segment id across canonical and legacy layout should block recovery",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Store(WalStoreError::DuplicateSegment(segment_id))
+            if segment_id == WalSegmentId::from_raw(1)
+    ));
+}
+
+#[test]
+fn writable_recovery_rewrite_preserves_canonical_segments_directory() {
+    let mut fixture = WalHardeningFixture::new("layout-rewrite");
+    fixture.append_submission("layout-rewrite", Lsn::from_raw(0));
+    fixture.append_uncommitted_tick_frame("layout-rewrite-tail", Lsn::from_raw(2));
+
+    let report = must_ok(recover_filesystem_store(
+        &fixture.root,
+        RecoveryAccessMode::Writable,
+    ));
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::TruncatedAfter(Lsn::from_raw(1))
+    );
+    assert!(fixture
+        .root
+        .join("segments")
+        .join(segment_file_name(1))
+        .exists());
+}
+
+#[test]
+fn next_segment_id_overflow_blocks_rotation() {
+    let error = must_err(
+        next_segment_id(Some(WalSegmentId::from_raw(u64::MAX))),
+        "segment id overflow should block rotation",
+    );
+
+    assert_eq!(error, WalSegmentIdError::Overflow);
+}
+
+#[test]
+fn segment_manifest_entry_binds_logical_id_not_wall_clock_path() {
+    let transaction = submission_transaction("layout-manifest-entry", Lsn::from_raw(0));
+    let entry = segment_manifest_entry(WalSegmentId::from_raw(1), &transaction.frames);
+
+    assert_eq!(entry.segment_id, WalSegmentId::from_raw(1));
+    assert_eq!(
+        entry.relative_path,
+        PathBuf::from("segments").join(segment_file_name(1))
+    );
+    assert!(!entry.relative_path.to_string_lossy().contains("2026/"));
+    assert_eq!(entry.first_lsn, Some(Lsn::from_raw(0)));
+    assert_eq!(entry.last_lsn, Some(Lsn::from_raw(1)));
+}
+
+#[test]
+fn segment_layout_gate_is_part_of_wal_release_readiness() {
+    let report = audit_wal_release_readiness(WalReleaseReadinessGates {
+        filesystem_adapter: true,
+        object_store_capability_gate: true,
+        segment_repair: true,
+        crash_matrix: true,
+        crashpoint_manifest: true,
+        shadow_replay: true,
+        outbox: true,
+        commit_evidence: true,
+        wal_doctor: true,
+        semantic_validator: true,
+        filesystem_sync_evidence: true,
+        object_store_manifest_negatives: true,
+        security_redaction: true,
+        app_noun_guard: true,
+        external_consumer_gate: true,
+        ..WalReleaseReadinessGates::default()
+    });
+
+    assert!(
+        report.blocked_gates.contains(&"segment_layout_policy"),
+        "layout policy should be an explicit WAL release gate"
+    );
 }

--- a/crates/warp-core/tests/causal_wal_hardening_tests.rs
+++ b/crates/warp-core/tests/causal_wal_hardening_tests.rs
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Adversarial causal WAL hardening tests.
+
+use warp_core::causal_wal::{
+    build_submission_acceptance_transaction, build_tick_transaction, recover_filesystem_store,
+    recover_receipt_index, recover_submission_index, AffectedFrontier, AffectedFrontierKind,
+    FilesystemWalStore, Lsn, PayloadCodecId, PayloadSchemaId, RecoveredSubmissionPosture,
+    RecoveryAccessMode, RecoveryTailPosture, SubmissionAcceptanceRecord, SubmissionRetryPosture,
+    TickReceiptRecord, WalAppendAuthority, WalCommittedTransaction, WalDurabilityMode,
+    WalReceiptCorrelationRecord, WalRecoveryError, WalSegmentId, WalStoreError, WalStorePort,
+    WalTickDecision, WalTransactionBuilder, WalTransactionId, WalTransactionKind, WriterEpochId,
+    WriterEpochRequest,
+};
+use warp_core::Hash;
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const WAL_SEGMENT_RECORD_MAGIC: &[u8; 8] = b"ECWALR1!";
+const WAL_DISK_RECORD_DOMAIN: &[u8] = b"echo:causal_wal:disk_record:v1\0";
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn digest(label: &str) -> Hash {
+    blake3::hash(label.as_bytes()).into()
+}
+
+fn must_ok<T, E: std::fmt::Debug>(result: Result<T, E>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => {
+            let ok = false;
+            assert!(ok, "expected Ok(..), got {error:?}");
+            std::process::abort();
+        }
+    }
+}
+
+fn must_err<T: std::fmt::Debug, E>(result: Result<T, E>, context: &str) -> E {
+    match result {
+        Err(error) => error,
+        Ok(value) => {
+            let ok = false;
+            assert!(ok, "{context}: expected Err(..), got Ok({value:?})");
+            std::process::abort();
+        }
+    }
+}
+
+fn must_some<T>(option: Option<T>, context: &str) -> T {
+    if let Some(value) = option {
+        value
+    } else {
+        let ok = false;
+        assert!(ok, "{context}: expected Some(..), got None");
+        std::process::abort();
+    }
+}
+
+fn transaction_id(label: &str) -> WalTransactionId {
+    WalTransactionId::from_hash(digest(label))
+}
+
+fn epoch_id() -> WriterEpochId {
+    WriterEpochId::from_hash(digest("hardening:epoch:1"))
+}
+
+fn writer_epoch_request() -> WriterEpochRequest {
+    WriterEpochRequest {
+        epoch_id: epoch_id(),
+        storage_fencing_token: digest("hardening:fence:1"),
+        process_identity: digest("hardening:process:1"),
+        host_identity: digest("hardening:host:1"),
+        started_at_lsn: Lsn::from_raw(0),
+        previous_epoch_id: None,
+        previous_epoch_final_commit_digest: None,
+        lease_or_lock_evidence: digest("hardening:lock:1"),
+    }
+}
+
+fn builder(
+    label: &str,
+    first_lsn: Lsn,
+    authority: WalAppendAuthority,
+    transaction_kind: WalTransactionKind,
+) -> WalTransactionBuilder {
+    WalTransactionBuilder::new(
+        epoch_id(),
+        WalSegmentId::from_raw(1),
+        transaction_id(&format!("hardening:tx:{label}")),
+        transaction_kind,
+        authority,
+        first_lsn,
+        digest("hardening:previous-frame"),
+        digest("hardening:previous-commit"),
+        WalDurabilityMode::StrictFilesystem,
+        PayloadCodecId::from_hash(digest("hardening:codec")),
+        PayloadSchemaId::from_hash(digest("hardening:schema")),
+        1,
+        1,
+        digest("hardening:domain"),
+    )
+}
+
+fn frontier(label: &str, kind: AffectedFrontierKind) -> AffectedFrontier {
+    AffectedFrontier {
+        kind,
+        before_digest: digest(&format!("hardening:frontier:{label}:before")),
+        after_digest: digest(&format!("hardening:frontier:{label}:after")),
+    }
+}
+
+fn submission_acceptance(label: &str) -> SubmissionAcceptanceRecord {
+    SubmissionAcceptanceRecord {
+        submission_id: digest(&format!("hardening:submission:{label}")),
+        canonical_envelope_digest: digest(&format!("hardening:envelope:{label}")),
+        idempotency_key_digest: None,
+        acceptance_evidence_digest: digest(&format!("hardening:acceptance:{label}")),
+    }
+}
+
+fn submission_transaction(label: &str, first_lsn: Lsn) -> WalCommittedTransaction {
+    must_ok(build_submission_acceptance_transaction(
+        builder(
+            label,
+            first_lsn,
+            WalAppendAuthority::SubmissionIntake,
+            WalTransactionKind::SubmissionIntake,
+        ),
+        submission_acceptance(label),
+        vec![frontier(label, AffectedFrontierKind::SubmissionQueue)],
+    ))
+}
+
+fn tick_transaction(
+    label: &str,
+    first_lsn: Lsn,
+    decision: WalTickDecision,
+) -> WalCommittedTransaction {
+    let receipt = TickReceiptRecord {
+        submission_id: digest(&format!("hardening:submission:{label}")),
+        ticket_digest: digest(&format!("hardening:ticket:{label}")),
+        receipt_digest: digest(&format!("hardening:receipt:{label}")),
+        decision,
+    };
+    let correlation = WalReceiptCorrelationRecord {
+        submission_id: receipt.submission_id,
+        ticket_digest: receipt.ticket_digest,
+        receipt_digest: receipt.receipt_digest,
+    };
+    must_ok(build_tick_transaction(
+        builder(
+            &format!("tick:{label}"),
+            first_lsn,
+            WalAppendAuthority::TrustedScheduler,
+            WalTransactionKind::SchedulerTick,
+        ),
+        receipt,
+        correlation,
+        digest(&format!("hardening:state-delta:{label}")),
+        vec![frontier(label, AffectedFrontierKind::RuntimeState)],
+    ))
+}
+
+fn temp_wal_root(label: &str) -> PathBuf {
+    let unique = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "echo-wal-hardening-{label}-{}-{unique}",
+        std::process::id()
+    ));
+    must_ok(fs::create_dir_all(&root));
+    root
+}
+
+struct WalHardeningFixture {
+    root: PathBuf,
+    store: FilesystemWalStore,
+}
+
+impl WalHardeningFixture {
+    fn new(label: &str) -> Self {
+        let root = temp_wal_root(label);
+        let mut store = must_ok(FilesystemWalStore::open(&root, WalSegmentId::from_raw(1)));
+        must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+        Self { root, store }
+    }
+
+    fn segment_path(&self) -> PathBuf {
+        self.store.segment_path()
+    }
+
+    fn segment_len(&self) -> u64 {
+        must_ok(fs::metadata(self.segment_path())).len()
+    }
+
+    fn segment_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        must_ok(must_ok(fs::File::open(self.segment_path())).read_to_end(&mut bytes));
+        bytes
+    }
+
+    fn replace_segment_bytes(&self, bytes: &[u8]) {
+        must_ok(fs::write(self.segment_path(), bytes));
+    }
+
+    fn truncate_segment(&self, len: u64) {
+        must_ok(must_ok(OpenOptions::new().write(true).open(self.segment_path())).set_len(len));
+    }
+
+    fn append_submission(&mut self, label: &str, first_lsn: Lsn) -> WalCommittedTransaction {
+        let transaction = submission_transaction(label, first_lsn);
+        must_ok(self.store.append_transaction(transaction.clone()));
+        transaction
+    }
+
+    fn append_tick(
+        &mut self,
+        label: &str,
+        first_lsn: Lsn,
+        decision: WalTickDecision,
+    ) -> WalCommittedTransaction {
+        let transaction = tick_transaction(label, first_lsn, decision);
+        must_ok(self.store.append_transaction(transaction.clone()));
+        transaction
+    }
+
+    fn append_uncommitted_submission_frame(&mut self, label: &str, first_lsn: Lsn) {
+        let transaction = submission_transaction(label, first_lsn);
+        must_ok(
+            self.store
+                .append_uncommitted_frame(epoch_id(), transaction.frames[0].clone()),
+        );
+    }
+
+    fn append_uncommitted_tick_frame(&mut self, label: &str, first_lsn: Lsn) {
+        let transaction = tick_transaction(label, first_lsn, WalTickDecision::Applied);
+        must_ok(
+            self.store
+                .append_uncommitted_frame(epoch_id(), transaction.frames[0].clone()),
+        );
+    }
+
+    fn recover_read_only(
+        &self,
+    ) -> Result<warp_core::causal_wal::RecoveryScanReport, WalRecoveryError> {
+        recover_filesystem_store(&self.root, RecoveryAccessMode::ReadOnly)
+    }
+}
+
+fn disk_record_digest(kind: u8, payload: &[u8]) -> Hash {
+    let mut h = blake3::Hasher::new();
+    h.update(WAL_DISK_RECORD_DOMAIN);
+    h.update(&[kind]);
+    h.update(&(payload.len() as u64).to_le_bytes());
+    h.update(payload);
+    h.finalize().into()
+}
+
+fn write_manual_disk_record(path: &Path, kind: u8, payload: &[u8]) {
+    let mut file = must_ok(OpenOptions::new().create(true).append(true).open(path));
+    must_ok(file.write_all(WAL_SEGMENT_RECORD_MAGIC));
+    must_ok(file.write_all(&[kind]));
+    must_ok(file.write_all(&(payload.len() as u64).to_le_bytes()));
+    must_ok(file.write_all(payload));
+    must_ok(file.write_all(&disk_record_digest(kind, payload)));
+    must_ok(file.sync_all());
+}
+
+#[test]
+fn hardening_fixture_recovers_committed_submission() {
+    let mut fixture = WalHardeningFixture::new("fixture-committed");
+    fixture.append_submission("fixture", Lsn::from_raw(0));
+
+    let report = must_ok(fixture.recover_read_only());
+    let index = must_ok(recover_submission_index(&report));
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(report.transactions.len(), 1);
+    assert_eq!(
+        index.retry_posture(
+            submission_acceptance("fixture").submission_id,
+            submission_acceptance("fixture").canonical_envelope_digest,
+        ),
+        SubmissionRetryPosture::AlreadyAcceptedPending,
+        "fixture should recover a committed submission as accepted pending"
+    );
+}
+
+#[test]
+fn hardening_fixture_appends_uncommitted_tail() {
+    let mut fixture = WalHardeningFixture::new("fixture-tail");
+    fixture.append_submission("fixture-tail", Lsn::from_raw(0));
+    fixture.append_uncommitted_submission_frame("tail", Lsn::from_raw(2));
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1)),
+        "read-only recovery should report the uncommitted tail without mutating it"
+    );
+    assert_eq!(report.transactions.len(), 1);
+}
+
+#[test]
+fn hardening_fixture_read_only_recovery_does_not_mutate_segment() {
+    let mut fixture = WalHardeningFixture::new("fixture-read-only");
+    fixture.append_submission("read-only", Lsn::from_raw(0));
+    fixture.append_uncommitted_submission_frame("read-only-tail", Lsn::from_raw(2));
+    let before_len = fixture.segment_len();
+
+    let report = must_ok(fixture.recover_read_only());
+    let after_len = fixture.segment_len();
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(after_len, before_len, "read-only recovery mutated the WAL");
+}
+
+#[test]
+fn hardening_fixture_truncates_segment_for_torn_tail() {
+    let mut fixture = WalHardeningFixture::new("fixture-torn");
+    fixture.append_submission("torn", Lsn::from_raw(0));
+    fixture.append_uncommitted_submission_frame("torn-tail", Lsn::from_raw(2));
+    fixture.truncate_segment(fixture.segment_len().saturating_sub(11));
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(report.transactions.len(), 1);
+}
+
+#[test]
+fn wal_recovery_golden_empty_store() {
+    let fixture = WalHardeningFixture::new("golden-empty");
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert!(report.transactions.is_empty());
+    assert_eq!(report.first_committed_lsn(), None);
+    assert_eq!(report.last_committed_lsn(), None);
+}
+
+#[test]
+fn wal_recovery_golden_clean_committed_segment() {
+    let mut fixture = WalHardeningFixture::new("golden-clean");
+    fixture.append_submission("clean", Lsn::from_raw(0));
+    fixture.append_tick("clean", Lsn::from_raw(2), WalTickDecision::Applied);
+
+    let report = must_ok(fixture.recover_read_only());
+    let receipts = must_ok(recover_receipt_index(&report));
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(report.transactions.len(), 2);
+    assert_eq!(report.first_committed_lsn(), Some(Lsn::from_raw(0)));
+    assert_eq!(report.last_committed_lsn(), Some(Lsn::from_raw(4)));
+    assert_eq!(
+        receipts
+            .receipt_by_submission
+            .get(&submission_acceptance("clean").submission_id),
+        Some(&digest("hardening:receipt:clean"))
+    );
+}
+
+#[test]
+fn wal_recovery_golden_uncommitted_tail() {
+    let mut fixture = WalHardeningFixture::new("golden-tail");
+    fixture.append_submission("tail-base", Lsn::from_raw(0));
+    fixture.append_uncommitted_tick_frame("tail-extra", Lsn::from_raw(2));
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(report.transactions.len(), 1);
+}
+
+#[test]
+fn wal_recovery_golden_torn_record() {
+    let mut fixture = WalHardeningFixture::new("golden-torn");
+    fixture.append_submission("torn-base", Lsn::from_raw(0));
+    fixture.append_uncommitted_tick_frame("torn-extra", Lsn::from_raw(2));
+    fixture.truncate_segment(fixture.segment_len().saturating_sub(3));
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(report.transactions.len(), 1);
+}
+
+#[test]
+fn wal_recovery_golden_corrupt_digest() {
+    let mut fixture = WalHardeningFixture::new("golden-corrupt-digest");
+    fixture.append_submission("corrupt-digest", Lsn::from_raw(0));
+    let mut bytes = fixture.segment_bytes();
+    assert!(
+        !bytes.is_empty(),
+        "fixture should contain at least one disk record"
+    );
+    let last_index = bytes.len() - 1;
+    bytes[last_index] ^= 0x55;
+    fixture.replace_segment_bytes(&bytes);
+
+    let error = must_err(
+        fixture.recover_read_only(),
+        "corrupt disk record digest should block recovery",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Store(WalStoreError::SegmentRecordDigestMismatch)
+    ));
+}
+
+#[test]
+fn wal_recovery_golden_bad_magic() {
+    let mut fixture = WalHardeningFixture::new("golden-bad-magic");
+    fixture.append_submission("bad-magic", Lsn::from_raw(0));
+    let mut bytes = fixture.segment_bytes();
+    bytes[0] ^= 0x11;
+    fixture.replace_segment_bytes(&bytes);
+
+    let error = must_err(
+        fixture.recover_read_only(),
+        "bad segment magic should block recovery",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Store(WalStoreError::SegmentRecordDigestMismatch)
+    ));
+}
+
+#[test]
+fn wal_recovery_golden_unknown_record_kind() {
+    let fixture = WalHardeningFixture::new("golden-unknown-kind");
+    write_manual_disk_record(&fixture.segment_path(), 99, &[]);
+
+    let error = must_err(
+        fixture.recover_read_only(),
+        "unknown disk record kind should block recovery",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Store(WalStoreError::UnknownDiskRecordKind(99))
+    ));
+}
+
+#[test]
+fn crash_before_submission_commit_recovers_not_accepted() {
+    let mut fixture = WalHardeningFixture::new("submission-before-commit");
+    fixture.append_uncommitted_submission_frame("before-commit", Lsn::from_raw(0));
+
+    let report = must_ok(fixture.recover_read_only());
+    let index = must_ok(recover_submission_index(&report));
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::WouldTruncateAll);
+    assert_eq!(
+        index.retry_posture(
+            submission_acceptance("before-commit").submission_id,
+            submission_acceptance("before-commit").canonical_envelope_digest,
+        ),
+        SubmissionRetryPosture::NotAccepted
+    );
+}
+
+#[test]
+fn crash_after_submission_commit_before_ack_recovers_pending() {
+    let mut fixture = WalHardeningFixture::new("submission-commit-before-ack");
+    fixture.append_submission("commit-before-ack", Lsn::from_raw(0));
+
+    let report = must_ok(fixture.recover_read_only());
+    let index = must_ok(recover_submission_index(&report));
+    let entry = must_some(
+        index.get(&submission_acceptance("commit-before-ack").submission_id),
+        "accepted submission should recover",
+    );
+
+    assert_eq!(entry.posture, RecoveredSubmissionPosture::AcceptedPending);
+    assert_eq!(
+        index.retry_posture(
+            submission_acceptance("commit-before-ack").submission_id,
+            submission_acceptance("commit-before-ack").canonical_envelope_digest,
+        ),
+        SubmissionRetryPosture::AlreadyAcceptedPending
+    );
+}
+
+#[test]
+fn crash_after_submission_commit_before_ack_different_envelope_is_protocol_violation() {
+    let mut fixture = WalHardeningFixture::new("submission-conflict");
+    fixture.append_submission("conflict", Lsn::from_raw(0));
+
+    let report = must_ok(fixture.recover_read_only());
+    let index = must_ok(recover_submission_index(&report));
+
+    assert_eq!(
+        index.retry_posture(
+            submission_acceptance("conflict").submission_id,
+            digest("hardening:envelope:conflict:changed"),
+        ),
+        SubmissionRetryPosture::ConflictSameIdDifferentEnvelope
+    );
+}
+
+#[test]
+fn new_submission_id_same_envelope_is_not_duplicate_without_policy() {
+    let mut fixture = WalHardeningFixture::new("submission-new-id-same-envelope");
+    fixture.append_submission("same-envelope", Lsn::from_raw(0));
+
+    let report = must_ok(fixture.recover_read_only());
+    let index = must_ok(recover_submission_index(&report));
+
+    assert_eq!(
+        index.retry_posture(
+            digest("hardening:submission:same-envelope:new-id"),
+            submission_acceptance("same-envelope").canonical_envelope_digest,
+        ),
+        SubmissionRetryPosture::NewSubmissionWithoutPolicyDedupe
+    );
+}
+
+#[test]
+fn crash_after_tick_commit_before_publish_rebuilds_receipt_indexes() {
+    let mut fixture = WalHardeningFixture::new("tick-commit-before-publish");
+    fixture.append_submission("tick", Lsn::from_raw(0));
+    fixture.append_tick("tick", Lsn::from_raw(2), WalTickDecision::Applied);
+
+    let report = must_ok(fixture.recover_read_only());
+    let submission_index = must_ok(recover_submission_index(&report));
+    let receipt_index = must_ok(recover_receipt_index(&report));
+
+    assert_eq!(
+        submission_index.retry_posture(
+            submission_acceptance("tick").submission_id,
+            submission_acceptance("tick").canonical_envelope_digest,
+        ),
+        SubmissionRetryPosture::AlreadyDecidedApplied
+    );
+    assert_eq!(
+        receipt_index
+            .receipt_by_submission
+            .get(&submission_acceptance("tick").submission_id),
+        Some(&digest("hardening:receipt:tick"))
+    );
+}
+
+#[test]
+fn uncommitted_tick_tail_does_not_advance_frontier() {
+    let mut fixture = WalHardeningFixture::new("tick-uncommitted-tail");
+    fixture.append_submission("tick-tail", Lsn::from_raw(0));
+    fixture.append_uncommitted_tick_frame("tick-tail", Lsn::from_raw(2));
+
+    let report = must_ok(fixture.recover_read_only());
+    let submission_index = must_ok(recover_submission_index(&report));
+    let receipt_index = must_ok(recover_receipt_index(&report));
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(
+        submission_index.retry_posture(
+            submission_acceptance("tick-tail").submission_id,
+            submission_acceptance("tick-tail").canonical_envelope_digest,
+        ),
+        SubmissionRetryPosture::AlreadyAcceptedPending
+    );
+    assert!(receipt_index.receipt_by_submission.is_empty());
+}

--- a/crates/warp-core/tests/causal_wal_hardening_tests.rs
+++ b/crates/warp-core/tests/causal_wal_hardening_tests.rs
@@ -3,28 +3,35 @@
 //! Adversarial causal WAL hardening tests.
 
 use warp_core::causal_wal::{
-    apply_committed_transaction, build_materialization_outbox_transaction,
-    build_retained_reading_transaction, build_submission_acceptance_transaction,
-    build_tick_transaction, doctor_filesystem_store, doctor_in_memory_store,
-    doctor_in_memory_store_with_materials, evaluate_checkpoint_publication,
-    project_absent_causal_commit_evidence, project_causal_commit_evidence,
-    project_obstructed_causal_commit_evidence, read_checkpoint_record, recover_filesystem_store,
-    recover_from_frames_and_commits, recover_materialization_outbox, recover_receipt_index,
-    recover_retention_index, recover_submission_index, retained_material_obstructions,
-    shadow_replay_matches, shadow_replay_report, validate_checkpoint_record,
-    write_checkpoint_record_atomic, AffectedFrontier, AffectedFrontierKind,
+    apply_committed_transaction, audit_wal_release_readiness,
+    build_materialization_outbox_transaction, build_retained_reading_transaction,
+    build_submission_acceptance_transaction, build_tick_transaction, doctor_filesystem_store,
+    doctor_in_memory_store, doctor_in_memory_store_with_materials, evaluate_checkpoint_publication,
+    inspect_evidence_material_posture, project_absent_causal_commit_evidence,
+    project_causal_commit_evidence, project_obstructed_causal_commit_evidence,
+    read_checkpoint_record, recover_filesystem_store, recover_from_frames_and_commits,
+    recover_materialization_outbox, recover_receipt_index, recover_retention_index,
+    recover_submission_index, retained_material_obstructions, shadow_replay_matches,
+    shadow_replay_report, validate_checkpoint_record, validate_filesystem_strict_sync_evidence,
+    validate_strict_object_store_capabilities, validate_strict_object_store_manifest_commit,
+    wal_crashpoint_manifest, write_checkpoint_record_atomic,
+    write_checkpoint_record_atomic_with_evidence, AffectedFrontier, AffectedFrontierKind,
     CausalCommitEvidencePosture, CausalCommitEvidenceSource, CheckpointPublicationRecord,
     CheckpointRecord, CheckpointValidationPosture, EvidenceMaterialPosture,
-    ExistingMaterializedArtifact, FilesystemWalStore, InMemoryWalStore, Lsn,
+    ExistingMaterializedArtifact, FilesystemSyncBoundary, FilesystemSyncEvidenceError,
+    FilesystemWalStore, InMemoryWalStore, Lsn, MaterialInspectionPosture,
     MaterializationIntentRecord, MaterializationObservationRecord, MaterializationReplayPosture,
-    MissingMaterialScope, PayloadCodecId, PayloadSchemaId, ReadingRefRecord, RecoveredState,
-    RecoveredSubmissionPosture, RecoveryAccessMode, RecoveryTailPosture, RetainedMaterialKind,
-    RetainedMaterialRecord, ShadowReplayMismatch, SubmissionAcceptanceRecord,
-    SubmissionRetryPosture, TickReceiptRecord, WalAppendAuthority, WalBuildError,
-    WalCommittedTransaction, WalDoctorPosture, WalDoctorReport, WalDurabilityMode,
-    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryError, WalReplayError, WalSegmentId,
-    WalStoreError, WalStorePort, WalTickDecision, WalTransactionBuilder, WalTransactionId,
-    WalTransactionKind, WalValidationError, WriterEpochId, WriterEpochRequest,
+    MissingMaterialScope, ObjectStoreCapabilityError, ObjectStoreManifestCommitMode,
+    ObjectStoreManifestCommitShape, ObjectStoreReadAfterWritePosture, ObjectStoreWalCapabilities,
+    PayloadCodecId, PayloadSchemaId, ReadingRefRecord, RecoveredState, RecoveredSubmissionPosture,
+    RecoveryAccessMode, RecoveryTailPosture, RetainedMaterialKind, RetainedMaterialRecord,
+    ShadowReplayMismatch, SubmissionAcceptanceRecord, SubmissionRetryPosture, TickReceiptRecord,
+    WalAppendAuthority, WalBuildError, WalCommittedTransaction, WalCrashpointBoundary,
+    WalCrashpointExecution, WalDoctorPosture, WalDoctorReport, WalDurabilityMode, WalManifest,
+    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryError, WalReleaseReadinessGates,
+    WalReplayError, WalSegmentId, WalStoreError, WalStorePort, WalTickDecision,
+    WalTransactionBuilder, WalTransactionId, WalTransactionKind, WalValidationError, WriterEpochId,
+    WriterEpochRequest,
 };
 use warp_core::Hash;
 
@@ -1759,4 +1766,337 @@ fn recovery_certificate_has_stable_json_shape() {
     assert_eq!(certificate.tail_posture, RecoveryTailPosture::Clean);
     assert_eq!(certificate.obstruction_count, 0);
     assert_eq!(WalDoctorReport::stable_field_names().len(), 6);
+}
+
+#[test]
+fn crashpoint_manifest_lists_submission_boundaries() {
+    let manifest = wal_crashpoint_manifest();
+
+    assert!(manifest.iter().any(|entry| {
+        entry.name == "submission.before_commit"
+            && entry.boundary == WalCrashpointBoundary::Submission
+            && entry.execution == WalCrashpointExecution::SimulatedInProcess
+    }));
+    assert!(manifest.iter().any(|entry| {
+        entry.name == "submission.after_commit_before_ack"
+            && entry.boundary == WalCrashpointBoundary::Submission
+            && entry.execution == WalCrashpointExecution::SimulatedInProcess
+    }));
+}
+
+#[test]
+fn crashpoint_manifest_lists_tick_boundaries() {
+    let manifest = wal_crashpoint_manifest();
+
+    assert!(manifest.iter().any(|entry| {
+        entry.name == "tick.before_commit"
+            && entry.boundary == WalCrashpointBoundary::Tick
+            && entry.execution == WalCrashpointExecution::SimulatedInProcess
+    }));
+    assert!(manifest.iter().any(|entry| {
+        entry.name == "tick.after_commit_before_publish"
+            && entry.boundary == WalCrashpointBoundary::Tick
+            && entry.execution == WalCrashpointExecution::SimulatedInProcess
+    }));
+}
+
+#[test]
+fn crashpoint_manifest_lists_checkpoint_boundaries() {
+    let manifest = wal_crashpoint_manifest();
+
+    assert!(manifest.iter().any(|entry| {
+        entry.name == "checkpoint.before_rename"
+            && entry.boundary == WalCrashpointBoundary::Checkpoint
+            && entry.execution == WalCrashpointExecution::SimulatedInProcess
+    }));
+    assert!(manifest.iter().any(|entry| {
+        entry.name == "checkpoint.after_rename_before_publication"
+            && entry.boundary == WalCrashpointBoundary::Checkpoint
+            && entry.execution == WalCrashpointExecution::SimulatedInProcess
+    }));
+}
+
+#[test]
+fn crashpoint_manifest_marks_process_kill_as_future_until_runner_exists() {
+    let process_entries = wal_crashpoint_manifest()
+        .iter()
+        .filter(|entry| entry.boundary == WalCrashpointBoundary::Process)
+        .collect::<Vec<_>>();
+
+    assert!(!process_entries.is_empty());
+    assert!(process_entries
+        .iter()
+        .all(|entry| entry.execution == WalCrashpointExecution::ProcessKillFuture));
+}
+
+#[test]
+fn filesystem_commit_flush_is_ack_boundary() {
+    let mut fixture = WalHardeningFixture::new("sync-commit");
+    let transaction = fixture.append_submission("sync-commit", Lsn::from_raw(0));
+
+    assert!(fixture.store.sync_evidence().iter().any(|entry| {
+        entry.boundary == FilesystemSyncBoundary::CommitFileSynced
+            && entry.transaction_id == Some(transaction.commit.transaction_id)
+    }));
+}
+
+#[test]
+fn filesystem_segment_creation_syncs_directory() {
+    let fixture = WalHardeningFixture::new("sync-segment");
+
+    must_ok(validate_filesystem_strict_sync_evidence(
+        fixture.store.sync_evidence(),
+        &[
+            FilesystemSyncBoundary::SegmentFileCreated,
+            FilesystemSyncBoundary::SegmentDirectorySynced,
+        ],
+    ));
+}
+
+#[test]
+fn filesystem_manifest_rename_syncs_directory() {
+    let mut fixture = WalHardeningFixture::new("sync-manifest");
+    let manifest = WalManifest {
+        manifest_digest: digest("hardening:manifest:sync"),
+        last_committed_lsn: None,
+        last_commit_digest: None,
+        sealed_segment_count: 0,
+    };
+
+    must_ok(fixture.store.publish_manifest(epoch_id(), manifest));
+
+    must_ok(validate_filesystem_strict_sync_evidence(
+        fixture.store.sync_evidence(),
+        &[
+            FilesystemSyncBoundary::ManifestTempFileSynced,
+            FilesystemSyncBoundary::ManifestRenamedDirectorySynced,
+        ],
+    ));
+}
+
+#[test]
+fn filesystem_checkpoint_rename_syncs_directory() {
+    let root = temp_wal_root("sync-checkpoint");
+    let checkpoint = checkpoint(
+        "sync-checkpoint",
+        Lsn::from_raw(1),
+        digest("hardening:checkpoint:sync:commit"),
+    );
+
+    let evidence = must_ok(write_checkpoint_record_atomic_with_evidence(
+        root.join("checkpoint.ecwal"),
+        &checkpoint,
+    ));
+
+    must_ok(validate_filesystem_strict_sync_evidence(
+        &evidence,
+        &[
+            FilesystemSyncBoundary::CheckpointTempFileSynced,
+            FilesystemSyncBoundary::CheckpointRenamedDirectorySynced,
+        ],
+    ));
+}
+
+#[test]
+fn filesystem_strict_mode_rejects_missing_sync_evidence() {
+    let error = must_err(
+        validate_filesystem_strict_sync_evidence(&[], &[FilesystemSyncBoundary::CommitFileSynced]),
+        "missing sync evidence should block strict filesystem claim",
+    );
+
+    assert!(matches!(
+        error,
+        FilesystemSyncEvidenceError::Missing(FilesystemSyncBoundary::CommitFileSynced)
+    ));
+}
+
+#[test]
+fn strict_object_store_requires_content_addressed_objects() {
+    let error = must_err(
+        validate_strict_object_store_capabilities(ObjectStoreWalCapabilities {
+            content_addressed_object_write: false,
+            verify_object_version: true,
+            conditional_manifest_commit: true,
+            read_after_write: ObjectStoreReadAfterWritePosture::Verified,
+        }),
+        "strict object store needs content-addressed writes",
+    );
+
+    assert_eq!(
+        error,
+        ObjectStoreCapabilityError::MissingContentAddressedObjectWrite
+    );
+}
+
+#[test]
+fn strict_object_store_requires_object_version_verification() {
+    let error = must_err(
+        validate_strict_object_store_capabilities(ObjectStoreWalCapabilities {
+            content_addressed_object_write: true,
+            verify_object_version: false,
+            conditional_manifest_commit: true,
+            read_after_write: ObjectStoreReadAfterWritePosture::Verified,
+        }),
+        "strict object store needs version evidence",
+    );
+
+    assert_eq!(
+        error,
+        ObjectStoreCapabilityError::MissingObjectVersionVerification
+    );
+}
+
+#[test]
+fn strict_object_store_requires_conditional_manifest_commit_negative() {
+    let error = must_err(
+        validate_strict_object_store_capabilities(ObjectStoreWalCapabilities {
+            content_addressed_object_write: true,
+            verify_object_version: true,
+            conditional_manifest_commit: false,
+            read_after_write: ObjectStoreReadAfterWritePosture::Verified,
+        }),
+        "strict object store needs conditional manifest commit",
+    );
+
+    assert_eq!(
+        error,
+        ObjectStoreCapabilityError::MissingConditionalManifestCommit
+    );
+}
+
+#[test]
+fn strict_object_store_requires_verified_read_after_write() {
+    let error = must_err(
+        validate_strict_object_store_capabilities(ObjectStoreWalCapabilities {
+            content_addressed_object_write: true,
+            verify_object_version: true,
+            conditional_manifest_commit: true,
+            read_after_write: ObjectStoreReadAfterWritePosture::Unverified,
+        }),
+        "strict object store needs verified read-after-write",
+    );
+
+    assert_eq!(error, ObjectStoreCapabilityError::MissingReadAfterWrite);
+}
+
+#[test]
+fn strict_object_store_rejects_unconditional_manifest_overwrite() {
+    let error = must_err(
+        validate_strict_object_store_manifest_commit(ObjectStoreManifestCommitShape {
+            mode: ObjectStoreManifestCommitMode::UnconditionalOverwrite,
+            expected_previous_manifest_digest: None,
+            new_manifest_digest: digest("hardening:object-store:manifest"),
+        }),
+        "strict object store cannot overwrite manifest unconditionally",
+    );
+
+    assert_eq!(
+        error,
+        ObjectStoreCapabilityError::UnconditionalManifestOverwrite
+    );
+}
+
+#[test]
+fn redacted_material_is_policy_posture_not_missing() {
+    assert_eq!(
+        inspect_evidence_material_posture(EvidenceMaterialPosture::RedactedByPolicy),
+        MaterialInspectionPosture::PolicyHidden
+    );
+}
+
+#[test]
+fn encrypted_key_unavailable_is_policy_posture_not_corruption() {
+    assert_eq!(
+        inspect_evidence_material_posture(EvidenceMaterialPosture::EncryptedKeyUnavailable),
+        MaterialInspectionPosture::EncryptedKeyUnavailable
+    );
+}
+
+#[test]
+fn missing_material_is_not_redaction() {
+    assert_eq!(
+        inspect_evidence_material_posture(EvidenceMaterialPosture::Missing),
+        MaterialInspectionPosture::Missing
+    );
+}
+
+#[test]
+fn corrupt_material_is_not_redaction() {
+    assert_eq!(
+        inspect_evidence_material_posture(EvidenceMaterialPosture::Corrupt),
+        MaterialInspectionPosture::Corrupt
+    );
+}
+
+#[test]
+fn inspector_reports_redaction_posture_explicitly() {
+    let postures = [
+        (
+            EvidenceMaterialPosture::Present,
+            MaterialInspectionPosture::Present,
+        ),
+        (
+            EvidenceMaterialPosture::RedactedByPolicy,
+            MaterialInspectionPosture::PolicyHidden,
+        ),
+        (
+            EvidenceMaterialPosture::EncryptedKeyUnavailable,
+            MaterialInspectionPosture::EncryptedKeyUnavailable,
+        ),
+        (
+            EvidenceMaterialPosture::Missing,
+            MaterialInspectionPosture::Missing,
+        ),
+        (
+            EvidenceMaterialPosture::Corrupt,
+            MaterialInspectionPosture::Corrupt,
+        ),
+        (
+            EvidenceMaterialPosture::Obstructed,
+            MaterialInspectionPosture::Obstructed,
+        ),
+    ];
+
+    for (source, expected) in postures {
+        assert_eq!(inspect_evidence_material_posture(source), expected);
+    }
+}
+
+#[test]
+fn wal_hardening_gate_reports_blocked_categories() {
+    let report = audit_wal_release_readiness(WalReleaseReadinessGates {
+        filesystem_adapter: true,
+        object_store_capability_gate: true,
+        segment_repair: true,
+        ..WalReleaseReadinessGates::default()
+    });
+
+    assert!(!report.ready);
+    assert!(report.blocked_gates.contains(&"crashpoint_manifest"));
+    assert!(report.blocked_gates.contains(&"wal_doctor"));
+    assert!(report.blocked_gates.contains(&"app_noun_guard"));
+}
+
+#[test]
+fn wal_hardening_gate_passes_when_all_categories_are_green() {
+    let report = audit_wal_release_readiness(WalReleaseReadinessGates {
+        filesystem_adapter: true,
+        object_store_capability_gate: true,
+        segment_repair: true,
+        crash_matrix: true,
+        crashpoint_manifest: true,
+        shadow_replay: true,
+        outbox: true,
+        commit_evidence: true,
+        wal_doctor: true,
+        semantic_validator: true,
+        filesystem_sync_evidence: true,
+        object_store_manifest_negatives: true,
+        security_redaction: true,
+        app_noun_guard: true,
+        external_consumer_gate: true,
+    });
+
+    assert!(report.ready);
+    assert!(report.blocked_gates.is_empty());
 }

--- a/crates/warp-core/tests/causal_wal_hardening_tests.rs
+++ b/crates/warp-core/tests/causal_wal_hardening_tests.rs
@@ -3,17 +3,24 @@
 //! Adversarial causal WAL hardening tests.
 
 use warp_core::causal_wal::{
-    build_submission_acceptance_transaction, build_tick_transaction, recover_filesystem_store,
-    recover_receipt_index, recover_submission_index, AffectedFrontier, AffectedFrontierKind,
-    FilesystemWalStore, Lsn, PayloadCodecId, PayloadSchemaId, RecoveredSubmissionPosture,
-    RecoveryAccessMode, RecoveryTailPosture, SubmissionAcceptanceRecord, SubmissionRetryPosture,
-    TickReceiptRecord, WalAppendAuthority, WalCommittedTransaction, WalDurabilityMode,
-    WalReceiptCorrelationRecord, WalRecoveryError, WalSegmentId, WalStoreError, WalStorePort,
-    WalTickDecision, WalTransactionBuilder, WalTransactionId, WalTransactionKind, WriterEpochId,
-    WriterEpochRequest,
+    build_retained_reading_transaction, build_submission_acceptance_transaction,
+    build_tick_transaction, evaluate_checkpoint_publication, read_checkpoint_record,
+    recover_filesystem_store, recover_from_frames_and_commits, recover_receipt_index,
+    recover_retention_index, recover_submission_index, retained_material_obstructions,
+    validate_checkpoint_record, write_checkpoint_record_atomic, AffectedFrontier,
+    AffectedFrontierKind, CheckpointPublicationRecord, CheckpointRecord,
+    CheckpointValidationPosture, EvidenceMaterialPosture, FilesystemWalStore, InMemoryWalStore,
+    Lsn, MissingMaterialScope, PayloadCodecId, PayloadSchemaId, ReadingRefRecord,
+    RecoveredSubmissionPosture, RecoveryAccessMode, RecoveryTailPosture, RetainedMaterialKind,
+    RetainedMaterialRecord, SubmissionAcceptanceRecord, SubmissionRetryPosture, TickReceiptRecord,
+    WalAppendAuthority, WalBuildError, WalCommittedTransaction, WalDurabilityMode,
+    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryError, WalSegmentId, WalStoreError,
+    WalStorePort, WalTickDecision, WalTransactionBuilder, WalTransactionId, WalTransactionKind,
+    WalValidationError, WriterEpochId, WriterEpochRequest,
 };
 use warp_core::Hash;
 
+use std::collections::BTreeSet;
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -68,6 +75,10 @@ fn epoch_id() -> WriterEpochId {
     WriterEpochId::from_hash(digest("hardening:epoch:1"))
 }
 
+fn epoch_id_for(label: &str) -> WriterEpochId {
+    WriterEpochId::from_hash(digest(&format!("hardening:epoch:{label}")))
+}
+
 fn writer_epoch_request() -> WriterEpochRequest {
     WriterEpochRequest {
         epoch_id: epoch_id(),
@@ -78,6 +89,24 @@ fn writer_epoch_request() -> WriterEpochRequest {
         previous_epoch_id: None,
         previous_epoch_final_commit_digest: None,
         lease_or_lock_evidence: digest("hardening:lock:1"),
+    }
+}
+
+fn writer_epoch_request_for(
+    label: &str,
+    started_at_lsn: Lsn,
+    previous_epoch_id: Option<WriterEpochId>,
+    previous_epoch_final_commit_digest: Option<Hash>,
+) -> WriterEpochRequest {
+    WriterEpochRequest {
+        epoch_id: epoch_id_for(label),
+        storage_fencing_token: digest(&format!("hardening:fence:{label}")),
+        process_identity: digest(&format!("hardening:process:{label}")),
+        host_identity: digest("hardening:host:1"),
+        started_at_lsn,
+        previous_epoch_id,
+        previous_epoch_final_commit_digest,
+        lease_or_lock_evidence: digest(&format!("hardening:lock:{label}")),
     }
 }
 
@@ -163,6 +192,51 @@ fn tick_transaction(
         digest(&format!("hardening:state-delta:{label}")),
         vec![frontier(label, AffectedFrontierKind::RuntimeState)],
     ))
+}
+
+fn retained_material(
+    label: &str,
+    kind: RetainedMaterialKind,
+    posture: EvidenceMaterialPosture,
+) -> RetainedMaterialRecord {
+    RetainedMaterialRecord {
+        material_digest: digest(&format!("hardening:material:{label}")),
+        semantic_coordinate_digest: digest(&format!("hardening:coordinate:{label}")),
+        kind,
+        posture,
+    }
+}
+
+fn reading_ref(label: &str, posture: EvidenceMaterialPosture) -> ReadingRefRecord {
+    ReadingRefRecord {
+        reading_id: digest(&format!("hardening:reading:{label}")),
+        semantic_coordinate_digest: digest(&format!("hardening:coordinate:{label}")),
+        payload_digest: digest(&format!("hardening:material:{label}:payload")),
+        envelope_digest: digest(&format!("hardening:material:{label}:envelope")),
+        posture,
+    }
+}
+
+fn retention_transaction(
+    label: &str,
+    material: &[RetainedMaterialRecord],
+    first_lsn: Lsn,
+) -> WalCommittedTransaction {
+    must_ok(build_retained_reading_transaction(
+        builder(
+            &format!("retention:{label}"),
+            first_lsn,
+            WalAppendAuthority::TrustedScheduler,
+            WalTransactionKind::SchedulerTick,
+        ),
+        material,
+        reading_ref(label, EvidenceMaterialPosture::Present),
+        vec![frontier(label, AffectedFrontierKind::ReadingIndex)],
+    ))
+}
+
+fn refresh_commit_digest(transaction: &mut WalCommittedTransaction) {
+    transaction.commit.commit_digest = transaction.commit.expected_digest();
 }
 
 fn temp_wal_root(label: &str) -> PathBuf {
@@ -284,6 +358,19 @@ fn segment_file_name(segment_id: u64) -> String {
 
 fn duplicate_segment_file_name(segment_id: u64) -> String {
     format!("segment-{segment_id:020}-duplicate.ecwal")
+}
+
+fn checkpoint(label: &str, last_lsn: Lsn, last_commit_digest: Hash) -> CheckpointRecord {
+    CheckpointRecord {
+        checkpoint_id: digest(&format!("hardening:checkpoint:{label}")),
+        last_included_lsn: last_lsn,
+        last_included_commit_digest: last_commit_digest,
+        state_root: digest(&format!("hardening:checkpoint:{label}:state")),
+        index_root: digest(&format!("hardening:checkpoint:{label}:index")),
+        retained_material_root: digest(&format!("hardening:checkpoint:{label}:retention")),
+        schema_version: 1,
+        created_from_wal_digest: digest(&format!("hardening:checkpoint:{label}:wal")),
+    }
 }
 
 #[test]
@@ -554,6 +641,241 @@ fn duplicate_segment_id_blocks_recovery() {
 }
 
 #[test]
+fn closed_epoch_allows_next_epoch_with_matching_fence_evidence() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let transaction = submission_transaction("epoch-chain", Lsn::from_raw(0));
+    let previous_commit_digest = transaction.commit.commit_digest;
+    must_ok(store.append_transaction(transaction));
+    must_ok(store.close_epoch(epoch_id()));
+
+    let next = writer_epoch_request_for(
+        "2",
+        Lsn::from_raw(2),
+        Some(epoch_id()),
+        Some(previous_commit_digest),
+    );
+
+    let epoch = must_ok(store.acquire_writer_epoch(next));
+    assert_eq!(epoch.epoch_id, epoch_id_for("2"));
+    assert_eq!(epoch.previous_epoch_id, Some(epoch_id()));
+    assert_eq!(
+        epoch.previous_epoch_final_commit_digest,
+        Some(previous_commit_digest)
+    );
+}
+
+#[test]
+fn unknown_previous_writer_epoch_rejected() {
+    let mut store = InMemoryWalStore::new();
+
+    let error = must_err(
+        store.acquire_writer_epoch(writer_epoch_request_for(
+            "2",
+            Lsn::from_raw(0),
+            Some(epoch_id_for("missing")),
+            Some(digest("missing-final")),
+        )),
+        "unknown previous writer epoch should be rejected",
+    );
+
+    assert!(matches!(error, WalStoreError::UnknownPreviousWriterEpoch));
+}
+
+#[test]
+fn writer_epoch_chain_requires_previous_final_commit_digest() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let transaction = submission_transaction("epoch-final", Lsn::from_raw(0));
+    must_ok(store.append_transaction(transaction));
+    must_ok(store.close_epoch(epoch_id()));
+
+    let error = must_err(
+        store.acquire_writer_epoch(writer_epoch_request_for(
+            "2",
+            Lsn::from_raw(2),
+            Some(epoch_id()),
+            None,
+        )),
+        "missing previous final digest should be rejected",
+    );
+
+    assert!(matches!(
+        error,
+        WalStoreError::WriterEpochFinalCommitDigestMismatch
+    ));
+}
+
+#[test]
+fn writer_epoch_fencing_token_mismatch_blocks_recovery() {
+    let mut store = InMemoryWalStore::new();
+    let first = writer_epoch_request();
+    must_ok(store.acquire_writer_epoch(first.clone()));
+    let transaction = submission_transaction("epoch-fence", Lsn::from_raw(0));
+    let previous_commit_digest = transaction.commit.commit_digest;
+    must_ok(store.append_transaction(transaction));
+    must_ok(store.close_epoch(epoch_id()));
+    let mut next = writer_epoch_request_for(
+        "2",
+        Lsn::from_raw(2),
+        Some(epoch_id()),
+        Some(previous_commit_digest),
+    );
+    next.storage_fencing_token = first.storage_fencing_token;
+
+    let error = must_err(
+        store.acquire_writer_epoch(next),
+        "reused storage fencing token should be rejected",
+    );
+
+    assert!(matches!(error, WalStoreError::WriterEpochFencingMismatch));
+}
+
+#[test]
+fn writer_epoch_chain_gap_rejected() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.close_epoch(epoch_id()));
+
+    let error = must_err(
+        store.acquire_writer_epoch(writer_epoch_request_for("2", Lsn::from_raw(0), None, None)),
+        "new epoch should cite the previous closed epoch",
+    );
+
+    assert!(matches!(error, WalStoreError::WriterEpochChainGap));
+}
+
+#[test]
+fn interleaved_transactions_rejected() {
+    let first = submission_transaction("interleaved:first", Lsn::from_raw(0));
+    let second = submission_transaction("interleaved:second", Lsn::from_raw(1));
+    let mut frames = first.frames.clone();
+    frames.extend(second.frames.clone());
+    let commits = vec![first.commit, second.commit];
+
+    let error = must_err(
+        recover_from_frames_and_commits(&frames, &commits, RecoveryAccessMode::ReadOnly),
+        "overlapping/interleaved global LSN order should be rejected",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Validation(WalValidationError::LsnContinuityMismatch)
+    ));
+}
+
+#[test]
+fn commit_record_count_mismatch_rejected() {
+    let mut transaction = submission_transaction("record-count", Lsn::from_raw(0));
+    transaction.commit.record_count += 1;
+    refresh_commit_digest(&mut transaction);
+
+    let error = must_err(
+        transaction.validate(),
+        "record count mismatch should reject",
+    );
+
+    assert!(matches!(error, WalValidationError::RecordCountMismatch));
+}
+
+#[test]
+fn commit_lsn_range_gap_rejected() {
+    let mut transaction = submission_transaction("lsn-gap", Lsn::from_raw(0));
+    transaction.commit.last_lsn = Lsn::from_raw(2);
+    refresh_commit_digest(&mut transaction);
+
+    let error = must_err(transaction.validate(), "LSN range gap should reject");
+
+    assert!(matches!(error, WalValidationError::LastLsnMismatch));
+}
+
+#[test]
+fn commit_records_root_mismatch_rejected() {
+    let mut transaction = submission_transaction("records-root", Lsn::from_raw(0));
+    transaction.commit.records_root = digest("hardening:records-root:wrong");
+    refresh_commit_digest(&mut transaction);
+
+    let error = must_err(
+        transaction.validate(),
+        "records root mismatch should reject",
+    );
+
+    assert!(matches!(error, WalValidationError::RecordsRootMismatch));
+}
+
+#[test]
+fn byte_valid_submission_with_tick_record_rejected() {
+    let mut transaction = tick_transaction(
+        "semantic-submission",
+        Lsn::from_raw(0),
+        WalTickDecision::Applied,
+    );
+    transaction.commit.transaction_kind = WalTransactionKind::SubmissionIntake;
+    refresh_commit_digest(&mut transaction);
+
+    let error = must_err(
+        transaction.validate(),
+        "byte-valid tick records cannot masquerade as submission intake",
+    );
+
+    assert!(matches!(error, WalValidationError::RecordAuthorityMismatch));
+}
+
+#[test]
+fn runtime_control_record_without_runtime_authority_rejected() {
+    let mut builder = builder(
+        "runtime-control-semantic",
+        Lsn::from_raw(0),
+        WalAppendAuthority::RuntimeControl,
+        WalTransactionKind::RuntimePosture,
+    );
+    must_ok(builder.push_record(
+        WalRecordKind::TrustedRuntimeControlRecorded,
+        digest("hardening:runtime-control").to_vec(),
+    ));
+    let mut transaction = must_ok(builder.commit(vec![frontier(
+        "runtime-control-semantic",
+        AffectedFrontierKind::RuntimeControl,
+    )]));
+    transaction.commit.transaction_kind = WalTransactionKind::SchedulerTick;
+    refresh_commit_digest(&mut transaction);
+
+    let error = must_err(
+        transaction.validate(),
+        "runtime-control record without runtime authority should reject",
+    );
+
+    assert!(matches!(error, WalValidationError::RecordAuthorityMismatch));
+}
+
+#[test]
+fn frontier_transition_kind_mismatch_rejected() {
+    let mut builder = builder(
+        "frontier-kind",
+        Lsn::from_raw(0),
+        WalAppendAuthority::SubmissionIntake,
+        WalTransactionKind::SubmissionIntake,
+    );
+    must_ok(builder.push_record(
+        WalRecordKind::SubmissionAcceptedRecorded,
+        submission_acceptance("frontier-kind").to_payload_bytes(),
+    ));
+
+    let error = must_err(
+        builder.commit(vec![frontier(
+            "frontier-kind",
+            AffectedFrontierKind::RuntimeState,
+        )]),
+        "submission intake cannot mutate runtime-state frontier",
+    );
+
+    assert!(matches!(
+        error,
+        WalBuildError::Validation(WalValidationError::FrontierTransitionKindMismatch)
+    ));
+}
+
+#[test]
 fn crash_before_submission_commit_recovers_not_accepted() {
     let mut fixture = WalHardeningFixture::new("submission-before-commit");
     fixture.append_uncommitted_submission_frame("before-commit", Lsn::from_raw(0));
@@ -674,4 +996,209 @@ fn uncommitted_tick_tail_does_not_advance_frontier() {
         SubmissionRetryPosture::AlreadyAcceptedPending
     );
     assert!(receipt_index.receipt_by_submission.is_empty());
+}
+
+#[test]
+fn crash_before_checkpoint_rename_uses_full_replay() {
+    let mut fixture = WalHardeningFixture::new("checkpoint-before-rename");
+    fixture.append_submission("checkpoint-before-rename", Lsn::from_raw(0));
+    let temp_checkpoint = fixture.root.join(".checkpoint.ecwal.tmp");
+    must_ok(fs::write(&temp_checkpoint, b"incomplete-checkpoint-temp"));
+
+    let report = must_ok(fixture.recover_read_only());
+    let final_checkpoint = fixture.root.join("checkpoint.ecwal");
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(report.transactions.len(), 1);
+    assert!(!final_checkpoint.exists());
+}
+
+#[test]
+fn checkpoint_ahead_of_wal_chain_is_rejected() {
+    let mut fixture = WalHardeningFixture::new("checkpoint-ahead");
+    let transaction = fixture.append_submission("checkpoint-ahead", Lsn::from_raw(0));
+    let report = must_ok(fixture.recover_read_only());
+    let ahead = checkpoint("ahead", Lsn::from_raw(99), transaction.commit.commit_digest);
+
+    assert_eq!(
+        validate_checkpoint_record(&ahead, &report, &[]),
+        CheckpointValidationPosture::Invalid
+    );
+}
+
+#[test]
+fn published_checkpoint_missing_material_obstructs() {
+    let mut fixture = WalHardeningFixture::new("checkpoint-missing-material");
+    fixture.append_submission("checkpoint-missing-material", Lsn::from_raw(0));
+    let report = must_ok(fixture.recover_read_only());
+    let publication = CheckpointPublicationRecord {
+        checkpoint_id: digest("hardening:checkpoint:missing"),
+        checkpoint_digest: digest("hardening:checkpoint:missing:digest"),
+    };
+
+    assert_eq!(
+        evaluate_checkpoint_publication(&publication, None, &report),
+        CheckpointValidationPosture::PublishedCheckpointMaterialMissing
+    );
+}
+
+#[test]
+fn corrupt_latest_checkpoint_falls_back_to_prior_valid_checkpoint() {
+    let mut fixture = WalHardeningFixture::new("checkpoint-fallback");
+    let transaction = fixture.append_submission("checkpoint-fallback", Lsn::from_raw(0));
+    let report = must_ok(fixture.recover_read_only());
+    let prior = checkpoint(
+        "prior",
+        transaction.commit.last_lsn,
+        transaction.commit.commit_digest,
+    );
+    let prior_path = fixture.root.join("checkpoint-prior.ecwal");
+    let latest_path = fixture.root.join("checkpoint-latest.ecwal");
+    must_ok(write_checkpoint_record_atomic(&prior_path, &prior));
+    must_ok(fs::write(&latest_path, b"corrupt-latest-checkpoint"));
+
+    let latest_error = must_err(
+        read_checkpoint_record(&latest_path),
+        "corrupt latest checkpoint should not parse",
+    );
+    let recovered_prior = must_ok(read_checkpoint_record(&prior_path));
+
+    assert!(matches!(
+        latest_error,
+        warp_core::causal_wal::WalCheckpointIoError::InvalidMagic
+    ));
+    assert_eq!(
+        validate_checkpoint_record(&recovered_prior, &report, &[]),
+        CheckpointValidationPosture::UsableWithoutPublicationRecord
+    );
+}
+
+#[test]
+fn missing_submission_payload_recovers_submission_obstruction() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let material = retained_material(
+        "submission-payload",
+        RetainedMaterialKind::SubmissionPayload,
+        EvidenceMaterialPosture::Present,
+    );
+    must_ok(store.append_transaction(retention_transaction(
+        "submission-payload",
+        &[material],
+        Lsn::from_raw(0),
+    )));
+    let report = must_ok(recover_from_frames_and_commits(
+        &store.read_frames(),
+        &store.read_commits(),
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+    let obstructions = retained_material_obstructions(&retention, &BTreeSet::new());
+
+    assert_eq!(obstructions.len(), 1);
+    assert_eq!(obstructions[0].scope, MissingMaterialScope::Submission);
+}
+
+#[test]
+fn missing_tick_receipt_material_recovers_receipt_obstruction() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let material = retained_material(
+        "tick-receipt",
+        RetainedMaterialKind::TickReceipt,
+        EvidenceMaterialPosture::Present,
+    );
+    must_ok(store.append_transaction(retention_transaction(
+        "tick-receipt",
+        &[material],
+        Lsn::from_raw(0),
+    )));
+    let report = must_ok(recover_from_frames_and_commits(
+        &store.read_frames(),
+        &store.read_commits(),
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+    let obstructions = retained_material_obstructions(&retention, &BTreeSet::new());
+
+    assert_eq!(obstructions.len(), 1);
+    assert_eq!(obstructions[0].scope, MissingMaterialScope::ReceiptOrTicket);
+}
+
+#[test]
+fn missing_tick_state_delta_blocks_frontier_recovery() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let material = retained_material(
+        "state-delta",
+        RetainedMaterialKind::RuntimeStateDelta,
+        EvidenceMaterialPosture::Present,
+    );
+    must_ok(store.append_transaction(retention_transaction(
+        "state-delta",
+        &[material],
+        Lsn::from_raw(0),
+    )));
+    let report = must_ok(recover_from_frames_and_commits(
+        &store.read_frames(),
+        &store.read_commits(),
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+    let obstructions = retained_material_obstructions(&retention, &BTreeSet::new());
+
+    assert_eq!(obstructions.len(), 1);
+    assert_eq!(obstructions[0].scope, MissingMaterialScope::RuntimeGlobal);
+}
+
+#[test]
+fn missing_reading_material_returns_obstruction() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let material = retained_material(
+        "reading-payload",
+        RetainedMaterialKind::ReadingPayload,
+        EvidenceMaterialPosture::Present,
+    );
+    must_ok(store.append_transaction(retention_transaction(
+        "reading-payload",
+        &[material],
+        Lsn::from_raw(0),
+    )));
+    let report = must_ok(recover_from_frames_and_commits(
+        &store.read_frames(),
+        &store.read_commits(),
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+    let obstructions = retained_material_obstructions(&retention, &BTreeSet::new());
+
+    assert_eq!(obstructions.len(), 1);
+    assert_eq!(obstructions[0].scope, MissingMaterialScope::Reading);
+}
+
+#[test]
+fn missing_diagnostic_material_does_not_block_recovery() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let material = retained_material(
+        "diagnostic",
+        RetainedMaterialKind::Diagnostic,
+        EvidenceMaterialPosture::Present,
+    );
+    must_ok(store.append_transaction(retention_transaction(
+        "diagnostic",
+        &[material],
+        Lsn::from_raw(0),
+    )));
+    let report = must_ok(recover_from_frames_and_commits(
+        &store.read_frames(),
+        &store.read_commits(),
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+    let obstructions = retained_material_obstructions(&retention, &BTreeSet::new());
+
+    assert_eq!(obstructions.len(), 1);
+    assert_eq!(obstructions[0].scope, MissingMaterialScope::DiagnosticLoss);
 }

--- a/crates/warp-core/tests/causal_wal_hardening_tests.rs
+++ b/crates/warp-core/tests/causal_wal_hardening_tests.rs
@@ -3,24 +3,32 @@
 //! Adversarial causal WAL hardening tests.
 
 use warp_core::causal_wal::{
+    apply_committed_transaction, build_materialization_outbox_transaction,
     build_retained_reading_transaction, build_submission_acceptance_transaction,
-    build_tick_transaction, evaluate_checkpoint_publication, read_checkpoint_record,
-    recover_filesystem_store, recover_from_frames_and_commits, recover_receipt_index,
+    build_tick_transaction, doctor_filesystem_store, doctor_in_memory_store,
+    doctor_in_memory_store_with_materials, evaluate_checkpoint_publication,
+    project_absent_causal_commit_evidence, project_causal_commit_evidence,
+    project_obstructed_causal_commit_evidence, read_checkpoint_record, recover_filesystem_store,
+    recover_from_frames_and_commits, recover_materialization_outbox, recover_receipt_index,
     recover_retention_index, recover_submission_index, retained_material_obstructions,
-    validate_checkpoint_record, write_checkpoint_record_atomic, AffectedFrontier,
-    AffectedFrontierKind, CheckpointPublicationRecord, CheckpointRecord,
-    CheckpointValidationPosture, EvidenceMaterialPosture, FilesystemWalStore, InMemoryWalStore,
-    Lsn, MissingMaterialScope, PayloadCodecId, PayloadSchemaId, ReadingRefRecord,
+    shadow_replay_matches, shadow_replay_report, validate_checkpoint_record,
+    write_checkpoint_record_atomic, AffectedFrontier, AffectedFrontierKind,
+    CausalCommitEvidencePosture, CausalCommitEvidenceSource, CheckpointPublicationRecord,
+    CheckpointRecord, CheckpointValidationPosture, EvidenceMaterialPosture,
+    ExistingMaterializedArtifact, FilesystemWalStore, InMemoryWalStore, Lsn,
+    MaterializationIntentRecord, MaterializationObservationRecord, MaterializationReplayPosture,
+    MissingMaterialScope, PayloadCodecId, PayloadSchemaId, ReadingRefRecord, RecoveredState,
     RecoveredSubmissionPosture, RecoveryAccessMode, RecoveryTailPosture, RetainedMaterialKind,
-    RetainedMaterialRecord, SubmissionAcceptanceRecord, SubmissionRetryPosture, TickReceiptRecord,
-    WalAppendAuthority, WalBuildError, WalCommittedTransaction, WalDurabilityMode,
-    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryError, WalSegmentId, WalStoreError,
-    WalStorePort, WalTickDecision, WalTransactionBuilder, WalTransactionId, WalTransactionKind,
-    WalValidationError, WriterEpochId, WriterEpochRequest,
+    RetainedMaterialRecord, ShadowReplayMismatch, SubmissionAcceptanceRecord,
+    SubmissionRetryPosture, TickReceiptRecord, WalAppendAuthority, WalBuildError,
+    WalCommittedTransaction, WalDoctorPosture, WalDoctorReport, WalDurabilityMode,
+    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryError, WalReplayError, WalSegmentId,
+    WalStoreError, WalStorePort, WalTickDecision, WalTransactionBuilder, WalTransactionId,
+    WalTransactionKind, WalValidationError, WriterEpochId, WriterEpochRequest,
 };
 use warp_core::Hash;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -235,6 +243,59 @@ fn retention_transaction(
     ))
 }
 
+fn materialization_intent(label: &str) -> MaterializationIntentRecord {
+    MaterializationIntentRecord {
+        effect_id: digest(&format!("hardening:effect:{label}")),
+        expected_artifact_digest: digest(&format!("hardening:artifact:{label}")),
+        materialization_intent_digest: digest(&format!("hardening:materialization:{label}")),
+        idempotency_token: digest(&format!("hardening:idempotency:{label}")),
+        target_metadata_digest: digest(&format!("hardening:metadata:{label}")),
+    }
+}
+
+fn materialization_observation(label: &str) -> MaterializationObservationRecord {
+    MaterializationObservationRecord {
+        effect_id: digest(&format!("hardening:effect:{label}")),
+        observed_artifact_digest: digest(&format!("hardening:artifact:{label}")),
+        observed_metadata_digest: digest(&format!("hardening:metadata:{label}")),
+    }
+}
+
+fn materialization_transaction(
+    label: &str,
+    first_lsn: Lsn,
+    observation: Option<MaterializationObservationRecord>,
+) -> WalCommittedTransaction {
+    must_ok(build_materialization_outbox_transaction(
+        builder(
+            &format!("materialization:{label}"),
+            first_lsn,
+            WalAppendAuthority::TrustedScheduler,
+            WalTransactionKind::MaterializationOutbox,
+        ),
+        materialization_intent(label),
+        observation,
+        vec![frontier(label, AffectedFrontierKind::ReceiptIndex)],
+    ))
+}
+
+fn matching_existing_artifact(label: &str) -> ExistingMaterializedArtifact {
+    let intent = materialization_intent(label);
+    ExistingMaterializedArtifact {
+        effect_id: intent.effect_id,
+        artifact_digest: intent.expected_artifact_digest,
+        metadata_digest: intent.target_metadata_digest,
+    }
+}
+
+fn replay_state(transactions: &[WalCommittedTransaction]) -> RecoveredState {
+    let mut state = RecoveredState::default();
+    for transaction in transactions {
+        state = must_ok(apply_committed_transaction(state, transaction));
+    }
+    state
+}
+
 fn refresh_commit_digest(transaction: &mut WalCommittedTransaction) {
     transaction.commit.commit_digest = transaction.commit.expected_digest();
 }
@@ -311,6 +372,14 @@ impl WalHardeningFixture {
 
     fn append_uncommitted_tick_frame(&mut self, label: &str, first_lsn: Lsn) {
         let transaction = tick_transaction(label, first_lsn, WalTickDecision::Applied);
+        must_ok(
+            self.store
+                .append_uncommitted_frame(epoch_id(), transaction.frames[0].clone()),
+        );
+    }
+
+    fn append_uncommitted_outbox_frame(&mut self, label: &str, first_lsn: Lsn) {
+        let transaction = materialization_transaction(label, first_lsn, None);
         must_ok(
             self.store
                 .append_uncommitted_frame(epoch_id(), transaction.frames[0].clone()),
@@ -1201,4 +1270,493 @@ fn missing_diagnostic_material_does_not_block_recovery() {
 
     assert_eq!(obstructions.len(), 1);
     assert_eq!(obstructions[0].scope, MissingMaterialScope::DiagnosticLoss);
+}
+
+#[test]
+fn external_effect_requires_committed_outbox_authorization() {
+    let mut fixture = WalHardeningFixture::new("outbox-uncommitted");
+    fixture.append_uncommitted_outbox_frame("uncommitted", Lsn::from_raw(0));
+
+    let report = must_ok(fixture.recover_read_only());
+    let outbox = must_ok(recover_materialization_outbox(&report, &BTreeMap::new()));
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::WouldTruncateAll);
+    assert!(
+        outbox.is_empty(),
+        "uncommitted outbox intent must not authorize an external effect"
+    );
+}
+
+#[test]
+fn crash_after_effect_before_observation_detects_existing_artifact() {
+    let mut fixture = WalHardeningFixture::new("outbox-existing");
+    must_ok(
+        fixture
+            .store
+            .append_transaction(materialization_transaction(
+                "existing",
+                Lsn::from_raw(0),
+                None,
+            )),
+    );
+    let report = must_ok(fixture.recover_read_only());
+    let intent = materialization_intent("existing");
+    let existing = BTreeMap::from([(intent.effect_id, matching_existing_artifact("existing"))]);
+
+    let outbox = must_ok(recover_materialization_outbox(&report, &existing));
+
+    assert_eq!(
+        must_some(outbox.get(&intent.effect_id), "outbox entry").posture,
+        MaterializationReplayPosture::ExistingArtifactMatches
+    );
+}
+
+#[test]
+fn existing_artifact_digest_mismatch_obstructs() {
+    let mut fixture = WalHardeningFixture::new("outbox-mismatch");
+    must_ok(
+        fixture
+            .store
+            .append_transaction(materialization_transaction(
+                "mismatch",
+                Lsn::from_raw(0),
+                None,
+            )),
+    );
+    let report = must_ok(fixture.recover_read_only());
+    let intent = materialization_intent("mismatch");
+    let existing = BTreeMap::from([(
+        intent.effect_id,
+        ExistingMaterializedArtifact {
+            effect_id: intent.effect_id,
+            artifact_digest: digest("hardening:artifact:mismatch:wrong"),
+            metadata_digest: intent.target_metadata_digest,
+        },
+    )]);
+
+    let outbox = must_ok(recover_materialization_outbox(&report, &existing));
+
+    assert_eq!(
+        must_some(outbox.get(&intent.effect_id), "outbox entry").posture,
+        MaterializationReplayPosture::Obstructed
+    );
+}
+
+#[test]
+fn materialization_observation_marks_effect_already_observed() {
+    let mut fixture = WalHardeningFixture::new("outbox-observed");
+    must_ok(
+        fixture
+            .store
+            .append_transaction(materialization_transaction(
+                "observed",
+                Lsn::from_raw(0),
+                Some(materialization_observation("observed")),
+            )),
+    );
+    let report = must_ok(fixture.recover_read_only());
+    let intent = materialization_intent("observed");
+
+    let outbox = must_ok(recover_materialization_outbox(&report, &BTreeMap::new()));
+    let entry = must_some(outbox.get(&intent.effect_id), "outbox entry");
+
+    assert_eq!(entry.posture, MaterializationReplayPosture::AlreadyObserved);
+    assert_eq!(
+        entry.observation,
+        Some(materialization_observation("observed"))
+    );
+}
+
+#[test]
+fn outbox_replay_uses_idempotency_token() {
+    let mut fixture = WalHardeningFixture::new("outbox-idempotency");
+    must_ok(
+        fixture
+            .store
+            .append_transaction(materialization_transaction(
+                "idempotency",
+                Lsn::from_raw(0),
+                None,
+            )),
+    );
+    let report = must_ok(fixture.recover_read_only());
+    let intent = materialization_intent("idempotency");
+    let existing = BTreeMap::from([(intent.effect_id, matching_existing_artifact("idempotency"))]);
+
+    let outbox = must_ok(recover_materialization_outbox(&report, &existing));
+    let entry = must_some(outbox.get(&intent.effect_id), "outbox entry");
+
+    assert_eq!(entry.intent.idempotency_token, intent.idempotency_token);
+    assert_eq!(
+        entry.posture,
+        MaterializationReplayPosture::ExistingArtifactMatches
+    );
+}
+
+#[test]
+fn pure_replay_same_transactions_same_roots() {
+    let transactions = vec![
+        submission_transaction("pure-replay", Lsn::from_raw(0)),
+        tick_transaction("pure-replay", Lsn::from_raw(2), WalTickDecision::Applied),
+    ];
+
+    let first = replay_state(&transactions);
+    let second = replay_state(&transactions);
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn pure_replay_order_is_commit_chain_order() {
+    let submission = submission_transaction("order-submission", Lsn::from_raw(0));
+    let tick = tick_transaction("order-tick", Lsn::from_raw(2), WalTickDecision::Applied);
+
+    let forward = replay_state(&[submission.clone(), tick.clone()]);
+    let reversed = replay_state(&[tick.clone(), submission.clone()]);
+
+    assert_eq!(
+        forward.applied_transactions,
+        vec![submission.commit.transaction_id, tick.commit.transaction_id,]
+    );
+    assert_eq!(
+        reversed.applied_transactions,
+        vec![tick.commit.transaction_id, submission.commit.transaction_id,]
+    );
+    assert_ne!(forward.applied_transactions, reversed.applied_transactions);
+}
+
+#[test]
+fn pure_replay_rejects_frontier_mismatch() {
+    let first = submission_transaction("frontier-a", Lsn::from_raw(0));
+    let second = submission_transaction("frontier-b", Lsn::from_raw(2));
+    let state = must_ok(apply_committed_transaction(
+        RecoveredState::default(),
+        &first,
+    ));
+
+    let error = must_err(
+        apply_committed_transaction(state, &second),
+        "frontier mismatch should reject",
+    );
+
+    assert!(matches!(
+        error,
+        WalReplayError::FrontierMismatch {
+            kind: AffectedFrontierKind::SubmissionQueue,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn recovery_reducer_does_not_require_scheduler() {
+    fn reducer_signature(
+        reducer: fn(
+            RecoveredState,
+            &WalCommittedTransaction,
+        ) -> Result<RecoveredState, WalReplayError>,
+    ) -> fn(RecoveredState, &WalCommittedTransaction) -> Result<RecoveredState, WalReplayError>
+    {
+        reducer
+    }
+
+    let reducer = reducer_signature(apply_committed_transaction);
+    let transaction = tick_transaction("no-scheduler", Lsn::from_raw(0), WalTickDecision::Applied);
+    let state = must_ok(reducer(RecoveredState::default(), &transaction));
+
+    assert_eq!(state.applied_transactions.len(), 1);
+}
+
+#[test]
+fn recovery_reducer_does_not_require_app_callbacks() {
+    let transaction = retention_transaction(
+        "no-app-callbacks",
+        &[retained_material(
+            "no-app-callbacks",
+            RetainedMaterialKind::ReadingPayload,
+            EvidenceMaterialPosture::Present,
+        )],
+        Lsn::from_raw(0),
+    );
+
+    let state = must_ok(apply_committed_transaction(
+        RecoveredState::default(),
+        &transaction,
+    ));
+
+    assert_eq!(
+        state.applied_transactions,
+        vec![transaction.commit.transaction_id]
+    );
+}
+
+#[test]
+fn shadow_replay_submission_path_matches_live() {
+    let transaction = submission_transaction("shadow-submission", Lsn::from_raw(0));
+    let live_state = replay_state(std::slice::from_ref(&transaction));
+
+    assert!(must_ok(shadow_replay_matches(&live_state, &[transaction])));
+}
+
+#[test]
+fn shadow_replay_tick_path_matches_live() {
+    let transaction = tick_transaction("shadow-tick", Lsn::from_raw(0), WalTickDecision::Applied);
+    let live_state = replay_state(std::slice::from_ref(&transaction));
+
+    assert!(must_ok(shadow_replay_matches(&live_state, &[transaction])));
+}
+
+#[test]
+fn shadow_replay_retention_path_matches_live() {
+    let transaction = retention_transaction(
+        "shadow-retention",
+        &[retained_material(
+            "shadow-retention",
+            RetainedMaterialKind::ReadingPayload,
+            EvidenceMaterialPosture::Present,
+        )],
+        Lsn::from_raw(0),
+    );
+    let live_state = replay_state(std::slice::from_ref(&transaction));
+
+    assert!(must_ok(shadow_replay_matches(&live_state, &[transaction])));
+}
+
+#[test]
+fn shadow_replay_outbox_path_matches_live() {
+    let transaction = materialization_transaction("shadow-outbox", Lsn::from_raw(0), None);
+    let live_state = replay_state(std::slice::from_ref(&transaction));
+
+    assert!(must_ok(shadow_replay_matches(&live_state, &[transaction])));
+}
+
+#[test]
+fn shadow_replay_reports_first_mismatch() {
+    let transaction = submission_transaction("shadow-mismatch", Lsn::from_raw(0));
+
+    let report = must_ok(shadow_replay_report(
+        &RecoveredState::default(),
+        &[transaction],
+    ));
+
+    assert!(!report.matches);
+    assert!(matches!(
+        report.first_mismatch,
+        Some(ShadowReplayMismatch::AppliedTransactionCount {
+            live: 0,
+            replayed: 1
+        })
+    ));
+}
+
+#[test]
+fn commit_evidence_projects_accepted_pending() {
+    let mut fixture = WalHardeningFixture::new("evidence-accepted");
+    let transaction = fixture.append_submission("evidence-accepted", Lsn::from_raw(0));
+    let report = must_ok(fixture.recover_read_only());
+
+    let evidence = project_causal_commit_evidence(&report);
+
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(evidence[0].posture, CausalCommitEvidencePosture::Present);
+    assert_eq!(evidence[0].source, CausalCommitEvidenceSource::EchoWal);
+    assert_eq!(
+        evidence[0].durability_mode,
+        WalDurabilityMode::StrictFilesystem
+    );
+    assert_eq!(
+        evidence[0].transaction_id,
+        transaction.commit.transaction_id
+    );
+    assert_eq!(evidence[0].lsn, transaction.commit.last_lsn);
+}
+
+#[test]
+fn commit_evidence_projects_decided_applied() {
+    let mut fixture = WalHardeningFixture::new("evidence-applied");
+    fixture.append_submission("evidence-applied", Lsn::from_raw(0));
+    let tick = fixture.append_tick(
+        "evidence-applied",
+        Lsn::from_raw(2),
+        WalTickDecision::Applied,
+    );
+    let report = must_ok(fixture.recover_read_only());
+    let submission_index = must_ok(recover_submission_index(&report));
+
+    let evidence = project_causal_commit_evidence(&report);
+
+    assert_eq!(
+        must_some(
+            submission_index.get(&submission_acceptance("evidence-applied").submission_id),
+            "submission should recover",
+        )
+        .posture,
+        RecoveredSubmissionPosture::DecidedApplied
+    );
+    assert_eq!(
+        must_some(evidence.last(), "tick evidence").transaction_id,
+        tick.commit.transaction_id
+    );
+}
+
+#[test]
+fn commit_evidence_projects_decided_rejected() {
+    let mut fixture = WalHardeningFixture::new("evidence-rejected");
+    fixture.append_submission("evidence-rejected", Lsn::from_raw(0));
+    let tick = fixture.append_tick(
+        "evidence-rejected",
+        Lsn::from_raw(2),
+        WalTickDecision::RejectedFootprintConflict,
+    );
+    let report = must_ok(fixture.recover_read_only());
+    let submission_index = must_ok(recover_submission_index(&report));
+
+    let evidence = project_causal_commit_evidence(&report);
+
+    assert_eq!(
+        must_some(
+            submission_index.get(&submission_acceptance("evidence-rejected").submission_id),
+            "submission should recover",
+        )
+        .posture,
+        RecoveredSubmissionPosture::DecidedRejected
+    );
+    assert_eq!(
+        must_some(evidence.last(), "tick evidence").commit_digest,
+        tick.commit.commit_digest
+    );
+}
+
+#[test]
+fn commit_evidence_projects_obstructed() {
+    let transaction = tick_transaction(
+        "evidence-obstructed",
+        Lsn::from_raw(0),
+        WalTickDecision::Obstructed,
+    );
+    let obstruction_digest = digest("hardening:evidence:obstruction");
+
+    let evidence =
+        project_obstructed_causal_commit_evidence(&transaction.commit, obstruction_digest);
+
+    assert_eq!(evidence.posture, CausalCommitEvidencePosture::Obstructed);
+    assert_eq!(evidence.obstruction_digest, Some(obstruction_digest));
+    assert_eq!(evidence.commit_digest, transaction.commit.commit_digest);
+}
+
+#[test]
+fn commit_evidence_absent_is_explicit() {
+    let evidence = project_absent_causal_commit_evidence(
+        digest("hardening:evidence:absent"),
+        WalDurabilityMode::Disabled,
+    );
+
+    assert_eq!(evidence.posture, CausalCommitEvidencePosture::Absent);
+    assert_eq!(evidence.durability_mode, WalDurabilityMode::Disabled);
+    assert_eq!(evidence.commit_digest, [0; 32]);
+}
+
+#[test]
+fn wal_doctor_clean_report_is_stable() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(submission_transaction("doctor-clean", Lsn::from_raw(0))));
+
+    let report = must_ok(doctor_in_memory_store(&store));
+
+    assert_eq!(report.posture, WalDoctorPosture::Recoverable);
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(
+        WalDoctorReport::stable_field_names(),
+        &[
+            "posture",
+            "tail_posture",
+            "committed_transactions_replayed",
+            "obstruction_count",
+            "recovered_frontier_root",
+            "recovered_indexes_root",
+        ]
+    );
+}
+
+#[test]
+fn wal_doctor_would_truncate_does_not_mutate() {
+    let mut fixture = WalHardeningFixture::new("doctor-would-truncate");
+    fixture.append_submission("doctor-would-truncate", Lsn::from_raw(0));
+    fixture.append_uncommitted_tick_frame("doctor-would-truncate-tail", Lsn::from_raw(2));
+    let before = fixture.segment_bytes();
+
+    let report = must_ok(doctor_filesystem_store(&fixture.root));
+    let after = fixture.segment_bytes();
+
+    assert_eq!(
+        report.posture,
+        WalDoctorPosture::RecoverableWithUncommittedTail
+    );
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(
+        after, before,
+        "doctor must not mutate files in read-only mode"
+    );
+}
+
+#[test]
+fn wal_doctor_corrupt_committed_record_reports_obstructed() {
+    let mut fixture = WalHardeningFixture::new("doctor-corrupt");
+    fixture.append_submission("doctor-corrupt", Lsn::from_raw(0));
+    let mut bytes = fixture.segment_bytes();
+    let last_index = bytes.len() - 1;
+    bytes[last_index] ^= 0x77;
+    fixture.replace_segment_bytes(&bytes);
+
+    let report = must_ok(doctor_filesystem_store(&fixture.root));
+
+    assert_eq!(report.posture, WalDoctorPosture::Obstructed);
+    assert_eq!(report.recovery_certificate.obstruction_count, 1);
+}
+
+#[test]
+fn wal_doctor_missing_material_reports_obstruction() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(retention_transaction(
+        "doctor-missing-material",
+        &[retained_material(
+            "doctor-missing-material",
+            RetainedMaterialKind::ReadingPayload,
+            EvidenceMaterialPosture::Present,
+        )],
+        Lsn::from_raw(0),
+    )));
+
+    let report = must_ok(doctor_in_memory_store_with_materials(
+        &store,
+        &BTreeSet::new(),
+    ));
+
+    assert_eq!(report.posture, WalDoctorPosture::Obstructed);
+    assert_eq!(report.recovery_certificate.obstruction_count, 1);
+}
+
+#[test]
+fn recovery_certificate_has_stable_json_shape() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(submission_transaction(
+        "doctor-certificate",
+        Lsn::from_raw(0),
+    )));
+
+    let report = must_ok(doctor_in_memory_store(&store));
+    let certificate = report.recovery_certificate;
+
+    assert_eq!(certificate.first_lsn, Some(Lsn::from_raw(0)));
+    assert_eq!(certificate.last_lsn, Some(Lsn::from_raw(1)));
+    assert_eq!(certificate.committed_transactions_replayed, 1);
+    assert_eq!(certificate.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(certificate.obstruction_count, 0);
+    assert_eq!(WalDoctorReport::stable_field_names().len(), 6);
 }

--- a/crates/warp-core/tests/causal_wal_hardening_tests.rs
+++ b/crates/warp-core/tests/causal_wal_hardening_tests.rs
@@ -10,10 +10,11 @@ use warp_core::causal_wal::{
     doctor_in_memory_store_with_materials, evaluate_checkpoint_publication,
     inspect_evidence_material_posture, next_segment_id, project_absent_causal_commit_evidence,
     project_causal_commit_evidence, project_obstructed_causal_commit_evidence,
-    read_checkpoint_record, recover_filesystem_store, recover_from_frames_and_commits,
-    recover_materialization_outbox, recover_receipt_index, recover_retention_index,
-    recover_submission_index, retained_material_obstructions, segment_manifest_entry,
-    shadow_replay_matches, shadow_replay_report, validate_checkpoint_record,
+    read_checkpoint_record, read_filesystem_manifest, recover_filesystem_store,
+    recover_from_frames_and_commits, recover_materialization_outbox, recover_receipt_index,
+    recover_retention_index, recover_submission_index, retained_material_obstructions,
+    segment_manifest_entry, shadow_replay_matches, shadow_replay_report,
+    validate_checkpoint_record, validate_filesystem_manifest,
     validate_filesystem_strict_sync_evidence, validate_segment_placement_policy,
     validate_strict_object_store_capabilities, validate_strict_object_store_manifest_commit,
     wal_crashpoint_manifest, write_checkpoint_record_atomic,
@@ -134,9 +135,25 @@ fn builder(
     authority: WalAppendAuthority,
     transaction_kind: WalTransactionKind,
 ) -> WalTransactionBuilder {
+    builder_on_segment(
+        label,
+        first_lsn,
+        authority,
+        transaction_kind,
+        WalSegmentId::from_raw(1),
+    )
+}
+
+fn builder_on_segment(
+    label: &str,
+    first_lsn: Lsn,
+    authority: WalAppendAuthority,
+    transaction_kind: WalTransactionKind,
+    segment_id: WalSegmentId,
+) -> WalTransactionBuilder {
     WalTransactionBuilder::new(
         epoch_id(),
-        WalSegmentId::from_raw(1),
+        segment_id,
         transaction_id(&format!("hardening:tx:{label}")),
         transaction_kind,
         authority,
@@ -170,12 +187,21 @@ fn submission_acceptance(label: &str) -> SubmissionAcceptanceRecord {
 }
 
 fn submission_transaction(label: &str, first_lsn: Lsn) -> WalCommittedTransaction {
+    submission_transaction_on_segment(label, first_lsn, WalSegmentId::from_raw(1))
+}
+
+fn submission_transaction_on_segment(
+    label: &str,
+    first_lsn: Lsn,
+    segment_id: WalSegmentId,
+) -> WalCommittedTransaction {
     must_ok(build_submission_acceptance_transaction(
-        builder(
+        builder_on_segment(
             label,
             first_lsn,
             WalAppendAuthority::SubmissionIntake,
             WalTransactionKind::SubmissionIntake,
+            segment_id,
         ),
         submission_acceptance(label),
         vec![frontier(label, AffectedFrontierKind::SubmissionQueue)],
@@ -357,6 +383,17 @@ impl WalHardeningFixture {
 
     fn append_submission(&mut self, label: &str, first_lsn: Lsn) -> WalCommittedTransaction {
         let transaction = submission_transaction(label, first_lsn);
+        must_ok(self.store.append_transaction(transaction.clone()));
+        transaction
+    }
+
+    fn append_submission_on_segment(
+        &mut self,
+        label: &str,
+        first_lsn: Lsn,
+        segment_id: WalSegmentId,
+    ) -> WalCommittedTransaction {
+        let transaction = submission_transaction_on_segment(label, first_lsn, segment_id);
         must_ok(self.store.append_transaction(transaction.clone()));
         transaction
     }
@@ -2099,6 +2136,7 @@ fn wal_hardening_gate_passes_when_all_categories_are_green() {
         object_store_capability_gate: true,
         segment_repair: true,
         segment_layout_policy: true,
+        segment_manifest_validation: true,
         crash_matrix: true,
         crashpoint_manifest: true,
         shadow_replay: true,
@@ -2297,5 +2335,290 @@ fn segment_layout_gate_is_part_of_wal_release_readiness() {
     assert!(
         report.blocked_gates.contains(&"segment_layout_policy"),
         "layout policy should be an explicit WAL release gate"
+    );
+}
+
+#[test]
+fn filesystem_append_frame_rejects_inactive_segment_id() {
+    let mut fixture = WalHardeningFixture::new("rotation-segment-mismatch");
+    fixture.append_submission("rotation-segment-mismatch", Lsn::from_raw(0));
+    must_ok(fixture.store.rotate_segment(epoch_id()));
+
+    let error = must_err(
+        fixture
+            .store
+            .append_transaction(submission_transaction("wrong-segment", Lsn::from_raw(2))),
+        "active segment 2 should reject frame declaring segment 1",
+    );
+
+    assert!(matches!(
+        error,
+        WalStoreError::SegmentMismatch { expected, actual }
+            if expected == WalSegmentId::from_raw(2) && actual == WalSegmentId::from_raw(1)
+    ));
+}
+
+#[test]
+fn filesystem_rotate_segment_creates_next_canonical_segment() {
+    let mut fixture = WalHardeningFixture::new("rotation-next-segment");
+    fixture.append_submission("rotation-next-segment", Lsn::from_raw(0));
+
+    let seal = must_ok(fixture.store.rotate_segment(epoch_id()));
+
+    assert_eq!(seal.segment_id, WalSegmentId::from_raw(1));
+    assert_eq!(seal.sealed_lsn, Some(Lsn::from_raw(1)));
+    assert_eq!(fixture.store.active_segment_id(), WalSegmentId::from_raw(2));
+    assert!(fixture
+        .root
+        .join("segments")
+        .join(segment_file_name(2))
+        .exists());
+    assert!(fixture.store.sync_evidence().iter().any(|entry| {
+        entry.boundary == FilesystemSyncBoundary::SegmentDirectorySynced
+            && entry.segment_id == Some(WalSegmentId::from_raw(2))
+    }));
+}
+
+#[test]
+fn filesystem_rotate_segment_does_not_overwrite_existing_next_segment() {
+    let mut fixture = WalHardeningFixture::new("rotation-existing-next-segment");
+    fixture.append_submission("rotation-existing-next-segment", Lsn::from_raw(0));
+    let next_path = fixture.root.join("segments").join(segment_file_name(2));
+    must_ok(fs::write(&next_path, b"existing-segment-material"));
+
+    let error = must_err(
+        fixture.store.rotate_segment(epoch_id()),
+        "rotation should not overwrite an existing next segment",
+    );
+
+    assert_eq!(
+        error,
+        WalStoreError::DuplicateSegment(WalSegmentId::from_raw(2))
+    );
+    assert_eq!(
+        must_ok(fs::read(next_path)),
+        b"existing-segment-material",
+        "existing next segment material should not be truncated"
+    );
+}
+
+#[test]
+fn filesystem_rotate_segment_rejects_uncommitted_tail() {
+    let mut fixture = WalHardeningFixture::new("rotation-uncommitted-tail");
+    fixture.append_uncommitted_submission_frame("rotation-uncommitted-tail", Lsn::from_raw(0));
+
+    let error = must_err(
+        fixture.store.rotate_segment(epoch_id()),
+        "rotation should not seal a segment with uncommitted frames",
+    );
+
+    assert_eq!(
+        error,
+        WalStoreError::SegmentHasUncommittedTail(WalSegmentId::from_raw(1))
+    );
+}
+
+#[test]
+fn filesystem_rotate_segment_rejects_epoch_mismatch() {
+    let mut fixture = WalHardeningFixture::new("rotation-epoch-mismatch");
+
+    let error = must_err(
+        fixture.store.rotate_segment(epoch_id_for("wrong")),
+        "rotation should require the active writer epoch",
+    );
+
+    assert_eq!(error, WalStoreError::WriterEpochMismatch);
+}
+
+#[test]
+fn filesystem_recovery_reads_transactions_across_rotated_segments() {
+    let mut fixture = WalHardeningFixture::new("rotation-recover-multi");
+    fixture.append_submission("rotation-recover-first", Lsn::from_raw(0));
+    must_ok(fixture.store.rotate_segment(epoch_id()));
+    fixture.append_submission_on_segment(
+        "rotation-recover-second",
+        Lsn::from_raw(2),
+        WalSegmentId::from_raw(2),
+    );
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(report.transactions.len(), 2);
+    assert_eq!(report.last_committed_lsn(), Some(Lsn::from_raw(3)));
+}
+
+#[test]
+fn filesystem_manifest_read_roundtrips_published_manifest() {
+    let mut fixture = WalHardeningFixture::new("manifest-roundtrip");
+    let transaction = fixture.append_submission("manifest-roundtrip", Lsn::from_raw(0));
+    let manifest = WalManifest {
+        manifest_digest: digest("hardening:manifest:roundtrip"),
+        last_committed_lsn: Some(transaction.commit.last_lsn),
+        last_commit_digest: Some(transaction.commit.commit_digest),
+        sealed_segment_count: 1,
+    };
+
+    must_ok(fixture.store.publish_manifest(epoch_id(), manifest.clone()));
+
+    assert_eq!(
+        must_ok(read_filesystem_manifest(&fixture.root)),
+        Some(manifest)
+    );
+}
+
+#[test]
+fn filesystem_manifest_validation_accepts_matching_segment_summary() {
+    let mut fixture = WalHardeningFixture::new("manifest-valid");
+    fixture.append_submission("manifest-valid-first", Lsn::from_raw(0));
+    must_ok(fixture.store.rotate_segment(epoch_id()));
+    let second = fixture.append_submission_on_segment(
+        "manifest-valid-second",
+        Lsn::from_raw(2),
+        WalSegmentId::from_raw(2),
+    );
+    let manifest = WalManifest {
+        manifest_digest: digest("hardening:manifest:valid"),
+        last_committed_lsn: Some(second.commit.last_lsn),
+        last_commit_digest: Some(second.commit.commit_digest),
+        sealed_segment_count: 2,
+    };
+
+    must_ok(fixture.store.publish_manifest(epoch_id(), manifest.clone()));
+    let report = must_ok(validate_filesystem_manifest(&fixture.root));
+
+    assert_eq!(report.manifest, manifest);
+    assert_eq!(report.segment_count, 2);
+    assert_eq!(report.last_committed_lsn, Some(Lsn::from_raw(3)));
+    assert_eq!(report.last_commit_digest, Some(second.commit.commit_digest));
+}
+
+#[test]
+fn filesystem_manifest_validation_rejects_segment_count_mismatch() {
+    let mut fixture = WalHardeningFixture::new("manifest-count-mismatch");
+    let transaction = fixture.append_submission("manifest-count-mismatch", Lsn::from_raw(0));
+    let manifest = WalManifest {
+        manifest_digest: digest("hardening:manifest:count-mismatch"),
+        last_committed_lsn: Some(transaction.commit.last_lsn),
+        last_commit_digest: Some(transaction.commit.commit_digest),
+        sealed_segment_count: 2,
+    };
+
+    must_ok(fixture.store.publish_manifest(epoch_id(), manifest));
+    let error = must_err(
+        validate_filesystem_manifest(&fixture.root),
+        "manifest segment count mismatch should reject",
+    );
+
+    assert_eq!(
+        error,
+        WalStoreError::ManifestSegmentCountMismatch {
+            expected: 1,
+            actual: 2
+        }
+    );
+}
+
+#[test]
+fn filesystem_manifest_validation_rejects_last_lsn_mismatch() {
+    let mut fixture = WalHardeningFixture::new("manifest-lsn-mismatch");
+    let transaction = fixture.append_submission("manifest-lsn-mismatch", Lsn::from_raw(0));
+    let manifest = WalManifest {
+        manifest_digest: digest("hardening:manifest:lsn-mismatch"),
+        last_committed_lsn: Some(Lsn::from_raw(99)),
+        last_commit_digest: Some(transaction.commit.commit_digest),
+        sealed_segment_count: 1,
+    };
+
+    must_ok(fixture.store.publish_manifest(epoch_id(), manifest));
+    let error = must_err(
+        validate_filesystem_manifest(&fixture.root),
+        "manifest last LSN mismatch should reject",
+    );
+
+    assert_eq!(
+        error,
+        WalStoreError::ManifestLastCommittedLsnMismatch {
+            expected: Some(transaction.commit.last_lsn),
+            actual: Some(Lsn::from_raw(99))
+        }
+    );
+}
+
+#[test]
+fn filesystem_manifest_validation_rejects_last_digest_mismatch() {
+    let mut fixture = WalHardeningFixture::new("manifest-digest-mismatch");
+    let transaction = fixture.append_submission("manifest-digest-mismatch", Lsn::from_raw(0));
+    let wrong_digest = digest("hardening:manifest:digest-mismatch:wrong");
+    let manifest = WalManifest {
+        manifest_digest: digest("hardening:manifest:digest-mismatch"),
+        last_committed_lsn: Some(transaction.commit.last_lsn),
+        last_commit_digest: Some(wrong_digest),
+        sealed_segment_count: 1,
+    };
+
+    must_ok(fixture.store.publish_manifest(epoch_id(), manifest));
+    let error = must_err(
+        validate_filesystem_manifest(&fixture.root),
+        "manifest last digest mismatch should reject",
+    );
+
+    assert_eq!(
+        error,
+        WalStoreError::ManifestLastCommitDigestMismatch {
+            expected: Some(transaction.commit.commit_digest),
+            actual: Some(wrong_digest)
+        }
+    );
+}
+
+#[test]
+fn filesystem_manifest_validation_rejects_uncommitted_tail() {
+    let mut fixture = WalHardeningFixture::new("manifest-tail");
+    let transaction = fixture.append_submission("manifest-tail", Lsn::from_raw(0));
+    let manifest = WalManifest {
+        manifest_digest: digest("hardening:manifest:tail"),
+        last_committed_lsn: Some(transaction.commit.last_lsn),
+        last_commit_digest: Some(transaction.commit.commit_digest),
+        sealed_segment_count: 1,
+    };
+    must_ok(fixture.store.publish_manifest(epoch_id(), manifest));
+    fixture.append_uncommitted_submission_frame("manifest-tail-uncommitted", Lsn::from_raw(2));
+
+    let error = must_err(
+        validate_filesystem_manifest(&fixture.root),
+        "manifest validation should reject uncommitted tails",
+    );
+
+    assert_eq!(error, WalStoreError::ManifestCannotValidateUncommittedTail);
+}
+
+#[test]
+fn segment_manifest_validation_gate_is_part_of_wal_release_readiness() {
+    let report = audit_wal_release_readiness(WalReleaseReadinessGates {
+        filesystem_adapter: true,
+        object_store_capability_gate: true,
+        segment_repair: true,
+        segment_layout_policy: true,
+        crash_matrix: true,
+        crashpoint_manifest: true,
+        shadow_replay: true,
+        outbox: true,
+        commit_evidence: true,
+        wal_doctor: true,
+        semantic_validator: true,
+        filesystem_sync_evidence: true,
+        object_store_manifest_negatives: true,
+        security_redaction: true,
+        app_noun_guard: true,
+        external_consumer_gate: true,
+        ..WalReleaseReadinessGates::default()
+    });
+
+    assert!(
+        report
+            .blocked_gates
+            .contains(&"segment_manifest_validation"),
+        "manifest validation should be an explicit WAL release gate"
     );
 }

--- a/crates/warp-core/tests/causal_wal_hardening_tests.rs
+++ b/crates/warp-core/tests/causal_wal_hardening_tests.rs
@@ -269,6 +269,23 @@ fn write_manual_disk_record(path: &Path, kind: u8, payload: &[u8]) {
     must_ok(file.sync_all());
 }
 
+fn write_torn_disk_record(path: &Path, kind: u8, declared_len: u64, payload: &[u8]) {
+    let mut file = must_ok(OpenOptions::new().write(true).truncate(true).open(path));
+    must_ok(file.write_all(WAL_SEGMENT_RECORD_MAGIC));
+    must_ok(file.write_all(&[kind]));
+    must_ok(file.write_all(&declared_len.to_le_bytes()));
+    must_ok(file.write_all(payload));
+    must_ok(file.sync_all());
+}
+
+fn segment_file_name(segment_id: u64) -> String {
+    format!("segment-{segment_id:020}.ecwal")
+}
+
+fn duplicate_segment_file_name(segment_id: u64) -> String {
+    format!("segment-{segment_id:020}-duplicate.ecwal")
+}
+
 #[test]
 fn hardening_fixture_recovers_committed_submission() {
     let mut fixture = WalHardeningFixture::new("fixture-committed");
@@ -458,6 +475,81 @@ fn wal_recovery_golden_unknown_record_kind() {
     assert!(matches!(
         error,
         WalRecoveryError::Store(WalStoreError::UnknownDiskRecordKind(99))
+    ));
+}
+
+#[test]
+fn torn_segment_header_reports_tail() {
+    let fixture = WalHardeningFixture::new("segment-torn-header");
+    fixture.replace_segment_bytes(&WAL_SEGMENT_RECORD_MAGIC[..4]);
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::WouldTruncateAll);
+    assert!(report.transactions.is_empty());
+}
+
+#[test]
+fn torn_segment_payload_reports_tail() {
+    let fixture = WalHardeningFixture::new("segment-torn-payload");
+    write_torn_disk_record(&fixture.segment_path(), 1, 64, b"partial-payload");
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::WouldTruncateAll);
+    assert!(report.transactions.is_empty());
+}
+
+#[test]
+fn torn_segment_digest_reports_tail() {
+    let fixture = WalHardeningFixture::new("segment-torn-digest");
+    write_torn_disk_record(&fixture.segment_path(), 99, 0, &[]);
+
+    let report = must_ok(fixture.recover_read_only());
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::WouldTruncateAll);
+    assert!(report.transactions.is_empty());
+}
+
+#[test]
+fn segment_gap_blocks_recovery() {
+    let fixture = WalHardeningFixture::new("segment-gap");
+    must_ok(fs::write(
+        fixture.root.join(segment_file_name(3)),
+        b"gap-segment",
+    ));
+
+    let error = must_err(
+        fixture.recover_read_only(),
+        "segment gap should block recovery",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Store(WalStoreError::SegmentGap {
+            expected,
+            actual
+        }) if expected == WalSegmentId::from_raw(2) && actual == WalSegmentId::from_raw(3)
+    ));
+}
+
+#[test]
+fn duplicate_segment_id_blocks_recovery() {
+    let fixture = WalHardeningFixture::new("segment-duplicate");
+    must_ok(fs::write(
+        fixture.root.join(duplicate_segment_file_name(1)),
+        b"duplicate-segment",
+    ));
+
+    let error = must_err(
+        fixture.recover_read_only(),
+        "duplicate segment id should block recovery",
+    );
+
+    assert!(matches!(
+        error,
+        WalRecoveryError::Store(WalStoreError::DuplicateSegment(segment_id))
+            if segment_id == WalSegmentId::from_raw(1)
     ));
 }
 

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -3,27 +3,34 @@
 //! Causal WAL foundation tests.
 
 use warp_core::causal_wal::{
-    apply_committed_transaction, build_checkpoint_publication_transaction,
+    apply_committed_transaction, audit_wal_release_readiness,
+    build_checkpoint_publication_transaction, build_materialization_outbox_transaction,
     build_recovery_certificate, build_retained_reading_transaction,
     build_submission_acceptance_transaction, build_tick_transaction, doctor_in_memory_store,
     evaluate_checkpoint_publication, lint_wal_schema_terms, missing_material_scope,
-    read_checkpoint_record, recover_checkpoint_publications, recover_in_memory_store,
+    project_causal_commit_evidence, read_checkpoint_record, recover_checkpoint_publications,
+    recover_filesystem_store, recover_in_memory_store, recover_materialization_outbox,
     recover_receipt_index, recover_retention_index, recover_submission_index,
-    retained_material_obstructions, validate_checkpoint_record, write_checkpoint_record_atomic,
-    AffectedFrontier, AffectedFrontierKind, CheckpointPublicationRecord, CheckpointRecord,
-    CheckpointValidationPosture, EvidenceMaterialPosture, InMemoryWalStore, Lsn,
-    MissingMaterialScope, PayloadCodecId, PayloadSchemaId, ReadingRefRecord, RecoveredState,
-    RecoveredSubmissionPosture, RecoveryAccessMode, RecoveryTailPosture, RetainedMaterialKind,
-    RetainedMaterialRecord, SubmissionAcceptanceRecord, SubmissionRetryPosture, TickReceiptRecord,
-    TransactionLocalIndex, WalAppendAuthority, WalBuildError, WalCommittedTransaction,
-    WalDoctorPosture, WalDurabilityMode, WalManifest, WalReceiptCorrelationRecord, WalRecordKind,
-    WalSchemaLintError, WalSegmentId, WalStoreError, WalStorePort, WalTickDecision,
-    WalTransactionBuilder, WalTransactionId, WalTransactionKind, WriterEpochId, WriterEpochRequest,
+    retained_material_obstructions, shadow_replay_matches, validate_checkpoint_record,
+    validate_strict_object_store_capabilities, write_checkpoint_record_atomic, AffectedFrontier,
+    AffectedFrontierKind, CheckpointPublicationRecord, CheckpointRecord,
+    CheckpointValidationPosture, EvidenceMaterialPosture, ExistingMaterializedArtifact,
+    FilesystemWalStore, InMemoryWalStore, Lsn, MaterializationIntentRecord,
+    MaterializationObservationRecord, MaterializationReplayPosture, MissingMaterialScope,
+    ObjectStoreCapabilityError, ObjectStoreReadAfterWritePosture, ObjectStoreWalCapabilities,
+    PayloadCodecId, PayloadSchemaId, ReadingRefRecord, RecoveredState, RecoveredSubmissionPosture,
+    RecoveryAccessMode, RecoveryTailPosture, RetainedMaterialKind, RetainedMaterialRecord,
+    SubmissionAcceptanceRecord, SubmissionRetryPosture, TickReceiptRecord, TransactionLocalIndex,
+    WalAppendAuthority, WalBuildError, WalCommittedTransaction, WalDoctorPosture,
+    WalDurabilityMode, WalManifest, WalReceiptCorrelationRecord, WalRecordKind,
+    WalReleaseReadinessGates, WalSchemaLintError, WalSegmentId, WalStoreError, WalStorePort,
+    WalTickDecision, WalTransactionBuilder, WalTransactionId, WalTransactionKind, WriterEpochId,
+    WriterEpochRequest,
 };
 use warp_core::Hash;
 
-use std::collections::BTreeSet;
-use std::fs;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, OpenOptions};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -54,6 +61,16 @@ fn temp_checkpoint_path(label: &str) -> std::path::PathBuf {
     ));
     must_ok(fs::create_dir_all(&dir));
     dir.join("checkpoint.ecwal")
+}
+
+fn temp_wal_dir(label: &str) -> std::path::PathBuf {
+    let unique = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "echo-causal-wal-store-{label}-{}-{unique}",
+        std::process::id()
+    ));
+    must_ok(fs::create_dir_all(&dir));
+    dir
 }
 
 fn epoch_id() -> WriterEpochId {
@@ -1035,4 +1052,298 @@ fn read_only_wal_doctor_reports_uncommitted_tail_without_truncating() {
         RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
     );
     assert_eq!(store.read_frames().len(), before);
+}
+
+#[test]
+fn filesystem_wal_adapter_recovers_committed_transaction_from_disk() {
+    let dir = temp_wal_dir("filesystem-committed");
+    let mut store = must_ok(FilesystemWalStore::open(&dir, WalSegmentId::from_raw(1)));
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "filesystem",
+        Lsn::from_raw(0),
+    )));
+
+    let report = must_ok(recover_filesystem_store(&dir, RecoveryAccessMode::ReadOnly));
+    let index = must_ok(recover_submission_index(&report));
+
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(
+        index.retry_posture(
+            submission_acceptance("filesystem").submission_id,
+            submission_acceptance("filesystem").canonical_envelope_digest
+        ),
+        SubmissionRetryPosture::AlreadyAcceptedPending
+    );
+}
+
+#[test]
+fn filesystem_read_only_recovery_reports_uncommitted_tail_without_truncating() {
+    let dir = temp_wal_dir("filesystem-tail-read-only");
+    let mut store = must_ok(FilesystemWalStore::open(&dir, WalSegmentId::from_raw(1)));
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "filesystem-tail",
+        Lsn::from_raw(0),
+    )));
+    let tx = durable_tick_transaction(
+        "filesystem-tail",
+        Lsn::from_raw(2),
+        WalTickDecision::Applied,
+    );
+    must_ok(store.append_uncommitted_frame(epoch_id(), tx.frames[0].clone()));
+    let before = must_ok(fs::metadata(store.segment_path())).len();
+
+    let report = must_ok(recover_filesystem_store(&dir, RecoveryAccessMode::ReadOnly));
+    let after = must_ok(fs::metadata(store.segment_path())).len();
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(after, before);
+}
+
+#[test]
+fn filesystem_writable_recovery_truncates_uncommitted_tail() {
+    let dir = temp_wal_dir("filesystem-tail-writable");
+    let mut store = must_ok(FilesystemWalStore::open(&dir, WalSegmentId::from_raw(1)));
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "filesystem-writable",
+        Lsn::from_raw(0),
+    )));
+    let tx = durable_tick_transaction(
+        "filesystem-writable",
+        Lsn::from_raw(2),
+        WalTickDecision::Applied,
+    );
+    must_ok(store.append_uncommitted_frame(epoch_id(), tx.frames[0].clone()));
+
+    let writable = must_ok(recover_filesystem_store(&dir, RecoveryAccessMode::Writable));
+    let read_only_after = must_ok(recover_filesystem_store(&dir, RecoveryAccessMode::ReadOnly));
+
+    assert_eq!(
+        writable.tail_posture,
+        RecoveryTailPosture::TruncatedAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(read_only_after.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(read_only_after.transactions.len(), 1);
+}
+
+#[test]
+fn filesystem_torn_final_record_is_reported_as_tail_not_history() {
+    let dir = temp_wal_dir("filesystem-torn-tail");
+    let mut store = must_ok(FilesystemWalStore::open(&dir, WalSegmentId::from_raw(1)));
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "filesystem-torn",
+        Lsn::from_raw(0),
+    )));
+    let tx = durable_tick_transaction(
+        "filesystem-torn",
+        Lsn::from_raw(2),
+        WalTickDecision::Applied,
+    );
+    must_ok(store.append_uncommitted_frame(epoch_id(), tx.frames[0].clone()));
+    let segment_path = store.segment_path();
+    let original_len = must_ok(fs::metadata(&segment_path)).len();
+    let file = must_ok(OpenOptions::new().write(true).open(&segment_path));
+    must_ok(file.set_len(original_len.saturating_sub(13)));
+
+    let report = must_ok(recover_filesystem_store(&dir, RecoveryAccessMode::ReadOnly));
+    let receipts = must_ok(recover_receipt_index(&report));
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert!(receipts.receipt_by_submission.is_empty());
+}
+
+#[test]
+fn filesystem_manifest_publish_writes_manifest_material() {
+    let dir = temp_wal_dir("filesystem-manifest");
+    let mut store = must_ok(FilesystemWalStore::open(&dir, WalSegmentId::from_raw(1)));
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let manifest = WalManifest {
+        manifest_digest: digest("manifest:filesystem"),
+        last_committed_lsn: Some(Lsn::from_raw(9)),
+        last_commit_digest: Some(digest("commit:filesystem")),
+        sealed_segment_count: 1,
+    };
+
+    must_ok(store.publish_manifest(epoch_id(), manifest));
+
+    assert!(dir.join("manifest.ecwal").exists());
+}
+
+#[test]
+fn strict_object_store_requires_conditional_manifest_commit() {
+    let invalid = ObjectStoreWalCapabilities {
+        content_addressed_object_write: true,
+        verify_object_version: true,
+        conditional_manifest_commit: false,
+        read_after_write: ObjectStoreReadAfterWritePosture::Verified,
+    };
+    assert!(matches!(
+        validate_strict_object_store_capabilities(invalid),
+        Err(ObjectStoreCapabilityError::MissingConditionalManifestCommit)
+    ));
+
+    let valid = ObjectStoreWalCapabilities {
+        conditional_manifest_commit: true,
+        ..invalid
+    };
+    assert!(validate_strict_object_store_capabilities(valid).is_ok());
+}
+
+#[test]
+fn materialization_replay_detects_existing_artifact_before_retry() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let intent = MaterializationIntentRecord {
+        effect_id: digest("effect:existing"),
+        expected_artifact_digest: digest("artifact:expected"),
+        materialization_intent_digest: digest("materialization:intent"),
+        idempotency_token: digest("idempotency:effect"),
+        target_metadata_digest: digest("artifact:metadata"),
+    };
+    let builder = builder(
+        transaction_id("tx:outbox"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::MaterializationOutbox,
+    );
+    must_ok(
+        store.append_transaction(must_ok(build_materialization_outbox_transaction(
+            builder,
+            intent,
+            None,
+            vec![frontier(
+                AffectedFrontierKind::ReceiptIndex,
+                "outbox:before",
+                "outbox:after",
+            )],
+        ))),
+    );
+    let mut existing = BTreeMap::new();
+    existing.insert(
+        intent.effect_id,
+        ExistingMaterializedArtifact {
+            effect_id: intent.effect_id,
+            artifact_digest: intent.expected_artifact_digest,
+            metadata_digest: intent.target_metadata_digest,
+        },
+    );
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let outbox = must_ok(recover_materialization_outbox(&report, &existing));
+
+    assert_eq!(
+        must_some(outbox.get(&intent.effect_id)).posture,
+        MaterializationReplayPosture::ExistingArtifactMatches
+    );
+}
+
+#[test]
+fn materialization_observation_marks_effect_already_observed() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let intent = MaterializationIntentRecord {
+        effect_id: digest("effect:observed"),
+        expected_artifact_digest: digest("artifact:observed"),
+        materialization_intent_digest: digest("materialization:observed"),
+        idempotency_token: digest("idempotency:observed"),
+        target_metadata_digest: digest("artifact:observed:metadata"),
+    };
+    let observation = MaterializationObservationRecord {
+        effect_id: intent.effect_id,
+        observed_artifact_digest: intent.expected_artifact_digest,
+        observed_metadata_digest: intent.target_metadata_digest,
+    };
+    let builder = builder(
+        transaction_id("tx:outbox-observed"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::MaterializationOutbox,
+    );
+    must_ok(
+        store.append_transaction(must_ok(build_materialization_outbox_transaction(
+            builder,
+            intent,
+            Some(observation),
+            vec![frontier(
+                AffectedFrontierKind::ReceiptIndex,
+                "outbox:before",
+                "outbox:after",
+            )],
+        ))),
+    );
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let outbox = must_ok(recover_materialization_outbox(&report, &BTreeMap::new()));
+
+    assert_eq!(
+        must_some(outbox.get(&intent.effect_id)).posture,
+        MaterializationReplayPosture::AlreadyObserved
+    );
+}
+
+#[test]
+fn causal_commit_evidence_projects_wal_commit_anchor() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let tx = durable_submission_transaction("commit-evidence", Lsn::from_raw(0));
+    let commit_digest = tx.commit.commit_digest;
+    must_ok(store.append_transaction(tx));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let evidence = project_causal_commit_evidence(&report);
+
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(evidence[0].commit_digest, commit_digest);
+    assert_eq!(evidence[0].lsn, Lsn::from_raw(1));
+}
+
+#[test]
+fn wal_shadow_replay_detects_recovered_state_match() {
+    let tx = tick_transaction(Lsn::from_raw(0));
+    let live_state = must_ok(apply_committed_transaction(RecoveredState::default(), &tx));
+
+    assert!(must_ok(shadow_replay_matches(&live_state, &[tx])));
+}
+
+#[test]
+fn wal_release_readiness_audit_reports_blocked_and_ready_gates() {
+    let blocked = audit_wal_release_readiness(WalReleaseReadinessGates {
+        filesystem_adapter: true,
+        object_store_capability_gate: true,
+        ..WalReleaseReadinessGates::default()
+    });
+    assert!(!blocked.ready);
+    assert!(blocked.passed_gates.contains(&"filesystem_adapter"));
+    assert!(blocked.blocked_gates.contains(&"shadow_replay"));
+
+    let ready = audit_wal_release_readiness(WalReleaseReadinessGates {
+        filesystem_adapter: true,
+        object_store_capability_gate: true,
+        segment_repair: true,
+        crash_matrix: true,
+        shadow_replay: true,
+        outbox: true,
+        commit_evidence: true,
+        external_consumer_gate: true,
+    });
+    assert!(ready.ready);
+    assert!(ready.blocked_gates.is_empty());
 }

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -1339,9 +1339,16 @@ fn wal_release_readiness_audit_reports_blocked_and_ready_gates() {
         object_store_capability_gate: true,
         segment_repair: true,
         crash_matrix: true,
+        crashpoint_manifest: true,
         shadow_replay: true,
         outbox: true,
         commit_evidence: true,
+        wal_doctor: true,
+        semantic_validator: true,
+        filesystem_sync_evidence: true,
+        object_store_manifest_negatives: true,
+        security_redaction: true,
+        app_noun_guard: true,
         external_consumer_gate: true,
     });
     assert!(ready.ready);

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Causal WAL foundation tests.
+
+use warp_core::causal_wal::{
+    apply_committed_transaction, lint_wal_schema_terms, recover_in_memory_store, AffectedFrontier,
+    AffectedFrontierKind, InMemoryWalStore, Lsn, PayloadCodecId, PayloadSchemaId, RecoveredState,
+    RecoveryAccessMode, RecoveryTailPosture, TransactionLocalIndex, WalAppendAuthority,
+    WalBuildError, WalCommittedTransaction, WalDurabilityMode, WalManifest, WalRecordKind,
+    WalSchemaLintError, WalSegmentId, WalStoreError, WalStorePort, WalTransactionBuilder,
+    WalTransactionId, WalTransactionKind, WriterEpochId, WriterEpochRequest,
+};
+use warp_core::Hash;
+
+fn digest(label: &str) -> Hash {
+    blake3::hash(label.as_bytes()).into()
+}
+
+fn must_ok<T, E>(result: Result<T, E>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(_) => std::process::abort(),
+    }
+}
+
+fn epoch_id() -> WriterEpochId {
+    WriterEpochId::from_hash(digest("epoch:1"))
+}
+
+fn transaction_id(label: &str) -> WalTransactionId {
+    WalTransactionId::from_hash(digest(label))
+}
+
+fn writer_epoch_request() -> WriterEpochRequest {
+    WriterEpochRequest {
+        epoch_id: epoch_id(),
+        storage_fencing_token: digest("fencing"),
+        process_identity: digest("process"),
+        host_identity: digest("host"),
+        started_at_lsn: Lsn::from_raw(0),
+        previous_epoch_id: None,
+        previous_epoch_final_commit_digest: None,
+        lease_or_lock_evidence: digest("lease"),
+    }
+}
+
+fn builder(
+    transaction_id: WalTransactionId,
+    first_lsn: Lsn,
+    authority: WalAppendAuthority,
+    kind: WalTransactionKind,
+) -> WalTransactionBuilder {
+    WalTransactionBuilder::new(
+        epoch_id(),
+        WalSegmentId::from_raw(1),
+        transaction_id,
+        kind,
+        authority,
+        first_lsn,
+        digest("previous-frame"),
+        digest("previous-commit"),
+        WalDurabilityMode::Buffered,
+        PayloadCodecId::from_hash(digest("codec")),
+        PayloadSchemaId::from_hash(digest("schema")),
+        1,
+        1,
+        digest("domain"),
+    )
+}
+
+fn frontier(kind: AffectedFrontierKind, before: &str, after: &str) -> AffectedFrontier {
+    AffectedFrontier {
+        kind,
+        before_digest: digest(before),
+        after_digest: digest(after),
+    }
+}
+
+fn submission_transaction(first_lsn: Lsn) -> WalCommittedTransaction {
+    let mut builder = builder(
+        transaction_id("tx:submission"),
+        first_lsn,
+        WalAppendAuthority::SubmissionIntake,
+        WalTransactionKind::SubmissionIntake,
+    );
+    must_ok(builder.push_record(
+        WalRecordKind::SubmissionAcceptedRecorded,
+        b"accepted".to_vec(),
+    ));
+    must_ok(builder.commit(vec![frontier(
+        AffectedFrontierKind::SubmissionQueue,
+        "queue:before",
+        "queue:after",
+    )]))
+}
+
+fn tick_transaction(first_lsn: Lsn) -> WalCommittedTransaction {
+    let mut builder = builder(
+        transaction_id("tx:tick"),
+        first_lsn,
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::SchedulerTick,
+    );
+    must_ok(builder.push_record(WalRecordKind::TickReceiptRecorded, b"receipt".to_vec()));
+    must_ok(builder.push_record(WalRecordKind::RuntimeStateDeltaRecorded, b"delta".to_vec()));
+    must_ok(builder.commit(vec![
+        frontier(
+            AffectedFrontierKind::RuntimeState,
+            "state:before",
+            "state:after",
+        ),
+        frontier(
+            AffectedFrontierKind::ReceiptIndex,
+            "receipt:before",
+            "receipt:after",
+        ),
+    ]))
+}
+
+#[test]
+fn record_kind_name_does_not_imply_commit_before_transaction_commit() {
+    let kinds = [
+        WalRecordKind::SubmissionAcceptedRecorded,
+        WalRecordKind::SubmissionAcceptanceEvidenceRecorded,
+        WalRecordKind::RuntimeLawWitnessRecorded,
+        WalRecordKind::RuntimeAdmissionTicketIssued,
+        WalRecordKind::TicketedRuntimeIngressRecorded,
+        WalRecordKind::TickReceiptRecorded,
+        WalRecordKind::RuntimeStateDeltaRecorded,
+        WalRecordKind::ReceiptCorrelationRecorded,
+        WalRecordKind::ReadingEnvelopeRetained,
+        WalRecordKind::RetainedMaterialRefRecorded,
+        WalRecordKind::SchedulerFaultQuarantined,
+        WalRecordKind::TrustedRuntimeControlRecorded,
+        WalRecordKind::CheckpointPublicationRecorded,
+        WalRecordKind::MaterializationIntentRecorded,
+        WalRecordKind::MaterializationEffectObserved,
+        WalRecordKind::RecoveryPostureRecorded,
+    ];
+
+    assert!(kinds
+        .iter()
+        .all(|kind| kind.obeys_recorded_not_committed_grammar()));
+}
+
+#[test]
+fn application_cannot_append_tick_or_runtime_control_records() {
+    let mut builder = builder(
+        transaction_id("tx:bad-authority"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::SubmissionIntake,
+        WalTransactionKind::SubmissionIntake,
+    );
+
+    let error = builder.push_record(WalRecordKind::TickReceiptRecorded, b"receipt".to_vec());
+
+    assert!(matches!(
+        error,
+        Err(WalBuildError::WrongAppendAuthority {
+            record_kind: WalRecordKind::TickReceiptRecorded,
+            required: WalAppendAuthority::TrustedScheduler,
+            actual: WalAppendAuthority::SubmissionIntake
+        })
+    ));
+}
+
+#[test]
+fn transaction_builder_creates_contiguous_lsn_and_local_indexes() {
+    let tx = tick_transaction(Lsn::from_raw(7));
+
+    assert_eq!(tx.frames[0].header.lsn, Lsn::from_raw(7));
+    assert_eq!(tx.frames[1].header.lsn, Lsn::from_raw(8));
+    assert_eq!(
+        tx.frames[0].header.transaction_local_index,
+        TransactionLocalIndex::from_raw(0)
+    );
+    assert_eq!(
+        tx.frames[1].header.transaction_local_index,
+        TransactionLocalIndex::from_raw(1)
+    );
+    assert_eq!(tx.commit.first_lsn, Lsn::from_raw(7));
+    assert_eq!(tx.commit.last_lsn, Lsn::from_raw(8));
+    assert!(tx.validate().is_ok());
+}
+
+#[test]
+fn commit_validation_rejects_record_count_mismatch() {
+    let mut tx = tick_transaction(Lsn::from_raw(0));
+    tx.commit.record_count = 99;
+
+    assert!(tx.validate().is_err());
+}
+
+#[test]
+fn commit_validation_rejects_corrupt_payload_even_when_commit_shape_exists() {
+    let mut tx = submission_transaction(Lsn::from_raw(0));
+    tx.frames[0].payload.canonical_bytes = b"tampered".to_vec();
+
+    assert!(tx.validate().is_err());
+}
+
+#[test]
+fn semantic_validation_rejects_record_authority_mismatch() {
+    let mut builder = builder(
+        transaction_id("tx:mismatched-kind"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::SubmissionIntake,
+    );
+    must_ok(builder.push_record(WalRecordKind::TickReceiptRecorded, b"receipt".to_vec()));
+    let tx = builder.commit(vec![frontier(
+        AffectedFrontierKind::ReceiptIndex,
+        "receipt:before",
+        "receipt:after",
+    )]);
+
+    assert!(matches!(
+        tx,
+        Err(WalBuildError::Validation(
+            warp_core::causal_wal::WalValidationError::RecordAuthorityMismatch
+        ))
+    ));
+}
+
+#[test]
+fn in_memory_store_appends_and_recovers_committed_transactions() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(submission_transaction(Lsn::from_raw(0))));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+
+    assert_eq!(report.transactions.len(), 1);
+    assert_eq!(report.tail_posture, RecoveryTailPosture::Clean);
+    assert_eq!(store.read_frames().len(), 1);
+}
+
+#[test]
+fn wal_store_port_seals_segment_and_publishes_manifest() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(submission_transaction(Lsn::from_raw(0))));
+
+    let seal = must_ok(store.seal_segment(epoch_id(), WalSegmentId::from_raw(1)));
+    assert_eq!(seal.segment_id, WalSegmentId::from_raw(1));
+    assert_eq!(seal.sealed_lsn, Some(Lsn::from_raw(0)));
+
+    must_ok(store.publish_manifest(
+        epoch_id(),
+        WalManifest {
+            manifest_digest: digest("manifest"),
+            last_committed_lsn: Some(Lsn::from_raw(0)),
+            last_commit_digest: Some(store.read_commits()[0].commit_digest),
+            sealed_segment_count: 1,
+        },
+    ));
+    assert_eq!(store.manifests().len(), 1);
+}
+
+#[test]
+fn overlapping_writer_epochs_block_recovery() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+
+    let second = store.acquire_writer_epoch(WriterEpochRequest {
+        epoch_id: WriterEpochId::from_hash(digest("epoch:2")),
+        ..writer_epoch_request()
+    });
+
+    assert!(matches!(
+        second,
+        Err(WalStoreError::WriterEpochAlreadyActive)
+    ));
+}
+
+#[test]
+fn read_only_recovery_reports_uncommitted_tail_without_truncating() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(submission_transaction(Lsn::from_raw(0))));
+    let uncommitted = tick_transaction(Lsn::from_raw(1)).frames.remove(0);
+    must_ok(store.append_uncommitted_frame(epoch_id(), uncommitted));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(0))
+    );
+    assert_eq!(store.read_frames().len(), 2);
+}
+
+#[test]
+fn writable_recovery_truncates_uncommitted_tail() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(submission_transaction(Lsn::from_raw(0))));
+    let uncommitted = tick_transaction(Lsn::from_raw(1)).frames.remove(0);
+    must_ok(store.append_uncommitted_frame(epoch_id(), uncommitted));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::Writable,
+    ));
+
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::TruncatedAfter(Lsn::from_raw(0))
+    );
+    assert_eq!(store.read_frames().len(), 1);
+}
+
+#[test]
+fn pure_replay_reducer_is_deterministic_over_committed_transactions() {
+    let tx = tick_transaction(Lsn::from_raw(0));
+
+    let first = must_ok(apply_committed_transaction(RecoveredState::default(), &tx));
+    let second = must_ok(apply_committed_transaction(RecoveredState::default(), &tx));
+
+    assert_eq!(first, second);
+    assert_eq!(first.applied_transactions, vec![tx.commit.transaction_id]);
+    assert_eq!(
+        first
+            .frontiers
+            .get(&AffectedFrontierKind::RuntimeState)
+            .copied(),
+        Some(digest("state:after"))
+    );
+}
+
+#[test]
+fn schema_linter_rejects_app_nouns_and_authority_leaks() {
+    let app_noun = lint_wal_schema_terms(["TextBufferCommit"], &["TextBuffer"]);
+    assert!(matches!(
+        app_noun,
+        Err(WalSchemaLintError::ForbiddenAppNoun { .. })
+    ));
+
+    let authority_leak = lint_wal_schema_terms(["ClientRuntimeControl"], &[]);
+    assert!(matches!(
+        authority_leak,
+        Err(WalSchemaLintError::ForbiddenAuthorityLeak { .. })
+    ));
+
+    let commit_name = lint_wal_schema_terms(["TickReceiptCommitted"], &[]);
+    assert!(matches!(
+        commit_name,
+        Err(WalSchemaLintError::RecordNameImpliesCommit { .. })
+    ));
+
+    assert!(lint_wal_schema_terms(
+        [
+            "SubmissionAcceptedRecorded",
+            "TickReceiptRecorded",
+            "WalTransactionCommit"
+        ],
+        &["TextBuffer"]
+    )
+    .is_ok());
+}

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -1339,6 +1339,7 @@ fn wal_release_readiness_audit_reports_blocked_and_ready_gates() {
         object_store_capability_gate: true,
         segment_repair: true,
         segment_layout_policy: true,
+        segment_manifest_validation: true,
         crash_matrix: true,
         crashpoint_manifest: true,
         shadow_replay: true,

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -1338,6 +1338,7 @@ fn wal_release_readiness_audit_reports_blocked_and_ready_gates() {
         filesystem_adapter: true,
         object_store_capability_gate: true,
         segment_repair: true,
+        segment_layout_policy: true,
         crash_matrix: true,
         crashpoint_manifest: true,
         shadow_replay: true,

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -3,14 +3,30 @@
 //! Causal WAL foundation tests.
 
 use warp_core::causal_wal::{
-    apply_committed_transaction, lint_wal_schema_terms, recover_in_memory_store, AffectedFrontier,
-    AffectedFrontierKind, InMemoryWalStore, Lsn, PayloadCodecId, PayloadSchemaId, RecoveredState,
-    RecoveryAccessMode, RecoveryTailPosture, TransactionLocalIndex, WalAppendAuthority,
-    WalBuildError, WalCommittedTransaction, WalDurabilityMode, WalManifest, WalRecordKind,
-    WalSchemaLintError, WalSegmentId, WalStoreError, WalStorePort, WalTransactionBuilder,
-    WalTransactionId, WalTransactionKind, WriterEpochId, WriterEpochRequest,
+    apply_committed_transaction, build_checkpoint_publication_transaction,
+    build_recovery_certificate, build_retained_reading_transaction,
+    build_submission_acceptance_transaction, build_tick_transaction, doctor_in_memory_store,
+    evaluate_checkpoint_publication, lint_wal_schema_terms, missing_material_scope,
+    read_checkpoint_record, recover_checkpoint_publications, recover_in_memory_store,
+    recover_receipt_index, recover_retention_index, recover_submission_index,
+    retained_material_obstructions, validate_checkpoint_record, write_checkpoint_record_atomic,
+    AffectedFrontier, AffectedFrontierKind, CheckpointPublicationRecord, CheckpointRecord,
+    CheckpointValidationPosture, EvidenceMaterialPosture, InMemoryWalStore, Lsn,
+    MissingMaterialScope, PayloadCodecId, PayloadSchemaId, ReadingRefRecord, RecoveredState,
+    RecoveredSubmissionPosture, RecoveryAccessMode, RecoveryTailPosture, RetainedMaterialKind,
+    RetainedMaterialRecord, SubmissionAcceptanceRecord, SubmissionRetryPosture, TickReceiptRecord,
+    TransactionLocalIndex, WalAppendAuthority, WalBuildError, WalCommittedTransaction,
+    WalDoctorPosture, WalDurabilityMode, WalManifest, WalReceiptCorrelationRecord, WalRecordKind,
+    WalSchemaLintError, WalSegmentId, WalStoreError, WalStorePort, WalTickDecision,
+    WalTransactionBuilder, WalTransactionId, WalTransactionKind, WriterEpochId, WriterEpochRequest,
 };
 use warp_core::Hash;
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn digest(label: &str) -> Hash {
     blake3::hash(label.as_bytes()).into()
@@ -21,6 +37,23 @@ fn must_ok<T, E>(result: Result<T, E>) -> T {
         Ok(value) => value,
         Err(_) => std::process::abort(),
     }
+}
+
+fn must_some<T>(option: Option<T>) -> T {
+    match option {
+        Some(value) => value,
+        None => std::process::abort(),
+    }
+}
+
+fn temp_checkpoint_path(label: &str) -> std::path::PathBuf {
+    let unique = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "echo-causal-wal-{label}-{}-{unique}",
+        std::process::id()
+    ));
+    must_ok(fs::create_dir_all(&dir));
+    dir.join("checkpoint.ecwal")
 }
 
 fn epoch_id() -> WriterEpochId {
@@ -76,6 +109,55 @@ fn frontier(kind: AffectedFrontierKind, before: &str, after: &str) -> AffectedFr
     }
 }
 
+fn submission_acceptance(label: &str) -> SubmissionAcceptanceRecord {
+    SubmissionAcceptanceRecord {
+        submission_id: digest(&format!("submission:{label}")),
+        canonical_envelope_digest: digest(&format!("envelope:{label}")),
+        idempotency_key_digest: None,
+        acceptance_evidence_digest: digest(&format!("accepted-evidence:{label}")),
+    }
+}
+
+fn receipt_record(label: &str, decision: WalTickDecision) -> TickReceiptRecord {
+    TickReceiptRecord {
+        submission_id: digest(&format!("submission:{label}")),
+        ticket_digest: digest(&format!("ticket:{label}")),
+        receipt_digest: digest(&format!("receipt:{label}")),
+        decision,
+    }
+}
+
+fn correlation_record(label: &str) -> WalReceiptCorrelationRecord {
+    WalReceiptCorrelationRecord {
+        submission_id: digest(&format!("submission:{label}")),
+        ticket_digest: digest(&format!("ticket:{label}")),
+        receipt_digest: digest(&format!("receipt:{label}")),
+    }
+}
+
+fn retained_material(
+    label: &str,
+    kind: RetainedMaterialKind,
+    posture: EvidenceMaterialPosture,
+) -> RetainedMaterialRecord {
+    RetainedMaterialRecord {
+        material_digest: digest(&format!("material:{label}")),
+        semantic_coordinate_digest: digest(&format!("coordinate:{label}")),
+        kind,
+        posture,
+    }
+}
+
+fn reading_ref(label: &str, posture: EvidenceMaterialPosture) -> ReadingRefRecord {
+    ReadingRefRecord {
+        reading_id: digest(&format!("reading:{label}")),
+        semantic_coordinate_digest: digest(&format!("coordinate:{label}")),
+        payload_digest: digest(&format!("material:{label}:payload")),
+        envelope_digest: digest(&format!("material:{label}:envelope")),
+        posture,
+    }
+}
+
 fn submission_transaction(first_lsn: Lsn) -> WalCommittedTransaction {
     let mut builder = builder(
         transaction_id("tx:submission"),
@@ -92,6 +174,24 @@ fn submission_transaction(first_lsn: Lsn) -> WalCommittedTransaction {
         "queue:before",
         "queue:after",
     )]))
+}
+
+fn durable_submission_transaction(label: &str, first_lsn: Lsn) -> WalCommittedTransaction {
+    let builder = builder(
+        transaction_id(&format!("tx:submission:{label}")),
+        first_lsn,
+        WalAppendAuthority::SubmissionIntake,
+        WalTransactionKind::SubmissionIntake,
+    );
+    must_ok(build_submission_acceptance_transaction(
+        builder,
+        submission_acceptance(label),
+        vec![frontier(
+            AffectedFrontierKind::SubmissionQueue,
+            &format!("queue:{label}:before"),
+            &format!("queue:{label}:after"),
+        )],
+    ))
 }
 
 fn tick_transaction(first_lsn: Lsn) -> WalCommittedTransaction {
@@ -115,6 +215,37 @@ fn tick_transaction(first_lsn: Lsn) -> WalCommittedTransaction {
             "receipt:after",
         ),
     ]))
+}
+
+fn durable_tick_transaction(
+    label: &str,
+    first_lsn: Lsn,
+    decision: WalTickDecision,
+) -> WalCommittedTransaction {
+    let builder = builder(
+        transaction_id(&format!("tx:tick:{label}")),
+        first_lsn,
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::SchedulerTick,
+    );
+    must_ok(build_tick_transaction(
+        builder,
+        receipt_record(label, decision),
+        correlation_record(label),
+        digest(&format!("state-delta:{label}")),
+        vec![
+            frontier(
+                AffectedFrontierKind::RuntimeState,
+                &format!("state:{label}:before"),
+                &format!("state:{label}:after"),
+            ),
+            frontier(
+                AffectedFrontierKind::ReceiptIndex,
+                &format!("receipt:{label}:before"),
+                &format!("receipt:{label}:after"),
+            ),
+        ],
+    ))
 }
 
 #[test]
@@ -363,4 +494,545 @@ fn schema_linter_rejects_app_nouns_and_authority_leaks() {
         &["TextBuffer"]
     )
     .is_ok());
+}
+
+#[test]
+fn accepted_submission_is_not_returned_before_wal_commit() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let tx = durable_submission_transaction("accept", Lsn::from_raw(0));
+    let uncommitted = tx.frames[0].clone();
+    must_ok(store.append_uncommitted_frame(epoch_id(), uncommitted));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let index = must_ok(recover_submission_index(&report));
+
+    assert!(index.is_empty());
+    assert_eq!(
+        index.retry_posture(
+            submission_acceptance("accept").submission_id,
+            submission_acceptance("accept").canonical_envelope_digest
+        ),
+        SubmissionRetryPosture::NotAccepted
+    );
+}
+
+#[test]
+fn crash_after_submission_commit_recovers_pending_submission() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction("pending", Lsn::from_raw(0))));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let index = must_ok(recover_submission_index(&report));
+    let entry = must_some(index.get(&submission_acceptance("pending").submission_id));
+
+    assert_eq!(entry.posture, RecoveredSubmissionPosture::AcceptedPending);
+    assert_eq!(index.len(), 1);
+}
+
+#[test]
+fn crash_after_submission_commit_before_ack_retry_returns_duplicate_posture() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction("retry", Lsn::from_raw(0))));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let index = must_ok(recover_submission_index(&report));
+    let record = submission_acceptance("retry");
+
+    assert_eq!(
+        index.retry_posture(record.submission_id, record.canonical_envelope_digest),
+        SubmissionRetryPosture::AlreadyAcceptedPending
+    );
+}
+
+#[test]
+fn same_payload_new_submission_id_is_not_duplicate_without_policy() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "same-payload",
+        Lsn::from_raw(0),
+    )));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let index = must_ok(recover_submission_index(&report));
+    let existing = submission_acceptance("same-payload");
+
+    assert_eq!(
+        index.retry_posture(
+            digest("submission:new-id"),
+            existing.canonical_envelope_digest
+        ),
+        SubmissionRetryPosture::NewSubmissionWithoutPolicyDedupe
+    );
+    assert_eq!(
+        index.retry_posture(existing.submission_id, digest("envelope:different")),
+        SubmissionRetryPosture::ConflictSameIdDifferentEnvelope
+    );
+}
+
+#[test]
+fn recovery_certificate_reports_clean_submission_posture() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "certificate",
+        Lsn::from_raw(0),
+    )));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let certificate =
+        build_recovery_certificate(&report, None, 0, digest("frontiers"), digest("indexes"));
+
+    assert_eq!(certificate.committed_transactions_replayed, 1);
+    assert_eq!(certificate.first_lsn, Some(Lsn::from_raw(0)));
+    assert_eq!(certificate.last_lsn, Some(Lsn::from_raw(1)));
+    assert_eq!(certificate.tail_posture, RecoveryTailPosture::Clean);
+}
+
+#[test]
+fn crash_before_tick_commit_commits_no_receipt() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "tick-tail",
+        Lsn::from_raw(0),
+    )));
+    let tx = durable_tick_transaction("tick-tail", Lsn::from_raw(2), WalTickDecision::Applied);
+    must_ok(store.append_uncommitted_frame(epoch_id(), tx.frames[0].clone()));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let receipt_index = must_ok(recover_receipt_index(&report));
+
+    assert!(receipt_index.receipt_by_submission.is_empty());
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+}
+
+#[test]
+fn crash_after_tick_commit_recovers_receipt_and_state_delta() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction("applied", Lsn::from_raw(0))));
+    must_ok(store.append_transaction(durable_tick_transaction(
+        "applied",
+        Lsn::from_raw(2),
+        WalTickDecision::Applied,
+    )));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let submissions = must_ok(recover_submission_index(&report));
+    let receipts = must_ok(recover_receipt_index(&report));
+
+    assert_eq!(
+        must_some(submissions.get(&submission_acceptance("applied").submission_id)).posture,
+        RecoveredSubmissionPosture::DecidedApplied
+    );
+    assert_eq!(
+        receipts
+            .receipt_by_submission
+            .get(&digest("submission:applied"))
+            .copied(),
+        Some(digest("receipt:applied"))
+    );
+}
+
+#[test]
+fn committed_receipt_correlation_rebuilds_after_restart() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_tick_transaction(
+        "correlated",
+        Lsn::from_raw(0),
+        WalTickDecision::Applied,
+    )));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let receipts = must_ok(recover_receipt_index(&report));
+
+    assert_eq!(
+        receipts
+            .receipt_by_ticket
+            .get(&digest("ticket:correlated"))
+            .copied(),
+        Some(digest("receipt:correlated"))
+    );
+    assert_eq!(
+        receipts
+            .ticket_by_submission
+            .get(&digest("submission:correlated"))
+            .copied(),
+        Some(digest("ticket:correlated"))
+    );
+}
+
+#[test]
+fn lawful_rejection_recovers_without_fault_posture() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction("rejected", Lsn::from_raw(0))));
+    must_ok(store.append_transaction(durable_tick_transaction(
+        "rejected",
+        Lsn::from_raw(2),
+        WalTickDecision::RejectedFootprintConflict,
+    )));
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let submissions = must_ok(recover_submission_index(&report));
+    let receipts = must_ok(recover_receipt_index(&report));
+
+    assert_eq!(
+        must_some(submissions.get(&digest("submission:rejected"))).posture,
+        RecoveredSubmissionPosture::DecidedRejected
+    );
+    assert!(must_some(
+        receipts
+            .decisions_by_receipt
+            .get(&digest("receipt:rejected"))
+            .copied()
+    )
+    .is_lawful_rejection());
+}
+
+#[test]
+fn retained_queryview_reading_lookup_recovers_by_semantic_coordinate() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let material = [
+        retained_material(
+            "query",
+            RetainedMaterialKind::ReadingPayload,
+            EvidenceMaterialPosture::Present,
+        ),
+        RetainedMaterialRecord {
+            material_digest: digest("material:query:envelope"),
+            semantic_coordinate_digest: digest("coordinate:query"),
+            kind: RetainedMaterialKind::ReadingEnvelope,
+            posture: EvidenceMaterialPosture::Present,
+        },
+    ];
+    let builder = builder(
+        transaction_id("tx:reading"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::SchedulerTick,
+    );
+    must_ok(
+        store.append_transaction(must_ok(build_retained_reading_transaction(
+            builder,
+            &material,
+            reading_ref("query", EvidenceMaterialPosture::Present),
+            vec![frontier(
+                AffectedFrontierKind::ReadingIndex,
+                "reading:before",
+                "reading:after",
+            )],
+        ))),
+    );
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+
+    assert!(must_some(
+        retention
+            .readings_by_semantic_coordinate
+            .get(&digest("coordinate:query"))
+    )
+    .contains(&digest("reading:query")));
+}
+
+#[test]
+fn same_payload_with_different_query_coordinate_remains_distinct() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let payload = digest("shared-payload");
+    let first = RetainedMaterialRecord {
+        material_digest: payload,
+        semantic_coordinate_digest: digest("coordinate:first"),
+        kind: RetainedMaterialKind::ReadingPayload,
+        posture: EvidenceMaterialPosture::Present,
+    };
+    let second = RetainedMaterialRecord {
+        material_digest: payload,
+        semantic_coordinate_digest: digest("coordinate:second"),
+        kind: RetainedMaterialKind::ReadingPayload,
+        posture: EvidenceMaterialPosture::Present,
+    };
+    let builder = builder(
+        transaction_id("tx:semantic-identity"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::SchedulerTick,
+    );
+    must_ok(
+        store.append_transaction(must_ok(build_retained_reading_transaction(
+            builder,
+            &[first, second],
+            reading_ref("semantic-identity", EvidenceMaterialPosture::Present),
+            vec![frontier(
+                AffectedFrontierKind::ReadingIndex,
+                "reading:before",
+                "reading:after",
+            )],
+        ))),
+    );
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+
+    assert!(retention
+        .material_by_semantic_coordinate
+        .contains_key(&digest("coordinate:first")));
+    assert!(retention
+        .material_by_semantic_coordinate
+        .contains_key(&digest("coordinate:second")));
+}
+
+#[test]
+fn security_and_redaction_postures_decode_without_becoming_missing() {
+    for posture in [
+        EvidenceMaterialPosture::Present,
+        EvidenceMaterialPosture::RedactedByPolicy,
+        EvidenceMaterialPosture::EncryptedKeyUnavailable,
+        EvidenceMaterialPosture::Missing,
+        EvidenceMaterialPosture::Corrupt,
+        EvidenceMaterialPosture::Obstructed,
+    ] {
+        let record = retained_material("posture", RetainedMaterialKind::ReadingPayload, posture);
+        let decoded = must_ok(RetainedMaterialRecord::from_payload_bytes(
+            &record.to_payload_bytes(),
+        ));
+        assert_eq!(decoded.posture, posture);
+    }
+}
+
+#[test]
+fn missing_retained_material_scope_matrix_is_precise() {
+    assert_eq!(
+        missing_material_scope(RetainedMaterialKind::SubmissionPayload),
+        MissingMaterialScope::Submission
+    );
+    assert_eq!(
+        missing_material_scope(RetainedMaterialKind::TickReceipt),
+        MissingMaterialScope::ReceiptOrTicket
+    );
+    assert_eq!(
+        missing_material_scope(RetainedMaterialKind::RuntimeStateDelta),
+        MissingMaterialScope::RuntimeGlobal
+    );
+    assert_eq!(
+        missing_material_scope(RetainedMaterialKind::ReadingEnvelope),
+        MissingMaterialScope::Reading
+    );
+    assert_eq!(
+        missing_material_scope(RetainedMaterialKind::Diagnostic),
+        MissingMaterialScope::DiagnosticLoss
+    );
+}
+
+#[test]
+fn missing_retained_material_returns_typed_obstruction() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let missing = retained_material(
+        "missing",
+        RetainedMaterialKind::RuntimeStateDelta,
+        EvidenceMaterialPosture::Present,
+    );
+    let builder = builder(
+        transaction_id("tx:missing-material"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::TrustedScheduler,
+        WalTransactionKind::SchedulerTick,
+    );
+    must_ok(
+        store.append_transaction(must_ok(build_retained_reading_transaction(
+            builder,
+            &[missing],
+            reading_ref("missing", EvidenceMaterialPosture::Present),
+            vec![frontier(
+                AffectedFrontierKind::ReadingIndex,
+                "reading:before",
+                "reading:after",
+            )],
+        ))),
+    );
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let retention = must_ok(recover_retention_index(&report));
+    let obstructions = retained_material_obstructions(&retention, &BTreeSet::new());
+
+    assert_eq!(obstructions.len(), 1);
+    assert_eq!(obstructions[0].scope, MissingMaterialScope::RuntimeGlobal);
+    assert_eq!(obstructions[0].posture, EvidenceMaterialPosture::Missing);
+}
+
+#[test]
+fn valid_checkpoint_without_checkpoint_published_record_can_be_used_after_validation() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "checkpoint",
+        Lsn::from_raw(0),
+    )));
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let checkpoint = CheckpointRecord {
+        checkpoint_id: digest("checkpoint"),
+        last_included_lsn: must_some(report.last_committed_lsn()),
+        last_included_commit_digest: must_some(report.last_commit_digest()),
+        state_root: digest("state-root"),
+        index_root: digest("index-root"),
+        retained_material_root: digest("material-root"),
+        schema_version: 1,
+        created_from_wal_digest: digest("wal-chain"),
+    };
+
+    assert_eq!(
+        validate_checkpoint_record(&checkpoint, &report, &[]),
+        CheckpointValidationPosture::UsableWithoutPublicationRecord
+    );
+}
+
+#[test]
+fn checkpoint_writer_roundtrips_atomic_checkpoint_file() {
+    let checkpoint = CheckpointRecord {
+        checkpoint_id: digest("checkpoint-file"),
+        last_included_lsn: Lsn::from_raw(42),
+        last_included_commit_digest: digest("commit:file"),
+        state_root: digest("state:file"),
+        index_root: digest("index:file"),
+        retained_material_root: digest("material:file"),
+        schema_version: 1,
+        created_from_wal_digest: digest("wal:file"),
+    };
+    let path = temp_checkpoint_path("roundtrip");
+
+    must_ok(write_checkpoint_record_atomic(&path, &checkpoint));
+    let restored = must_ok(read_checkpoint_record(&path));
+
+    assert_eq!(restored, checkpoint);
+    let temp_path = path.with_file_name(".checkpoint.ecwal.tmp");
+    assert!(!temp_path.exists());
+}
+
+#[test]
+fn checkpoint_published_without_checkpoint_blocks_or_obstructs_according_to_scope() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "checkpoint-missing",
+        Lsn::from_raw(0),
+    )));
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let publication = CheckpointPublicationRecord {
+        checkpoint_id: digest("checkpoint-missing"),
+        checkpoint_digest: digest("checkpoint-digest"),
+    };
+
+    assert_eq!(
+        evaluate_checkpoint_publication(&publication, None, &report),
+        CheckpointValidationPosture::PublishedCheckpointMaterialMissing
+    );
+}
+
+#[test]
+fn checkpoint_publication_roundtrip_recovers_from_wal() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    let publication = CheckpointPublicationRecord {
+        checkpoint_id: digest("checkpoint-publication"),
+        checkpoint_digest: digest("checkpoint-publication-digest"),
+    };
+    let builder = builder(
+        transaction_id("tx:checkpoint-publication"),
+        Lsn::from_raw(0),
+        WalAppendAuthority::Recovery,
+        WalTransactionKind::Checkpoint,
+    );
+    must_ok(
+        store.append_transaction(must_ok(build_checkpoint_publication_transaction(
+            builder,
+            publication,
+            vec![frontier(
+                AffectedFrontierKind::CheckpointIndex,
+                "checkpoint:before",
+                "checkpoint:after",
+            )],
+        ))),
+    );
+
+    let report = must_ok(recover_in_memory_store(
+        &mut store,
+        RecoveryAccessMode::ReadOnly,
+    ));
+    let publications = must_ok(recover_checkpoint_publications(&report));
+
+    assert_eq!(publications, vec![publication]);
+}
+
+#[test]
+fn read_only_wal_doctor_reports_uncommitted_tail_without_truncating() {
+    let mut store = InMemoryWalStore::new();
+    must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction("doctor", Lsn::from_raw(0))));
+    let tx = durable_tick_transaction("doctor", Lsn::from_raw(2), WalTickDecision::Applied);
+    must_ok(store.append_uncommitted_frame(epoch_id(), tx.frames[0].clone()));
+
+    let before = store.read_frames().len();
+    let report = must_ok(doctor_in_memory_store(&store));
+
+    assert_eq!(
+        report.posture,
+        WalDoctorPosture::RecoverableWithUncommittedTail
+    );
+    assert_eq!(
+        report.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+    assert_eq!(store.read_frames().len(), before);
 }

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -9,6 +9,10 @@ use echo_registry_api::{
     RegistryProvider,
 };
 use warp_core::{
+    causal_wal::{
+        recover_in_memory_store, recover_submission_index, Lsn, RecoveredSubmissionPosture,
+        RecoveryAccessMode, WalBuildError,
+    },
     make_head_id, make_intent_kind, make_node_id, make_type_id, AuthoredObserverPlan,
     ContractMutationHandler, ContractOperationKind, ContractPackageIdentity, ContractQueryObserver,
     ContractQueryObserverResult, EngineBuilder, GraphStore, GraphView, InboxPolicy,
@@ -16,8 +20,9 @@ use warp_core::{
     ObservationCoordinate, ObservationFrame, ObservationPayload, ObservationProjection,
     ObservationReadBudget, ObservationRequest, ObserverPlanId, OpticAdmissionTicket,
     OpticArtifactHandle, PatternGraph, PlaybackMode, SchedulerKind, TickDelta, TrustedRuntimeHost,
-    WarpOp, WorldlineId, WorldlineRuntime, WorldlineState, WriterHead, WriterHeadKey,
-    OPTIC_ADMISSION_TICKET_KIND, OPTIC_ARTIFACT_HANDLE_KIND,
+    TrustedRuntimeHostError, TrustedRuntimeWal, TrustedRuntimeWalError, WarpOp, WorldlineId,
+    WorldlineRuntime, WorldlineState, WriterHead, WriterHeadKey, OPTIC_ADMISSION_TICKET_KIND,
+    OPTIC_ARTIFACT_HANDLE_KIND,
 };
 
 const SCHEMA_SHA256_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -360,4 +365,154 @@ fn reference_host_loop_keeps_tick_authority_out_of_app_surface() {
         assert_eq!(contract.op_kind, ContractOperationKind::Query);
         assert_eq!(contract.package_name, "reference-counter");
     }
+}
+
+#[test]
+fn runtime_wal_ack_submit_commits_acceptance_before_returning_handle() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_in_memory_runtime_wal()
+        .expect("runtime WAL should initialize");
+
+    let envelope = eint_envelope(worldline_id);
+    let envelope_digest = envelope.ingress_id();
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope)
+            .expect("runtime WAL ACK submit should return accepted evidence")
+    };
+
+    let runtime_wal = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured");
+    assert_eq!(runtime_wal.submission_acceptance_count(), 1);
+    assert_eq!(runtime_wal.commits().len(), 1);
+
+    let mut store = runtime_wal.cloned_store();
+    let report = recover_in_memory_store(&mut store, RecoveryAccessMode::ReadOnly)
+        .expect("committed acceptance should recover");
+    let recovered = recover_submission_index(&report)
+        .expect("recovered acceptance should index by submission id");
+    let entry = recovered
+        .get(&submission.submission_id)
+        .expect("submission should recover from committed WAL");
+    assert_eq!(entry.acceptance.submission_id, submission.submission_id);
+    assert_eq!(entry.acceptance.canonical_envelope_digest, envelope_digest);
+    assert_eq!(entry.posture, RecoveredSubmissionPosture::AcceptedPending);
+}
+
+#[test]
+fn runtime_wal_ack_duplicate_submit_does_not_append_second_acceptance() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_in_memory_runtime_wal()
+        .expect("runtime WAL should initialize");
+
+    let envelope = eint_envelope(worldline_id);
+    let first = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope.clone())
+            .expect("first submission should be accepted")
+    };
+    let duplicate = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope)
+            .expect("duplicate submission should be recognized")
+    };
+
+    assert!(!first.duplicate);
+    assert!(duplicate.duplicate);
+    assert_eq!(duplicate.submission_id, first.submission_id);
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should stay configured")
+            .submission_acceptance_count(),
+        1
+    );
+}
+
+#[test]
+fn runtime_wal_ack_duplicate_without_prior_wal_backfills_acceptance() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_in_memory_runtime_wal()
+        .expect("runtime WAL should initialize");
+
+    let envelope = eint_envelope(worldline_id);
+    let first = {
+        let mut app = host.app();
+        app.submit_intent(envelope.clone())
+            .expect("legacy non-WAL submission should be accepted")
+    };
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should stay configured")
+            .submission_acceptance_count(),
+        0
+    );
+
+    let duplicate = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope)
+            .expect("WAL ACK duplicate should backfill acceptance evidence")
+    };
+
+    assert!(duplicate.duplicate);
+    assert_eq!(duplicate.submission_id, first.submission_id);
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should stay configured")
+            .submission_acceptance_count(),
+        1
+    );
+}
+
+#[test]
+fn runtime_wal_ack_path_requires_configured_runtime_wal() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+
+    let err = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect_err("ACK path without WAL should be explicit")
+    };
+
+    assert!(matches!(
+        err,
+        TrustedRuntimeHostError::RuntimeWalUnavailable
+    ));
+    assert_eq!(host.runtime().witnessed_submission_count(), 0);
+}
+
+#[test]
+fn runtime_wal_ack_failure_rolls_back_intake_mutation() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    let overflowing_wal = TrustedRuntimeWal::new_in_memory_at_lsn_for_test(Lsn::from_raw(u64::MAX))
+        .expect("overflow fixture WAL should initialize");
+    host.replace_runtime_wal_for_test(overflowing_wal);
+
+    let err = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect_err("overflowing WAL should reject ACK")
+    };
+
+    assert!(matches!(
+        err,
+        TrustedRuntimeHostError::Wal(TrustedRuntimeWalError::Build(WalBuildError::LsnOverflow))
+    ));
+    assert_eq!(host.runtime().witnessed_submission_count(), 0);
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should stay configured")
+            .submission_acceptance_count(),
+        0
+    );
 }

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -727,7 +727,7 @@ completed slice.
 
 ### PR 13: WAL Runner, Adapter, And Release Gate Hardening
 
-- [ ] **Slice 61: Crashpoint runner contract**
+- [x] **Slice 61: Crashpoint runner contract**
     - User story: As Echo, I need a future CLI/BATS crash runner contract that
       mirrors Rust fixture semantics before it shells out to real processes.
     - Acceptance criteria: canonical crashpoint names exist for submission, tick,
@@ -735,7 +735,7 @@ completed slice.
       future until implemented.
     - Test plan: crashpoint manifest fixtures.
 
-- [ ] **Slice 62: Filesystem strict sync evidence**
+- [x] **Slice 62: Filesystem strict sync evidence**
     - User story: As Echo, strict filesystem mode must make sync boundaries
       inspectable enough for tests to prove ACK ordering.
     - Acceptance criteria: commit flush, segment creation, manifest rename, and
@@ -743,7 +743,7 @@ completed slice.
       strict-mode claims.
     - Test plan: filesystem sync evidence fixtures.
 
-- [ ] **Slice 63: Object-store manifest negative matrix**
+- [x] **Slice 63: Object-store manifest negative matrix**
     - User story: As Echo, strict object-store mode must reject adapters that
       cannot prove conditional manifest semantics.
     - Acceptance criteria: every missing capability has a distinct validation
@@ -751,7 +751,7 @@ completed slice.
       compare-and-swap shaped.
     - Test plan: object-store capability negative fixtures.
 
-- [ ] **Slice 64: Security and redaction posture matrix**
+- [x] **Slice 64: Security and redaction posture matrix**
     - User story: As Echo, recovery and inspection must distinguish missing
       material from policy-hidden or encrypted material.
     - Acceptance criteria: present, redacted, encrypted-key-unavailable, missing,
@@ -759,7 +759,7 @@ completed slice.
       success.
     - Test plan: security/redaction posture fixtures.
 
-- [ ] **Slice 65: WAL hardening release gate**
+- [x] **Slice 65: WAL hardening release gate**
     - User story: As Echo, I need one gate that tells us whether the WAL is
       trustworthy enough for the next real-app persistence push.
     - Acceptance criteria: readiness check aggregates app-noun guard, shadow

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -634,7 +634,7 @@ completed slice.
       indexes; uncommitted tick attempts do not become history.
     - Test plan: tick commit/publish crash fixtures.
 
-- [ ] **Slice 50: Segment corruption matrix**
+- [x] **Slice 50: Segment corruption matrix**
     - User story: As recovery, segment corruption must produce deterministic
       posture instead of panic, silent skip, or partial history.
     - Acceptance criteria: torn header, torn payload, torn digest, bad magic,

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -644,7 +644,7 @@ completed slice.
 
 ### PR 11: WAL Semantic And Checkpoint Hardening
 
-- [ ] **Slice 51: Writer epoch fencing matrix**
+- [x] **Slice 51: Writer epoch fencing matrix**
     - User story: As Echo, recovery must detect split-writer evidence instead of
       merging conflicting histories.
     - Acceptance criteria: epoch metadata includes fencing evidence; overlapping
@@ -652,7 +652,7 @@ completed slice.
       deterministically.
     - Test plan: writer epoch fencing fixtures.
 
-- [ ] **Slice 52: Transaction contiguity and commit semantics**
+- [x] **Slice 52: Transaction contiguity and commit semantics**
     - User story: As Echo, only complete contiguous committed WAL transactions
       become history.
     - Acceptance criteria: frames are contiguous; commit binds LSN range, count,
@@ -660,7 +660,7 @@ completed slice.
       committed history.
     - Test plan: transaction contiguity and commit mismatch tests.
 
-- [ ] **Slice 53: Semantic validator negative cases**
+- [x] **Slice 53: Semantic validator negative cases**
     - User story: As Echo, byte-valid WAL transactions must still be rejected if
       they violate runtime law.
     - Acceptance criteria: digest-valid semantic violations are rejected for
@@ -668,7 +668,7 @@ completed slice.
       mismatches.
     - Test plan: semantic validator negative fixtures.
 
-- [ ] **Slice 54: Checkpoint crash matrix**
+- [x] **Slice 54: Checkpoint crash matrix**
     - User story: As recovery, checkpoints must accelerate replay without
       creating or erasing history.
     - Acceptance criteria: crash-before-rename, rename-before-publication,
@@ -676,7 +676,7 @@ completed slice.
       cases are covered.
     - Test plan: checkpoint crash matrix fixtures.
 
-- [ ] **Slice 55: Retained material before reference matrix**
+- [x] **Slice 55: Retained material before reference matrix**
     - User story: As Echo, committed references must not point at unavailable
       retained material without typed obstruction.
     - Acceptance criteria: missing payload, receipt, state-delta, reading,

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -514,14 +514,14 @@ satisfies its acceptance criteria.
 
 ### PR 8: Filesystem And Object Stores
 
-- [ ] **Slice 36: Filesystem WAL adapter**
+- [x] **Slice 36: Filesystem WAL adapter**
     - User story: As Echo, strict filesystem durability must use real fsync
       boundaries.
     - Acceptance criteria: segment creation, append, file fsync, rename, and
       directory fsync are explicit.
     - Test plan: filesystem crash fixtures for torn frame and missing segment.
 
-- [ ] **Slice 37: Object-store manifest adapter**
+- [x] **Slice 37: Object-store manifest adapter**
     - User story: As Echo, strict object-store durability must not pretend fsync
       exists.
     - Acceptance criteria: content-addressed object writes, version/ETag
@@ -529,19 +529,19 @@ satisfies its acceptance criteria.
       required.
     - Test plan: `strict_object_store_requires_conditional_manifest_commit`.
 
-- [ ] **Slice 38: Segment repair and truncation protocol**
+- [x] **Slice 38: Segment repair and truncation protocol**
     - User story: As recovery, tail repair must be explicit and mode-sensitive.
     - Acceptance criteria: writable stores can truncate incomplete tails; read-only
       stores can only report would-truncate.
     - Test plan: segment-gap, duplicate-segment, and torn-tail matrix.
 
-- [ ] **Slice 39: Crash matrix harness**
+- [x] **Slice 39: Crash matrix harness**
     - User story: As Echo, lifecycle ambiguity must be testable at every boundary.
     - Acceptance criteria: harness injects crash points around submit, tick,
       checkpoint, material, and index publication.
     - Test plan: generated crash matrix suite.
 
-- [ ] **Slice 40: WAL shadow replay in CI**
+- [x] **Slice 40: WAL shadow replay in CI**
     - User story: As a maintainer, every mutating integration path should prove
       live state equals replayed state.
     - Acceptance criteria: selected tests run live scenario, replay WAL into fresh
@@ -550,21 +550,21 @@ satisfies its acceptance criteria.
 
 ### PR 9: Outbox, Tooling, And Jedit Gate
 
-- [ ] **Slice 41: Side-effect outbox core**
+- [x] **Slice 41: Side-effect outbox core**
     - User story: As Echo, external effects must be authorized by committed
       history before escaping.
     - Acceptance criteria: durable outbox records effect id, expected artifact,
       materialization intent, and idempotency token.
     - Test plan: `external_effect_requires_committed_outbox_authorization`.
 
-- [ ] **Slice 42: Materialization observation replay detection**
+- [x] **Slice 42: Materialization observation replay detection**
     - User story: As recovery, existing external artifacts should be detected
       before retry.
     - Acceptance criteria: recovery verifies path, digest, and metadata before
       retrying or recording observation.
     - Test plan: `materialization_replay_detects_existing_artifact_before_retry`.
 
-- [ ] **Slice 43: Causal commit evidence projection**
+- [x] **Slice 43: Causal commit evidence projection**
     - User story: As [warp-ttd], I need Echo-projected commit evidence, not raw
       WAL access.
     - Acceptance criteria: Echo exposes `CausalCommitEvidence` and recovery
@@ -573,7 +573,7 @@ satisfies its acceptance criteria.
     - Test plan: accepted pending, decided applied, rejected, obstructed, faulted,
       and durability-unknown projection fixtures.
 
-- [ ] **Slice 44: `jedit` WAL recovery gate**
+- [x] **Slice 44: `jedit` WAL recovery gate**
     - User story: As [jedit], after crash/restart I need submitted edits to
       recover as not accepted, accepted pending, applied, rejected, or obstructed.
     - Acceptance criteria: stable submission id, recovered posture, export from
@@ -581,7 +581,7 @@ satisfies its acceptance criteria.
     - Test plan: sibling `jedit` crash/restart fixture and retry-after-ACK-loss
       fixture.
 
-- [ ] **Slice 45: WAL release readiness audit**
+- [x] **Slice 45: WAL release readiness audit**
     - User story: As an operator, I need a final audit before trusting the WAL as
       the jedit durability foundation.
     - Acceptance criteria: all WAL release gates pass, docs match code, app-noun

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -373,35 +373,35 @@ satisfies its acceptance criteria.
 
 ### PR 4: Submission Durability
 
-- [ ] **Slice 16: Submission acceptance transaction**
+- [x] **Slice 16: Submission acceptance transaction**
     - User story: As an app, if Echo returns accepted evidence, I need that
       acceptance to survive restart.
     - Acceptance criteria: `submit_intent` writes `SubmissionAcceptedRecorded`
       before returning accepted evidence.
     - Test plan: `accepted_submission_is_not_returned_before_wal_commit`.
 
-- [ ] **Slice 17: Accepted pending recovery**
+- [x] **Slice 17: Accepted pending recovery**
     - User story: As Echo, accepted-but-not-ticked submissions must recover as
       pending.
     - Acceptance criteria: pending inbox rebuilds from committed acceptance
       transactions without transport re-arrival.
     - Test plan: `crash_after_submission_commit_recovers_pending_submission`.
 
-- [ ] **Slice 18: Crash-before-ACK retry posture**
+- [x] **Slice 18: Crash-before-ACK retry posture**
     - User story: As a client, retry after crash-before-ACK must be deterministic.
     - Acceptance criteria: same submission id plus same envelope returns stable
       duplicate posture after recovery.
     - Test plan:
       `crash_after_submission_commit_before_ack_retry_returns_duplicate_posture`.
 
-- [ ] **Slice 19: Submission idempotency rules**
+- [x] **Slice 19: Submission idempotency rules**
     - User story: As Echo, I must not collapse intentional repeated intents.
     - Acceptance criteria: same id plus different envelope is protocol violation;
       new id plus same envelope is new unless explicit dedupe policy says
       otherwise.
     - Test plan: `same_payload_new_submission_id_is_not_duplicate_without_policy`.
 
-- [ ] **Slice 20: Submission recovery certificate posture**
+- [x] **Slice 20: Submission recovery certificate posture**
     - User story: As a host, I need restart output that explains recovered
       submission counts and posture.
     - Acceptance criteria: recovery certificate reports pending, decided,
@@ -410,30 +410,30 @@ satisfies its acceptance criteria.
 
 ### PR 5: Tick Transactions
 
-- [ ] **Slice 21: Tick transaction staging**
+- [x] **Slice 21: Tick transaction staging**
     - User story: As Echo, scheduler outputs must remain staged until WAL commit.
     - Acceptance criteria: tick receipts, state deltas, correlations, and retained
       refs are staged before publish.
     - Test plan: `crash_before_tick_commit_commits_no_receipt`.
 
-- [ ] **Slice 22: Tick commit publish boundary**
+- [x] **Slice 22: Tick commit publish boundary**
     - User story: As an observer, visible receipts must imply recoverable receipts.
     - Acceptance criteria: indexes publish only after tick transaction flush.
     - Test plan: `crash_after_tick_commit_recovers_receipt_and_state_delta`.
 
-- [ ] **Slice 23: Receipt correlation rebuild**
+- [x] **Slice 23: Receipt correlation rebuild**
     - User story: As a debugger/app, receipt correlation must survive restart.
     - Acceptance criteria: receipt-by-submission, receipt-by-ticket, and
       ticket-by-submission indexes rebuild from committed WAL transactions.
     - Test plan: `committed_receipt_correlation_rebuilds_after_restart`.
 
-- [ ] **Slice 24: Tick rollback compatibility**
+- [x] **Slice 24: Tick rollback compatibility**
     - User story: As Echo, WAL must not weaken failure-atomic tick rollback.
     - Acceptance criteria: failed attempted ticks commit no partial tick
       transaction; scoped fault quarantine remains separate runtime posture.
     - Test plan: existing rollback/quarantine tests plus WAL no-partial fixtures.
 
-- [ ] **Slice 25: Lawful rejection persistence**
+- [x] **Slice 25: Lawful rejection persistence**
     - User story: As Echo, lawful conflict/rejection is history, not an internal
       fault.
     - Acceptance criteria: rejected candidates commit receipt evidence and do not
@@ -442,32 +442,32 @@ satisfies its acceptance criteria.
 
 ### PR 6: Retention And Readings
 
-- [ ] **Slice 26: Retained material ordering**
+- [x] **Slice 26: Retained material ordering**
     - User story: As recovery, committed material refs must point at durable
       material or typed obstruction.
     - Acceptance criteria: material is durable before committed WAL reference.
     - Test plan: `missing_retained_material_returns_typed_obstruction`.
 
-- [ ] **Slice 27: Reading ref recovery**
+- [x] **Slice 27: Reading ref recovery**
     - User story: As an observer, retained reading refs must survive restart.
     - Acceptance criteria: reading refs rebuild by semantic coordinate and
       retained material digest.
     - Test plan: retained QueryView reading lookup after recovery.
 
-- [ ] **Slice 28: Semantic identity versus CAS identity**
+- [x] **Slice 28: Semantic identity versus CAS identity**
     - User story: As Echo, byte identity must not masquerade as query identity.
     - Acceptance criteria: semantic coordinate and CAS digest remain distinct in
       WAL records and rebuilt indexes.
     - Test plan: same payload with different query coordinate remains distinct.
 
-- [ ] **Slice 29: Security and redaction posture**
+- [x] **Slice 29: Security and redaction posture**
     - User story: As an operator, I need to distinguish missing evidence from
       policy-hidden evidence.
     - Acceptance criteria: present, redacted, encrypted-key-unavailable, missing,
       corrupt, and obstructed postures exist.
     - Test plan: recovery/inspection fixtures for each posture.
 
-- [ ] **Slice 30: Retention obstruction scope matrix**
+- [x] **Slice 30: Retention obstruction scope matrix**
     - User story: As recovery, missing material should fault only at the correct
       scope.
     - Acceptance criteria: payload, receipt, state-delta, runtime-control, and
@@ -476,14 +476,14 @@ satisfies its acceptance criteria.
 
 ### PR 7: Checkpoints And Inspector
 
-- [ ] **Slice 31: Checkpoint writer**
+- [x] **Slice 31: Checkpoint writer**
     - User story: As Echo, checkpoints should accelerate replay without creating
       history.
     - Acceptance criteria: temp write, fsync, atomic rename, directory fsync, and
       checkpoint binding to WAL chain are implemented.
     - Test plan: checkpoint round-trip and corrupt checkpoint fallback tests.
 
-- [ ] **Slice 32: Checkpoint validation without publication record**
+- [x] **Slice 32: Checkpoint validation without publication record**
     - User story: As recovery, valid checkpoint files should remain usable after
       crash before publication evidence.
     - Acceptance criteria: validated checkpoint can be used without
@@ -492,7 +492,7 @@ satisfies its acceptance criteria.
     - Test plan:
       `valid_checkpoint_without_checkpoint_published_record_can_be_used_after_validation`.
 
-- [ ] **Slice 33: Checkpoint publication obstruction**
+- [x] **Slice 33: Checkpoint publication obstruction**
     - User story: As recovery, publication evidence must not lie about missing or
       invalid checkpoint material.
     - Acceptance criteria: publication without checkpoint blocks or obstructs by
@@ -500,13 +500,13 @@ satisfies its acceptance criteria.
     - Test plan:
       `checkpoint_published_without_checkpoint_blocks_or_obstructs_according_to_scope`.
 
-- [ ] **Slice 34: Recovery certificate**
+- [x] **Slice 34: Recovery certificate**
     - User story: As jedit/operator/debugger, I need a precise restart report.
     - Acceptance criteria: certificate reports checkpoint, LSN range, replayed
       transactions, tail posture, obstruction count, and final roots.
     - Test plan: clean, tail-truncated, and obstructed recovery certificates.
 
-- [ ] **Slice 35: Read-only WAL inspector**
+- [x] **Slice 35: Read-only WAL inspector**
     - User story: As an operator, I need inspection without mutating storage.
     - Acceptance criteria: `echo wal doctor --json`, `inspect`, and read-only
       recovery report posture without truncation.

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -589,6 +589,184 @@ satisfies its acceptance criteria.
     - Test plan: full WAL slice suite, `cargo xtask test-slice`, app-noun guard,
       DIND/replay where available, and cross-repo jedit witness.
 
+### No-Count WAL Hardening Plan
+
+The WAL hardening matrix is tracked in
+[`docs/design/causal-wal-hardening-matrix.md`](design/causal-wal-hardening-matrix.md).
+This planning slice does not consume one of the twenty hardening slices. Agents
+must keep the checklist below and the plan document aligned before committing a
+completed slice.
+
+### PR 10: WAL Fixture And Corpus Hardening
+
+- [ ] **Slice 46: WAL hardening fixture surface**
+    - User story: As an Echo maintainer, I need deterministic fixtures that can
+      build valid WAL histories and damage them at exact byte/transaction
+      boundaries.
+    - Acceptance criteria: fixtures create filesystem WAL roots, append committed
+      transactions, append uncommitted tails, truncate/corrupt segments, recover
+      read-only/writable reports, and name every scenario in assertion failures.
+    - Test plan: fixture recovery, uncommitted-tail, torn-tail, and read-only
+      non-mutation witnesses.
+
+- [ ] **Slice 47: WAL recovery golden corpus**
+    - User story: As Echo, I need a fixed corpus of minimal WAL shapes that
+      proves recovery posture across clean, partial, and corrupt histories.
+    - Acceptance criteria: clean, empty, tail, torn, corrupt digest, bad magic,
+      and unknown-kind corpus cases assert transaction count, LSNs, posture, and
+      blocking/inspectable status.
+    - Test plan: `wal_recovery_golden_*` fixtures listed in the hardening matrix.
+
+- [ ] **Slice 48: Submission ACK crash matrix**
+    - User story: As an app retrying after a crash, I need Echo to distinguish
+      never accepted from accepted-before-ACK.
+    - Acceptance criteria: recovery never invents accepted evidence before
+      commit; retry after commit-before-ACK is stable; conflicting retry is a
+      protocol violation; same envelope with new id is not deduped without
+      policy.
+    - Test plan: submission intake crash matrix fixtures.
+
+- [ ] **Slice 49: Tick commit and publish crash matrix**
+    - User story: As Echo, visible tick outcomes must imply committed
+      recoverable history.
+    - Acceptance criteria: tick receipt, runtime delta, receipt correlation, and
+      index publication boundaries are tested; commit-before-publish rebuilds
+      indexes; uncommitted tick attempts do not become history.
+    - Test plan: tick commit/publish crash fixtures.
+
+- [ ] **Slice 50: Segment corruption matrix**
+    - User story: As recovery, segment corruption must produce deterministic
+      posture instead of panic, silent skip, or partial history.
+    - Acceptance criteria: torn header, torn payload, torn digest, bad magic,
+      corrupt digest, unknown disk kind, segment gap, and duplicate segment cases
+      are covered; read-only recovery never mutates files.
+    - Test plan: segment corruption matrix fixtures.
+
+### PR 11: WAL Semantic And Checkpoint Hardening
+
+- [ ] **Slice 51: Writer epoch fencing matrix**
+    - User story: As Echo, recovery must detect split-writer evidence instead of
+      merging conflicting histories.
+    - Acceptance criteria: epoch metadata includes fencing evidence; overlapping
+      epochs, unknown previous epochs, chain gaps, and fencing mismatches fault
+      deterministically.
+    - Test plan: writer epoch fencing fixtures.
+
+- [ ] **Slice 52: Transaction contiguity and commit semantics**
+    - User story: As Echo, only complete contiguous committed WAL transactions
+      become history.
+    - Acceptance criteria: frames are contiguous; commit binds LSN range, count,
+      and records root; interleaving is rejected; record names never imply
+      committed history.
+    - Test plan: transaction contiguity and commit mismatch tests.
+
+- [ ] **Slice 53: Semantic validator negative cases**
+    - User story: As Echo, byte-valid WAL transactions must still be rejected if
+      they violate runtime law.
+    - Acceptance criteria: digest-valid semantic violations are rejected for
+      authority, transaction kind, runtime-control, and frontier-transition
+      mismatches.
+    - Test plan: semantic validator negative fixtures.
+
+- [ ] **Slice 54: Checkpoint crash matrix**
+    - User story: As recovery, checkpoints must accelerate replay without
+      creating or erasing history.
+    - Acceptance criteria: crash-before-rename, rename-before-publication,
+      missing material, corrupt latest checkpoint, and checkpoint-ahead-of-WAL
+      cases are covered.
+    - Test plan: checkpoint crash matrix fixtures.
+
+- [ ] **Slice 55: Retained material before reference matrix**
+    - User story: As Echo, committed references must not point at unavailable
+      retained material without typed obstruction.
+    - Acceptance criteria: missing payload, receipt, state-delta, reading,
+      checkpoint, and diagnostic material map to documented scopes.
+    - Test plan: retained material obstruction fixtures.
+
+### PR 12: WAL Outbox, Projection, And Inspector Hardening
+
+- [ ] **Slice 56: Side-effect outbox crash matrix**
+    - User story: As Echo, external effects must never escape before committed
+      authorization and must be idempotent after crash.
+    - Acceptance criteria: effect authorization, existing artifact detection,
+      mismatch obstruction, observation commit, and idempotency token behavior
+      are covered.
+    - Test plan: side-effect outbox crash fixtures.
+
+- [ ] **Slice 57: Recovery reducer determinism**
+    - User story: As Echo, replay must apply committed facts without scheduler
+      callbacks, wall clock, random, network, or app code.
+    - Acceptance criteria: pure replay is deterministic; transaction ordering is
+      commit-chain order; frontier mismatch rejects; no app/scheduler callback is
+      needed.
+    - Test plan: pure replay determinism fixtures.
+
+- [ ] **Slice 58: Shadow replay harness**
+    - User story: As a maintainer, every mutating WAL path should prove live
+      state equals recovered state.
+    - Acceptance criteria: helper runs live scenario, recovers from WAL, compares
+      roots/indexes/receipts/readings, and reports first mismatch.
+    - Test plan: submission, tick, retention, outbox, and mismatch shadow replay
+      fixtures.
+
+- [ ] **Slice 59: Causal commit evidence projection matrix**
+    - User story: As [warp-ttd] or an operator, I need commit evidence posture
+      without raw WAL ownership.
+    - Acceptance criteria: accepted pending, applied, rejected, obstructed, and
+      absent evidence postures project transaction id, LSN, epoch, digest, and
+      durability mode without raw segment authority.
+    - Test plan: causal commit evidence projection fixtures.
+
+- [ ] **Slice 60: WAL doctor and inspector contract tests**
+    - User story: As an operator, I need inspection commands/read models to
+      report truth without mutating storage.
+    - Acceptance criteria: doctor reports clean, would-truncate, obstructed,
+      corrupt, and missing-material postures; report shape is stable; files are
+      unchanged in read-only mode.
+    - Test plan: WAL doctor and recovery certificate contract fixtures.
+
+### PR 13: WAL Runner, Adapter, And Release Gate Hardening
+
+- [ ] **Slice 61: Crashpoint runner contract**
+    - User story: As Echo, I need a future CLI/BATS crash runner contract that
+      mirrors Rust fixture semantics before it shells out to real processes.
+    - Acceptance criteria: canonical crashpoint names exist for submission, tick,
+      checkpoint, material, and index boundaries; process-kill cuts remain marked
+      future until implemented.
+    - Test plan: crashpoint manifest fixtures.
+
+- [ ] **Slice 62: Filesystem strict sync evidence**
+    - User story: As Echo, strict filesystem mode must make sync boundaries
+      inspectable enough for tests to prove ACK ordering.
+    - Acceptance criteria: commit flush, segment creation, manifest rename, and
+      checkpoint rename sync evidence are covered; missing sync evidence blocks
+      strict-mode claims.
+    - Test plan: filesystem sync evidence fixtures.
+
+- [ ] **Slice 63: Object-store manifest negative matrix**
+    - User story: As Echo, strict object-store mode must reject adapters that
+      cannot prove conditional manifest semantics.
+    - Acceptance criteria: every missing capability has a distinct validation
+      error; read-after-write uncertainty blocks strict mode; manifest commit is
+      compare-and-swap shaped.
+    - Test plan: object-store capability negative fixtures.
+
+- [ ] **Slice 64: Security and redaction posture matrix**
+    - User story: As Echo, recovery and inspection must distinguish missing
+      material from policy-hidden or encrypted material.
+    - Acceptance criteria: present, redacted, encrypted-key-unavailable, missing,
+      corrupt, and obstructed postures remain distinct and never become silent
+      success.
+    - Test plan: security/redaction posture fixtures.
+
+- [ ] **Slice 65: WAL hardening release gate**
+    - User story: As Echo, I need one gate that tells us whether the WAL is
+      trustworthy enough for the next real-app persistence push.
+    - Acceptance criteria: readiness check aggregates app-noun guard, shadow
+      replay, crash matrix, doctor, outbox, semantic validator, filesystem,
+      object-store, and projection coverage.
+    - Test plan: WAL hardening gate fixtures plus app-noun and doc checks.
+
 ## Recently Completed Slice Batch
 
 1. **Contract-Aware Receipts And Readings**

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -29,7 +29,9 @@ The filesystem lane for release-bar backlog cards is
 
 The production-core app-noun guard is `scripts/check-no-app-nouns-in-core.sh`.
 It checks that hardcoded jedit/Stack Witness fixture shortcuts stay out of
-Echo crate source.
+Echo crate source. The guard is intentionally production-source-scoped: tests
+and docs may still carry app-shaped fixtures as external-consumer examples,
+but production Echo code must remain generic.
 
 ## Current Bearing
 

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -27,6 +27,10 @@ The next ten jedit release-gate slices are planned in
 The filesystem lane for release-bar backlog cards is
 `docs/method/backlog/v0.1.0/`.
 
+The production-core app-noun guard is `scripts/check-no-app-nouns-in-core.sh`.
+It checks that hardcoded jedit/Stack Witness fixture shortcuts stay out of
+Echo crate source.
+
 ## Current Bearing
 
 Echo has a local witnessed intent pipeline into deterministic execution:

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -3,7 +3,7 @@
 
 # BEARING
 
-Last updated: 2026-05-23.
+Last updated: 2026-05-24.
 
 This signpost summarizes current direction. It does not create commitments or
 replace backlog items, design docs, retros, or CLI status. If it disagrees with
@@ -20,6 +20,9 @@ The current external release gate is maintained in
 
 Trusted runtime-control history is defined in
 `docs/design/trusted-runtime-control-history.md`.
+
+The causal WAL doctrine and recovery design is defined in
+`docs/design/causal-wal-end-to-end.md`.
 
 The next ten jedit release-gate slices are planned in
 `docs/design/v0.1.0-jedit-next-ten-slices.md`.
@@ -46,6 +49,11 @@ the `v0.1.0` release gate. Echo is not ready to release until jedit can submit
 an application-owned contract intent, let a trusted Echo host authorize
 scheduler opportunities, observe the outcome, query a bounded reading, retain
 evidence, and replay the result without moving application nouns into Echo core.
+
+The immediate durability hill is Echo's causal WAL: Echo may only claim what
+its WAL can recover. The WAL must make accepted submissions, tick outcomes,
+runtime posture, retained-material references, and side-effect authorization
+crash-recoverable without giving applications tick or WAL authority.
 
 ## What Is Already True
 
@@ -228,6 +236,358 @@ AdmissionTicket + witnessed submission -> ticketed runtime ingress
 - Ephemeral Scratch, Author-Only Speculative Lane, and Shared/Admitted Lane are
   paper-level privacy/runtime policy concepts. The local contract-host pipeline
   does not yet implement that full social lane model.
+
+## Causal WAL Forty-Five Slice Plan
+
+Track progress here. Check off slices just before committing the slice that
+satisfies its acceptance criteria.
+
+### PR 1: Doctrine And Grammar
+
+- [x] **Slice 1: WAL doctrine hardening**
+    - User story: As an Echo maintainer, I need the WAL doctrine to forbid
+      semantic confusion before code exists.
+    - Acceptance criteria: records are recorded, transactions are committed,
+      submission acceptance stays distinct from runtime admission, read-only
+      recovery cannot truncate, and explicit durable outboxes are allowed.
+    - Test plan: `git diff --check`; stale-term grep for forbidden record names
+      and intake/admission blur.
+
+- [x] **Slice 2: Record grammar and naming spec**
+    - User story: As an implementer, I need WAL record names that do not imply
+      history before commit.
+    - Acceptance criteria: ordinary record names use `*Recorded` or equivalent;
+      no causal record kind uses `*Committed`; `WalTransactionCommit` is the
+      only commit boundary.
+    - Test plan: unit/schema-linter tests reject misleading record names.
+
+- [x] **Slice 3: Transaction shape and affected frontiers**
+    - User story: As a recovery implementer, I need commit markers to bind the
+      exact frontiers affected by each transaction.
+    - Acceptance criteria: first-cut transactions are contiguous, non-interleaved,
+      and bind `affected_frontiers` or `affected_frontiers_root`.
+    - Test plan: transaction fixtures prove intake, tick, posture, and checkpoint
+      transactions bind distinct frontier kinds.
+
+- [x] **Slice 4: `WalStorePort` contract**
+    - User story: As a storage adapter author, I need a port contract that makes
+      strict durability impossible to fake.
+    - Acceptance criteria: port shape covers writer epoch acquisition, append,
+      flush commit, segment reads, sealing, truncation, manifest publication, and
+      epoch close; object-store conditional manifest rules are named.
+    - Test plan: compile-contract tests for the trait once implemented; docs grep
+      for all required operations.
+
+- [x] **Slice 5: Release-gate witness list**
+    - User story: As a reviewer, I need named crash and recovery witnesses before
+      implementation starts.
+    - Acceptance criteria: BEARING and WAL design name crash-before-ACK,
+      read-only recovery, checkpoint validation, materialization replay,
+      overlapping writer epoch, strict object-store, and record-name witnesses.
+    - Test plan: doc assertions or grep checks for every witness name.
+
+### PR 2: WAL Core In Memory
+
+- [x] **Slice 6: Core WAL identifiers and record kinds**
+    - User story: As a runtime developer, I need typed WAL identifiers and record
+      kinds before writing frames.
+    - Acceptance criteria: `Lsn`, `WalTransactionId`, `WriterEpochId`,
+      `WalRecordKind`, and durable mode/posture types exist without app nouns.
+    - Test plan: unit tests prove record-kind vocabulary and app-noun guard.
+
+- [x] **Slice 7: Frame metadata and digest domains**
+    - User story: As a recovery implementer, I need frames that separate torn
+      writes from semantic commitment.
+    - Acceptance criteria: frame headers bind LSN, transaction id, local index,
+      record kind, payload digest, previous frame digest, codec/schema identity,
+      and redaction posture.
+    - Test plan: frame metadata round-trip and digest-domain tests.
+
+- [x] **Slice 8: Record payload and transaction builder**
+    - User story: As Echo, I need a transaction builder that records payloads
+      before committing them.
+    - Acceptance criteria: contiguous transaction builder appends records,
+      computes payload roots, and refuses append-after-commit.
+    - Test plan: transaction builder tests for order, record count, and closed
+      transaction behavior.
+
+- [x] **Slice 9: Commit marker validation**
+    - User story: As recovery, I need commit markers that can be checked before
+      replay.
+    - Acceptance criteria: commit marker validates first/last LSN, record count,
+      records root, affected frontier root, previous commit digest, and durability
+      mode.
+    - Test plan: fixtures fail on mismatched LSN range, count, roots, and chain.
+
+- [x] **Slice 10: In-memory `WalStorePort`**
+    - User story: As a test writer, I need deterministic WAL behavior without
+      filesystem complexity.
+    - Acceptance criteria: in-memory store appends frames, flushes commits,
+      exposes segment streams, simulates torn tails, and never claims filesystem
+      strictness.
+    - Test plan: port tests for append/read/flush and synthetic crash tails.
+
+### PR 3: Recovery Foundation
+
+- [x] **Slice 11: Writer epoch fencing model**
+    - User story: As Echo, I need stored evidence proving which writer had append
+      authority.
+    - Acceptance criteria: writer epochs bind fencing token, process identity,
+      host identity, previous epoch id, previous final commit digest, and lease or
+      lock evidence.
+    - Test plan: overlapping epoch recovery fixture blocks recovery.
+
+- [x] **Slice 12: Recovery scanner and tail posture**
+    - User story: As Echo, I need recovery to group committed transactions and
+      classify incomplete tails by mode.
+    - Acceptance criteria: writable recovery may truncate validated incomplete
+      tails; read-only recovery reports would-truncate without mutating storage.
+    - Test plan: `read_only_recovery_reports_uncommitted_tail_without_truncating`
+      and torn-tail tests.
+
+- [x] **Slice 13: Pure replay reducer skeleton**
+    - User story: As Echo, I need replay to apply facts, not rerun scheduler or
+      application callbacks.
+    - Acceptance criteria: `apply_committed_transaction(before, tx) -> after`
+      exists as a pure reducer boundary with no wall clock, random, network,
+      scheduler, app callback, or external I/O dependency.
+    - Test plan: deterministic replay tests compare repeated reduction over the
+      same committed transactions.
+
+- [x] **Slice 14: Semantic transaction validators**
+    - User story: As recovery, I need semantic checks after bytes and digests pass.
+    - Acceptance criteria: validators check record kind authority, affected
+      frontiers, retained-material refs, submission identity, and tick authority
+      posture before replay.
+    - Test plan: invalid causal transaction fixtures block recovery even with
+      valid frame checksums.
+
+- [x] **Slice 15: WAL schema and authority linter**
+    - User story: As a reviewer, I need mechanical protection against app nouns
+      and authority leaks.
+    - Acceptance criteria: linter rejects app/product nouns and authority-leak
+      record names such as app tick, client runtime control, application receipt,
+      or document state delta.
+    - Test plan: passing generic fixture and failing forbidden-noun/authority
+      fixtures.
+
+### PR 4: Submission Durability
+
+- [ ] **Slice 16: Submission acceptance transaction**
+    - User story: As an app, if Echo returns accepted evidence, I need that
+      acceptance to survive restart.
+    - Acceptance criteria: `submit_intent` writes `SubmissionAcceptedRecorded`
+      before returning accepted evidence.
+    - Test plan: `accepted_submission_is_not_returned_before_wal_commit`.
+
+- [ ] **Slice 17: Accepted pending recovery**
+    - User story: As Echo, accepted-but-not-ticked submissions must recover as
+      pending.
+    - Acceptance criteria: pending inbox rebuilds from committed acceptance
+      transactions without transport re-arrival.
+    - Test plan: `crash_after_submission_commit_recovers_pending_submission`.
+
+- [ ] **Slice 18: Crash-before-ACK retry posture**
+    - User story: As a client, retry after crash-before-ACK must be deterministic.
+    - Acceptance criteria: same submission id plus same envelope returns stable
+      duplicate posture after recovery.
+    - Test plan:
+      `crash_after_submission_commit_before_ack_retry_returns_duplicate_posture`.
+
+- [ ] **Slice 19: Submission idempotency rules**
+    - User story: As Echo, I must not collapse intentional repeated intents.
+    - Acceptance criteria: same id plus different envelope is protocol violation;
+      new id plus same envelope is new unless explicit dedupe policy says
+      otherwise.
+    - Test plan: `same_payload_new_submission_id_is_not_duplicate_without_policy`.
+
+- [ ] **Slice 20: Submission recovery certificate posture**
+    - User story: As a host, I need restart output that explains recovered
+      submission counts and posture.
+    - Acceptance criteria: recovery certificate reports pending, decided,
+      rejected, obstructed, and faulted submission counts.
+    - Test plan: recovery certificate fixtures for clean and obstructed intake.
+
+### PR 5: Tick Transactions
+
+- [ ] **Slice 21: Tick transaction staging**
+    - User story: As Echo, scheduler outputs must remain staged until WAL commit.
+    - Acceptance criteria: tick receipts, state deltas, correlations, and retained
+      refs are staged before publish.
+    - Test plan: `crash_before_tick_commit_commits_no_receipt`.
+
+- [ ] **Slice 22: Tick commit publish boundary**
+    - User story: As an observer, visible receipts must imply recoverable receipts.
+    - Acceptance criteria: indexes publish only after tick transaction flush.
+    - Test plan: `crash_after_tick_commit_recovers_receipt_and_state_delta`.
+
+- [ ] **Slice 23: Receipt correlation rebuild**
+    - User story: As a debugger/app, receipt correlation must survive restart.
+    - Acceptance criteria: receipt-by-submission, receipt-by-ticket, and
+      ticket-by-submission indexes rebuild from committed WAL transactions.
+    - Test plan: `committed_receipt_correlation_rebuilds_after_restart`.
+
+- [ ] **Slice 24: Tick rollback compatibility**
+    - User story: As Echo, WAL must not weaken failure-atomic tick rollback.
+    - Acceptance criteria: failed attempted ticks commit no partial tick
+      transaction; scoped fault quarantine remains separate runtime posture.
+    - Test plan: existing rollback/quarantine tests plus WAL no-partial fixtures.
+
+- [ ] **Slice 25: Lawful rejection persistence**
+    - User story: As Echo, lawful conflict/rejection is history, not an internal
+      fault.
+    - Acceptance criteria: rejected candidates commit receipt evidence and do not
+      quarantine heads.
+    - Test plan: conflict receipt recovery fixture and `lawful_rejection_does_not_fault_head`.
+
+### PR 6: Retention And Readings
+
+- [ ] **Slice 26: Retained material ordering**
+    - User story: As recovery, committed material refs must point at durable
+      material or typed obstruction.
+    - Acceptance criteria: material is durable before committed WAL reference.
+    - Test plan: `missing_retained_material_returns_typed_obstruction`.
+
+- [ ] **Slice 27: Reading ref recovery**
+    - User story: As an observer, retained reading refs must survive restart.
+    - Acceptance criteria: reading refs rebuild by semantic coordinate and
+      retained material digest.
+    - Test plan: retained QueryView reading lookup after recovery.
+
+- [ ] **Slice 28: Semantic identity versus CAS identity**
+    - User story: As Echo, byte identity must not masquerade as query identity.
+    - Acceptance criteria: semantic coordinate and CAS digest remain distinct in
+      WAL records and rebuilt indexes.
+    - Test plan: same payload with different query coordinate remains distinct.
+
+- [ ] **Slice 29: Security and redaction posture**
+    - User story: As an operator, I need to distinguish missing evidence from
+      policy-hidden evidence.
+    - Acceptance criteria: present, redacted, encrypted-key-unavailable, missing,
+      corrupt, and obstructed postures exist.
+    - Test plan: recovery/inspection fixtures for each posture.
+
+- [ ] **Slice 30: Retention obstruction scope matrix**
+    - User story: As recovery, missing material should fault only at the correct
+      scope.
+    - Acceptance criteria: payload, receipt, state-delta, runtime-control, and
+      diagnostic material failures map to documented obstruction/fault scope.
+    - Test plan: scoped missing-material fixture suite.
+
+### PR 7: Checkpoints And Inspector
+
+- [ ] **Slice 31: Checkpoint writer**
+    - User story: As Echo, checkpoints should accelerate replay without creating
+      history.
+    - Acceptance criteria: temp write, fsync, atomic rename, directory fsync, and
+      checkpoint binding to WAL chain are implemented.
+    - Test plan: checkpoint round-trip and corrupt checkpoint fallback tests.
+
+- [ ] **Slice 32: Checkpoint validation without publication record**
+    - User story: As recovery, valid checkpoint files should remain usable after
+      crash before publication evidence.
+    - Acceptance criteria: validated checkpoint can be used without
+      `CheckpointPublicationRecorded`; publication record remains audit/index
+      evidence.
+    - Test plan:
+      `valid_checkpoint_without_checkpoint_published_record_can_be_used_after_validation`.
+
+- [ ] **Slice 33: Checkpoint publication obstruction**
+    - User story: As recovery, publication evidence must not lie about missing or
+      invalid checkpoint material.
+    - Acceptance criteria: publication without checkpoint blocks or obstructs by
+      documented scope.
+    - Test plan:
+      `checkpoint_published_without_checkpoint_blocks_or_obstructs_according_to_scope`.
+
+- [ ] **Slice 34: Recovery certificate**
+    - User story: As jedit/operator/debugger, I need a precise restart report.
+    - Acceptance criteria: certificate reports checkpoint, LSN range, replayed
+      transactions, tail posture, obstruction count, and final roots.
+    - Test plan: clean, tail-truncated, and obstructed recovery certificates.
+
+- [ ] **Slice 35: Read-only WAL inspector**
+    - User story: As an operator, I need inspection without mutating storage.
+    - Acceptance criteria: `echo wal doctor --json`, `inspect`, and read-only
+      recovery report posture without truncation.
+    - Test plan: inspector reports would-truncate and leaves files unchanged.
+
+### PR 8: Filesystem And Object Stores
+
+- [ ] **Slice 36: Filesystem WAL adapter**
+    - User story: As Echo, strict filesystem durability must use real fsync
+      boundaries.
+    - Acceptance criteria: segment creation, append, file fsync, rename, and
+      directory fsync are explicit.
+    - Test plan: filesystem crash fixtures for torn frame and missing segment.
+
+- [ ] **Slice 37: Object-store manifest adapter**
+    - User story: As Echo, strict object-store durability must not pretend fsync
+      exists.
+    - Acceptance criteria: content-addressed object writes, version/ETag
+      verification, conditional manifest commit, and read-after-write posture are
+      required.
+    - Test plan: `strict_object_store_requires_conditional_manifest_commit`.
+
+- [ ] **Slice 38: Segment repair and truncation protocol**
+    - User story: As recovery, tail repair must be explicit and mode-sensitive.
+    - Acceptance criteria: writable stores can truncate incomplete tails; read-only
+      stores can only report would-truncate.
+    - Test plan: segment-gap, duplicate-segment, and torn-tail matrix.
+
+- [ ] **Slice 39: Crash matrix harness**
+    - User story: As Echo, lifecycle ambiguity must be testable at every boundary.
+    - Acceptance criteria: harness injects crash points around submit, tick,
+      checkpoint, material, and index publication.
+    - Test plan: generated crash matrix suite.
+
+- [ ] **Slice 40: WAL shadow replay in CI**
+    - User story: As a maintainer, every mutating integration path should prove
+      live state equals replayed state.
+    - Acceptance criteria: selected tests run live scenario, replay WAL into fresh
+      runtime, and compare state/index/receipt/reading roots.
+    - Test plan: CI slice for shadow replay.
+
+### PR 9: Outbox, Tooling, And Jedit Gate
+
+- [ ] **Slice 41: Side-effect outbox core**
+    - User story: As Echo, external effects must be authorized by committed
+      history before escaping.
+    - Acceptance criteria: durable outbox records effect id, expected artifact,
+      materialization intent, and idempotency token.
+    - Test plan: `external_effect_requires_committed_outbox_authorization`.
+
+- [ ] **Slice 42: Materialization observation replay detection**
+    - User story: As recovery, existing external artifacts should be detected
+      before retry.
+    - Acceptance criteria: recovery verifies path, digest, and metadata before
+      retrying or recording observation.
+    - Test plan: `materialization_replay_detects_existing_artifact_before_retry`.
+
+- [ ] **Slice 43: Causal commit evidence projection**
+    - User story: As [warp-ttd], I need Echo-projected commit evidence, not raw
+      WAL access.
+    - Acceptance criteria: Echo exposes `CausalCommitEvidence` and recovery
+      posture through read-model facts; no raw segment path or recovery authority
+      is required.
+    - Test plan: accepted pending, decided applied, rejected, obstructed, faulted,
+      and durability-unknown projection fixtures.
+
+- [ ] **Slice 44: `jedit` WAL recovery gate**
+    - User story: As [jedit], after crash/restart I need submitted edits to
+      recover as not accepted, accepted pending, applied, rejected, or obstructed.
+    - Acceptance criteria: stable submission id, recovered posture, export from
+      committed causal basis, no jedit nouns in Echo core.
+    - Test plan: sibling `jedit` crash/restart fixture and retry-after-ACK-loss
+      fixture.
+
+- [ ] **Slice 45: WAL release readiness audit**
+    - User story: As an operator, I need a final audit before trusting the WAL as
+      the jedit durability foundation.
+    - Acceptance criteria: all WAL release gates pass, docs match code, app-noun
+      guard is green, and deferred post-WAL scope is explicit.
+    - Test plan: full WAL slice suite, `cargo xtask test-slice`, app-noun guard,
+      DIND/replay where available, and cross-repo jedit witness.
 
 ## Recently Completed Slice Batch
 

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -843,6 +843,82 @@ completed slice.
       include date partitions and wall-clock authoritative placement is rejected.
     - Test plan: segment manifest and placement-policy hardening fixtures.
 
+### PR 16: WAL Segment Rotation Hardening
+
+- [x] **Slice 76: Active segment id enforcement**
+    - User story: As Echo, frames must be appended only to the active logical
+      segment they claim.
+    - Acceptance criteria: filesystem append rejects frames whose header segment
+      id differs from the active segment id.
+    - Test plan: inactive segment append rejection fixture.
+
+- [x] **Slice 77: Canonical segment rotation**
+    - User story: As Echo, segment rotation should seal the current segment and
+      create the next canonical segment under `segments/`.
+    - Acceptance criteria: rotation returns the prior segment seal, advances the
+      active segment id, creates the next segment file, and records strict sync
+      evidence for the new segment; rotation does not overwrite an existing
+      next segment.
+    - Test plan: rotation creation, duplicate-protection, and sync evidence
+      fixtures.
+
+- [x] **Slice 78: Rotation tail safety**
+    - User story: As Echo, rotation must not seal a segment containing
+      uncommitted frames or a torn tail.
+    - Acceptance criteria: rotation rejects segments with uncommitted tails using
+      typed store errors.
+    - Test plan: uncommitted-tail rotation rejection fixture.
+
+- [x] **Slice 79: Multi-segment recovery**
+    - User story: As recovery, committed transactions split across rotated
+      segments must replay as one logical WAL stream.
+    - Acceptance criteria: recovery scans multiple canonical segments, preserves
+      clean tail posture, and reports the last committed LSN.
+    - Test plan: rotated multi-segment recovery fixture.
+
+- [x] **Slice 80: Rotation authority guard**
+    - User story: As Echo, only the active writer epoch may rotate WAL segments.
+    - Acceptance criteria: epoch mismatch rejects rotation before any new segment
+      is created.
+    - Test plan: rotation epoch mismatch fixture.
+
+### PR 17: WAL Manifest Validation Hardening
+
+- [x] **Slice 81: Manifest read roundtrip**
+    - User story: As Echo, published filesystem manifests must be readable as
+      structured WAL evidence.
+    - Acceptance criteria: manifest files decode back into `WalManifest` without
+      relying on ad hoc string parsing.
+    - Test plan: filesystem manifest roundtrip fixture.
+
+- [x] **Slice 82: Manifest segment-count validation**
+    - User story: As recovery, a published manifest must not lie about segment
+      count.
+    - Acceptance criteria: validation compares manifest segment count with
+      scanned canonical/legacy segment files and rejects mismatches.
+    - Test plan: manifest segment-count mismatch fixture.
+
+- [x] **Slice 83: Manifest commit-anchor validation**
+    - User story: As recovery, a published manifest must match the last
+      committed LSN and commit digest recovered from segment contents.
+    - Acceptance criteria: last-LSN and last-digest mismatches reject with typed
+      store errors.
+    - Test plan: manifest last-LSN and last-digest mismatch fixtures.
+
+- [x] **Slice 84: Manifest tail safety**
+    - User story: As recovery, a manifest cannot validate while segments contain
+      an uncommitted tail.
+    - Acceptance criteria: validation rejects uncommitted or torn tails before
+      accepting the manifest summary.
+    - Test plan: manifest uncommitted-tail rejection fixture.
+
+- [x] **Slice 85: Manifest validation release gate**
+    - User story: As a maintainer, release readiness must require manifest
+      validation coverage.
+    - Acceptance criteria: readiness reports `segment_manifest_validation` as a
+      distinct blocked gate until enabled.
+    - Test plan: release readiness manifest-validation gate fixture.
+
 ## Recently Completed Slice Batch
 
 1. **Contract-Aware Receipts And Readings**

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -599,7 +599,7 @@ completed slice.
 
 ### PR 10: WAL Fixture And Corpus Hardening
 
-- [ ] **Slice 46: WAL hardening fixture surface**
+- [x] **Slice 46: WAL hardening fixture surface**
     - User story: As an Echo maintainer, I need deterministic fixtures that can
       build valid WAL histories and damage them at exact byte/transaction
       boundaries.
@@ -609,7 +609,7 @@ completed slice.
     - Test plan: fixture recovery, uncommitted-tail, torn-tail, and read-only
       non-mutation witnesses.
 
-- [ ] **Slice 47: WAL recovery golden corpus**
+- [x] **Slice 47: WAL recovery golden corpus**
     - User story: As Echo, I need a fixed corpus of minimal WAL shapes that
       proves recovery posture across clean, partial, and corrupt histories.
     - Acceptance criteria: clean, empty, tail, torn, corrupt digest, bad magic,
@@ -617,7 +617,7 @@ completed slice.
       blocking/inspectable status.
     - Test plan: `wal_recovery_golden_*` fixtures listed in the hardening matrix.
 
-- [ ] **Slice 48: Submission ACK crash matrix**
+- [x] **Slice 48: Submission ACK crash matrix**
     - User story: As an app retrying after a crash, I need Echo to distinguish
       never accepted from accepted-before-ACK.
     - Acceptance criteria: recovery never invents accepted evidence before
@@ -626,7 +626,7 @@ completed slice.
       policy.
     - Test plan: submission intake crash matrix fixtures.
 
-- [ ] **Slice 49: Tick commit and publish crash matrix**
+- [x] **Slice 49: Tick commit and publish crash matrix**
     - User story: As Echo, visible tick outcomes must imply committed
       recoverable history.
     - Acceptance criteria: tick receipt, runtime delta, receipt correlation, and

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -685,7 +685,7 @@ completed slice.
 
 ### PR 12: WAL Outbox, Projection, And Inspector Hardening
 
-- [ ] **Slice 56: Side-effect outbox crash matrix**
+- [x] **Slice 56: Side-effect outbox crash matrix**
     - User story: As Echo, external effects must never escape before committed
       authorization and must be idempotent after crash.
     - Acceptance criteria: effect authorization, existing artifact detection,
@@ -693,7 +693,7 @@ completed slice.
       are covered.
     - Test plan: side-effect outbox crash fixtures.
 
-- [ ] **Slice 57: Recovery reducer determinism**
+- [x] **Slice 57: Recovery reducer determinism**
     - User story: As Echo, replay must apply committed facts without scheduler
       callbacks, wall clock, random, network, or app code.
     - Acceptance criteria: pure replay is deterministic; transaction ordering is
@@ -701,7 +701,7 @@ completed slice.
       needed.
     - Test plan: pure replay determinism fixtures.
 
-- [ ] **Slice 58: Shadow replay harness**
+- [x] **Slice 58: Shadow replay harness**
     - User story: As a maintainer, every mutating WAL path should prove live
       state equals recovered state.
     - Acceptance criteria: helper runs live scenario, recovers from WAL, compares
@@ -709,7 +709,7 @@ completed slice.
     - Test plan: submission, tick, retention, outbox, and mismatch shadow replay
       fixtures.
 
-- [ ] **Slice 59: Causal commit evidence projection matrix**
+- [x] **Slice 59: Causal commit evidence projection matrix**
     - User story: As [warp-ttd] or an operator, I need commit evidence posture
       without raw WAL ownership.
     - Acceptance criteria: accepted pending, applied, rejected, obstructed, and
@@ -717,7 +717,7 @@ completed slice.
       durability mode without raw segment authority.
     - Test plan: causal commit evidence projection fixtures.
 
-- [ ] **Slice 60: WAL doctor and inspector contract tests**
+- [x] **Slice 60: WAL doctor and inspector contract tests**
     - User story: As an operator, I need inspection commands/read models to
       report truth without mutating storage.
     - Acceptance criteria: doctor reports clean, would-truncate, obstructed,

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -919,6 +919,91 @@ completed slice.
       distinct blocked gate until enabled.
     - Test plan: release readiness manifest-validation gate fixture.
 
+### PR 18: Runtime WAL ACK Integration
+
+- [x] **Slice 86: Runtime WAL adapter port**
+    - User story: As a trusted runtime host, I need a local WAL adapter at the
+      app-facing ACK boundary without giving the application append authority.
+    - Acceptance criteria: `TrustedRuntimeHost` can configure an in-memory
+      runtime WAL adapter as read-only evidence; applications still only receive
+      `TrustedRuntimeApp`.
+    - Test plan: trusted-host loop test proving the configured WAL is visible
+      only as host evidence after app submission.
+
+- [x] **Slice 87: Submission acceptance transaction wiring**
+    - User story: As a caller, returned accepted submission evidence must be
+      backed by a committed submission-intake WAL transaction when using the
+      WAL-backed ACK path.
+    - Acceptance criteria: `submit_intent_with_runtime_wal_ack(...)` records
+      `SubmissionAcceptedRecorded` plus acceptance evidence before returning the
+      handle.
+    - Test plan:
+      `runtime_wal_ack_submit_commits_acceptance_before_returning_handle`.
+
+- [x] **Slice 88: Duplicate submit ACK posture**
+    - User story: As a retrying client, resubmitting the same accepted envelope
+      must not spray duplicate WAL acceptance transactions.
+    - Acceptance criteria: duplicate intake returns the original submission id
+      and leaves the submission-acceptance transaction count unchanged when WAL
+      evidence already exists; a duplicate from legacy non-WAL intake backfills
+      exactly one acceptance transaction before returning.
+    - Test plan:
+      `runtime_wal_ack_duplicate_submit_does_not_append_second_acceptance` and
+      `runtime_wal_ack_duplicate_without_prior_wal_backfills_acceptance`.
+
+- [x] **Slice 89: Pre-ACK WAL failure rollback**
+    - User story: As Echo, if the WAL cannot commit accepted-submission evidence,
+      the in-memory intake mutation must not remain visible.
+    - Acceptance criteria: WAL build failure restores the pre-submit runtime and
+      returns a typed host WAL error.
+    - Test plan: `runtime_wal_ack_failure_rolls_back_intake_mutation` and
+      `runtime_wal_ack_path_requires_configured_runtime_wal`.
+
+- [ ] **Slice 90: Tick receipt transaction wiring**
+    - User story: As Echo, visible tick receipts should eventually be backed by
+      committed scheduler-tick WAL transactions.
+    - Acceptance criteria: host-owned scheduler runs record receipt and
+      correlation facts before publishing product-facing receipt evidence.
+    - Test plan: trusted-host applied-intent fixture plus recovered receipt
+      index witness.
+
+- [ ] **Slice 91: Tick commit-before-publish rollback guard**
+    - User story: As Echo, a tick WAL failure must not leave a half-visible
+      receipt/outcome.
+    - Acceptance criteria: tick WAL failure either restores runtime/provenance
+      state or blocks receipt publication under a typed runtime fault posture.
+    - Test plan: injected tick-WAL failure fixture.
+
+- [ ] **Slice 92: Runtime index rebuild contract**
+    - User story: As recovery, WAL-backed submission and receipt indexes should
+      rebuild without scheduler callbacks.
+    - Acceptance criteria: recovered indexes answer pending/applied/rejected
+      posture from committed WAL transactions only.
+    - Test plan: pure in-memory recovery fixture for submit plus tick records.
+
+- [ ] **Slice 93: WAL-backed recovery certificate in runtime**
+    - User story: As an operator, restart should produce inspectable evidence
+      about what committed history was replayed.
+    - Acceptance criteria: recovery certificate covers checkpoint, LSN range,
+      commit digest, tail posture, and recovered counts.
+    - Test plan: recovery certificate fixture over committed and truncated-tail
+      WAL shapes.
+
+- [ ] **Slice 94: `jedit` recovery fixture contract**
+    - User story: As a real app consumer, `jedit` should be able to distinguish
+      not-accepted, accepted-pending, decided, rejected, and obstructed edits
+      from Echo recovery evidence.
+    - Acceptance criteria: Echo exposes only generic submission/receipt posture;
+      `jedit` maps that posture to editor terms outside Echo.
+    - Test plan: sibling `jedit` fixture consumes generic Echo recovery JSON.
+
+- [ ] **Slice 95: Runtime ACK drift gate**
+    - User story: As a maintainer, docs and tests should fail if Echo claims
+      durable ACK semantics without a WAL-backed witness.
+    - Acceptance criteria: release readiness names runtime ACK coverage as a
+      distinct gate.
+    - Test plan: runtime ACK readiness gate fixture plus stale-claim grep.
+
 ## Recently Completed Slice Batch
 
 1. **Contract-Aware Receipts And Readings**

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -767,6 +767,82 @@ completed slice.
       object-store, and projection coverage.
     - Test plan: WAL hardening gate fixtures plus app-noun and doc checks.
 
+### PR 14: WAL Segment Layout And Placement Hardening
+
+- [x] **Slice 66: Canonical segment namespace**
+    - User story: As Echo, WAL segment files must live under a logical namespace
+      that does not encode wall-clock semantics.
+    - Acceptance criteria: canonical segment paths use `segments/` plus
+      zero-padded logical segment id; recovery scans that namespace; creating
+      that namespace syncs the WAL root directory in strict filesystem mode.
+    - Test plan: canonical segment path, namespace sync, and recovery scan
+      fixtures.
+
+- [x] **Slice 67: Wall-clock placement policy guard**
+    - User story: As Echo, storage adapters may organize bytes by time only when
+      time is non-authoritative placement metadata.
+    - Acceptance criteria: wall-clock placement cannot be authoritative; causal
+      segment id placement remains allowed.
+    - Test plan: segment placement policy fixtures.
+
+- [x] **Slice 68: Legacy flat segment compatibility**
+    - User story: As recovery, older flat-layout WAL roots should remain
+      inspectable while the canonical namespace moves forward.
+    - Acceptance criteria: a root without `segments/` can still be scanned;
+      duplicate ids across legacy and canonical layouts are rejected.
+    - Test plan: legacy flat scan and cross-layout duplicate fixtures.
+
+- [x] **Slice 69: Canonical gap and rewrite behavior**
+    - User story: As recovery, canonical segment gaps and writable tail rewrites
+      must preserve the logical segment namespace.
+    - Acceptance criteria: segment gaps under `segments/` block recovery;
+      writable truncation rewrites retained records back under `segments/`.
+    - Test plan: canonical segment gap and writable rewrite fixtures.
+
+- [x] **Slice 70: Segment id rotation guard**
+    - User story: As Echo, segment rotation must fail deterministically instead
+      of overflowing logical segment identity.
+    - Acceptance criteria: next segment id is monotonic and overflow returns a
+      typed error.
+    - Test plan: segment id overflow fixture.
+
+### PR 15: WAL Segment Manifest And Layout Gate Hardening
+
+- [x] **Slice 71: Segment manifest entry shape**
+    - User story: As Echo, segment manifest entries must bind logical segment id,
+      canonical relative path, digest, and LSN range.
+    - Acceptance criteria: manifest entries derive from frames and never require
+      wall-clock path semantics.
+    - Test plan: segment manifest entry fixture.
+
+- [x] **Slice 72: Segment layout release gate**
+    - User story: As Echo, the release readiness audit must include segment
+      layout policy explicitly.
+    - Acceptance criteria: readiness reports `segment_layout_policy` as blocked
+      until set; a fully green gate requires it.
+    - Test plan: release readiness gate fixtures.
+
+- [x] **Slice 73: Manifest-addressed placement doctrine**
+    - User story: As a storage adapter author, date/path placement must be
+      understood as byte placement, not causal truth.
+    - Acceptance criteria: BEARING records that wall-clock paths are
+      non-authoritative and segment id/digest/commit chain decide truth.
+    - Test plan: docs lint plus segment placement policy fixtures.
+
+- [x] **Slice 74: Canonical layout migration witness**
+    - User story: As an operator, moving from flat first-cut layout to
+      `segments/` must not erase recoverability.
+    - Acceptance criteria: canonical layout is preferred; legacy flat roots
+      remain readable when no canonical namespace exists.
+    - Test plan: legacy flat compatibility fixture.
+
+- [x] **Slice 75: Segment layout drift gate**
+    - User story: As a maintainer, future changes must not accidentally make
+      wall-clock directory structure part of recovery truth.
+    - Acceptance criteria: hardening tests assert canonical relative paths do not
+      include date partitions and wall-clock authoritative placement is rejected.
+    - Test plan: segment manifest and placement-policy hardening fixtures.
+
 ## Recently Completed Slice Batch
 
 1. **Contract-Aware Receipts And Readings**

--- a/docs/design/causal-wal-end-to-end.md
+++ b/docs/design/causal-wal-end-to-end.md
@@ -45,7 +45,9 @@ No external effect without committed authorization.
 - No jedit, file, buffer, cursor, selection, or document semantics in Echo WAL.
 - No user undo or application-level redo.
 - No distributed multi-writer WAL.
-- No hidden retry queue.
+- No hidden process-local retry queue.
+- Explicit durable side-effect outboxes are allowed and required for fenced
+  external materialization.
 - No application-owned tick, receipt, runtime-control, or recovery record
   append authority.
 - No claim that WAL alone gives exactly-once external side effects.
@@ -101,14 +103,14 @@ flowchart LR
     end
 
     subgraph RuntimePlane[Trusted Runtime Plane]
-        Intake[Intake admission]
+        Intake[Submission intake acceptance]
         Scheduler[Scheduler-owned tick]
         RuntimeControl[Start Stop Cadence Drain Recovery]
     end
 
     subgraph WalPlane[Causal WAL Plane]
-        SubmissionRecord[WitnessedSubmissionAccepted]
-        TickRecord[TickReceiptCommitted]
+        SubmissionRecord[SubmissionAcceptedRecorded]
+        TickRecord[TickReceiptRecorded]
         ControlRecord[TrustedRuntimeControlRecorded]
         FaultRecord[SchedulerFaultQuarantined]
     end
@@ -128,18 +130,28 @@ Application code may cause a witnessed submission only by passing the canonical
 submit boundary. Application code must never possess append authority for tick,
 receipt, runtime-control, scheduler-fault, or recovery records.
 
+Echo reserves `admission` for runtime/law admission, not intake acceptance. A
+submission can be durably accepted into pending posture without yet being
+admitted for execution under runtime law.
+
+```text
+submission acceptance != runtime admission
+AdmissionTicket != accepted submission evidence
+TickReceipt != AdmissionTicket
+```
+
 ## ACK Contract
 
 Every public API that returns durable evidence must state what was committed
 before return.
 
-| Surface                  | May Return Only After                                           | Meaning Of Return                                            |
-| :----------------------- | :-------------------------------------------------------------- | :----------------------------------------------------------- |
-| Submission intake        | `WitnessedSubmissionAccepted` transaction committed and flushed | Returned accepted evidence is recoverable accepted evidence. |
-| Duplicate submission     | Prior committed submission was found and validated              | Duplicate posture is stable across restart.                  |
-| Tick outcome publication | tick transaction committed and flushed                          | Visible receipt is recoverable receipt.                      |
-| Runtime posture change   | posture transaction committed and flushed                       | Quarantine/control state is recoverable runtime state.       |
-| Retained reading ref     | referenced material durable before WAL reference                | Reading ref is not an empty content-hash guess.              |
+| Surface                  | May Return Only After                                          | Meaning Of Return                                            |
+| :----------------------- | :------------------------------------------------------------- | :----------------------------------------------------------- |
+| Submission intake        | `SubmissionAcceptedRecorded` transaction committed and flushed | Returned accepted evidence is recoverable accepted evidence. |
+| Duplicate submission     | Prior committed submission was found and validated             | Duplicate posture is stable across restart.                  |
+| Tick outcome publication | tick transaction committed and flushed                         | Visible receipt is recoverable receipt.                      |
+| Runtime posture change   | posture transaction committed and flushed                      | Quarantine/control state is recoverable runtime state.       |
+| Retained reading ref     | referenced material durable before WAL reference               | Reading ref is not an empty content-hash guess.              |
 
 Wrong:
 
@@ -160,6 +172,19 @@ return accepted evidence
 
 Buffered mode may exist for tests and local experimentation, but it must not be
 allowed to satisfy release durability gates.
+
+The crash-after-commit-before-ACK case is intentional and must be stable:
+
+```text
+WAL commit flushed
+process dies before application receives AcceptedSubmissionEvidence
+retry same submission id + same canonical envelope
+-> AlreadyAcceptedPending / AlreadyDecided / AlreadyRejected / AlreadyObstructed
+```
+
+Echo truth wins over client perception. The client may not know whether the ACK
+was delivered, but recovery must know whether the acceptance transaction
+committed.
 
 ## WAL Transactions
 
@@ -208,7 +233,7 @@ sequenceDiagram
     App->>Intake: submit_intent(canonical envelope)
     Intake->>Intake: validate envelope and idempotency identity
     Intake->>Wal: begin intake transaction
-    Wal->>Store: append WitnessedSubmissionAccepted
+    Wal->>Store: append SubmissionAcceptedRecorded
     Wal->>Store: append WalTransactionCommit
     Store-->>Wal: flushed under durability policy
     Wal-->>Intake: committed transaction
@@ -219,6 +244,10 @@ sequenceDiagram
 If the process dies before the commit marker is flushed, the submission was not
 accepted. If it dies after the commit marker is flushed, recovery must restore a
 pending or decided submission posture.
+
+If the process dies after the commit marker is flushed but before the app sees
+the ACK, a retry with the same submission id and canonical envelope must return
+the stable duplicate posture derived from the committed WAL transaction.
 
 ## Sequence: Scheduler Tick
 
@@ -269,7 +298,7 @@ sequenceDiagram
     Recovery->>Wal: scan segments after checkpoint LSN
     Wal-->>Recovery: frames and possible torn tail
     Recovery->>Recovery: group committed contiguous transactions
-    Recovery->>Recovery: truncate uncommitted tail
+    Recovery->>Recovery: truncate or ignore uncommitted tail by mode
     Recovery->>Validator: validate semantic transaction invariants
     Validator-->>Recovery: valid committed transactions
     Recovery->>Index: apply pure reducers
@@ -279,6 +308,15 @@ sequenceDiagram
 Recovery must replay committed facts. It must not ask the scheduler what should
 have happened. It must not call app code. It must not write files except through
 a separately fenced materialization phase.
+
+Recovery mode matters:
+
+| Mode                                | Tail Handling                                                 |
+| :---------------------------------- | :------------------------------------------------------------ |
+| `StrictFilesystem` / writable store | May truncate uncommitted tail after validation.               |
+| `StrictObjectStore`                 | May publish a corrected committed manifest if adapter allows. |
+| `ReadOnlyRecovery`                  | Must not truncate; report that truncation would be required.  |
+| `Disabled`                          | No durable recovery claim.                                    |
 
 ## Frame And Transaction Model
 
@@ -296,6 +334,13 @@ classDiagram
         record_kind
         payload_len
         payload_digest
+        payload_codec_id
+        payload_schema_id
+        payload_schema_version
+        canonical_encoding_version
+        digest_domain
+        compression_kind
+        encryption_or_redaction_posture
         previous_frame_digest
         header_crc
     }
@@ -317,8 +362,7 @@ classDiagram
         last_lsn
         record_count
         records_root
-        frontier_before_digest
-        frontier_after_digest
+        affected_frontiers_root
         previous_committed_transaction_digest
         durability_mode
         schema_version
@@ -334,9 +378,21 @@ classDiagram
 
     class WriterEpoch {
         epoch_id
+        storage_fencing_token
+        process_identity
+        host_identity
         started_at_lsn
+        previous_epoch_id
+        previous_epoch_final_commit_digest
+        lease_or_lock_evidence
         sealed_at_lsn
         recovered_from_epoch
+    }
+
+    class AffectedFrontier {
+        frontier_kind
+        before_digest
+        after_digest
     }
 
     WalSegment "1" --> "1" WriterEpoch
@@ -344,6 +400,7 @@ classDiagram
     WalFrameHeader "1" --> "1" WalRecordPayload
     WalFrameHeader "1" --> "1" WalFrameTrailer
     WalTransactionCommit "1" --> "*" WalFrameHeader
+    WalTransactionCommit "1" --> "*" AffectedFrontier
 ```
 
 Use two integrity mechanisms:
@@ -353,6 +410,19 @@ Use two integrity mechanisms:
   evidence.
 
 Do not make one mechanism do both jobs.
+
+`affected_frontiers_root` commits the set of frontier transitions touched by
+the transaction. Intake, tick, runtime posture, reading, and checkpoint
+transactions do not all mutate the same frontier. Use a typed set such as:
+
+```text
+affected_frontiers: [
+  { frontier_kind, before_digest, after_digest }
+]
+```
+
+Do not overload one `frontier_before_digest` / `frontier_after_digest` pair
+into a catch-all junk drawer.
 
 ## Writer Epoch Discipline
 
@@ -372,6 +442,51 @@ stateDiagram-v2
 
 Recovery seeing overlapping writer epochs is a recovery fault. It is not a
 merge opportunity.
+
+Each writer epoch must bind fencing evidence:
+
+```text
+epoch_id
+storage_fencing_token
+process_identity
+host_identity
+started_at_lsn
+previous_epoch_id
+previous_epoch_final_commit_digest
+lease_or_lock_evidence
+```
+
+Runtime intent says "one writer actor." Stored fencing evidence proves which
+writer had append authority for a range.
+
+## WalStorePort Contract
+
+`WalStorePort` is the storage boundary that prevents adapters from hand-waving
+strict durability. The trait shape can change during implementation, but the
+contract must preserve these operations:
+
+```text
+WalStorePort
+  acquire_writer_epoch(fencing_context) -> WriterEpoch
+  append_frame(epoch, frame) -> AppendResult
+  flush_commit(epoch, transaction_id) -> DurabilityResult
+  read_segments(from_lsn) -> SegmentStream
+  seal_segment(epoch, segment_id) -> SealResult
+  truncate_tail(after_lsn) -> TruncationResult
+  publish_manifest?(manifest) -> ManifestCommitResult
+  close_epoch(epoch) -> EpochSealResult
+```
+
+Object-store adapters also need explicit manifest operations:
+
+```text
+conditional_publish_manifest
+verify_object_version
+read_committed_manifest
+```
+
+An adapter must not report `StrictFilesystem` or `StrictObjectStore` unless its
+port implementation satisfies the ACK contract for that storage medium.
 
 ## Record Families
 
@@ -403,8 +518,7 @@ erDiagram
 
     WAL_COMMIT {
       string records_root
-      string frontier_before_digest
-      string frontier_after_digest
+      string affected_frontiers_root
       string commit_digest
     }
 
@@ -417,24 +531,36 @@ erDiagram
 
 Candidate causal record families:
 
-- `WitnessedSubmissionAccepted`
-- `AdmissionEvidenceRecorded`
-- `LawWitnessRecorded`
-- `AdmissionTicketIssued`
+- `SubmissionAcceptedRecorded`
+- `SubmissionAcceptanceEvidenceRecorded`
+- `RuntimeLawWitnessRecorded`
+- `RuntimeAdmissionTicketIssued`
 - `TicketedRuntimeIngressRecorded`
-- `TickReceiptCommitted`
-- `RuntimeStateDeltaCommitted`
+- `TickReceiptRecorded`
+- `RuntimeStateDeltaRecorded`
 - `ReceiptCorrelationRecorded`
 - `ReadingEnvelopeRetained`
 - `RetainedMaterialRefRecorded`
 - `SchedulerFaultQuarantined`
 - `TrustedRuntimeControlRecorded`
-- `CheckpointPublished`
-- `MaterializationIntentCommitted`
+- `CheckpointPublicationRecorded`
+- `MaterializationIntentRecorded`
 - `MaterializationEffectObserved`
 
 Diagnostic-only records should live in a separate trace lane. The causal WAL
 should stay clean.
+
+Naming rule:
+
+```text
+Records are recorded.
+Transactions are committed.
+History begins at WalTransactionCommit.
+```
+
+Do not use `*Committed` as an ordinary record kind. A frame containing
+`TickReceiptRecorded` is still almost-history until the containing transaction
+has a validated `WalTransactionCommit`.
 
 ## Causal WAL Versus Diagnostic Trace
 
@@ -463,6 +589,14 @@ Failed tick attempts are not causal history. After rollback, Echo may commit a
 runtime posture change such as `SchedulerFaultQuarantined`; that posture is
 causal runtime history because it affects future scheduling.
 
+Diagnostic trace failure behavior:
+
+- diagnostic trace loss must not block causal recovery;
+- diagnostic trace corruption must not poison causal WAL replay;
+- diagnostic trace records must not be required to rebuild causal indexes;
+- diagnostic segments, if durable, should use a separate adapter or segment
+  family from the causal WAL.
+
 ## Idempotency And Duplicate Submission
 
 Each submission needs a stable idempotency identity:
@@ -472,20 +606,28 @@ submission_id
 client_submission_nonce
 canonical_envelope_digest
 generation
-admission_context_digest
+submission_acceptance_context_digest
+idempotency_key_digest
+dedupe_scope
+dedupe_policy_id
 ```
 
 Recovery and retry can then classify:
 
-| Retry Shape                                      | Recovery Posture                                                 |
-| :----------------------------------------------- | :--------------------------------------------------------------- |
-| Same submission id, same canonical envelope      | `AlreadyAcceptedPending`, `AlreadyDecided`, or `AlreadyRejected` |
-| Same submission id, different canonical envelope | protocol violation                                               |
-| New submission id, same canonical envelope       | duplicate semantic submission posture if policy says so          |
-| No committed WAL transaction                     | `NotAccepted`                                                    |
+| Retry Shape                                      | Recovery Posture                                                                      |
+| :----------------------------------------------- | :------------------------------------------------------------------------------------ |
+| Same submission id, same canonical envelope      | `AlreadyAcceptedPending`, `AlreadyDecided`, `AlreadyRejected`, or `AlreadyObstructed` |
+| Same submission id, different canonical envelope | protocol violation                                                                    |
+| New submission id, same canonical envelope       | new submission unless explicit dedupe key or policy says otherwise                    |
+| No committed WAL transaction                     | `NotAccepted`                                                                         |
 
 Same id plus different bytes must never overwrite the previous record or become
 a new accepted submission.
+
+Echo must not infer semantic duplicate status from identical canonical envelope
+bytes alone. A user may intentionally submit the same canonical intent twice.
+Duplicate suppression requires an explicit idempotency key, dedupe scope, or
+dedupe policy.
 
 ## Semantic Validation
 
@@ -513,13 +655,25 @@ flowchart TD
 
 Examples:
 
-- `WitnessedSubmissionAccepted` requires canonical envelope digest, unique or
+- `SubmissionAcceptedRecorded` requires canonical envelope digest, unique or
   duplicate-compatible submission identity, and no scheduler-owned records.
-- `TickReceiptCommitted` requires trusted runtime authority, ticket identity,
+- `TickReceiptRecorded` requires trusted runtime authority, ticket identity,
   receipt identity, state/correlation records when applicable, and matching
-  `frontier_before_digest`.
+  affected frontier transition.
 - `RetainedMaterialRefRecorded` requires durable material before the committed
   WAL reference.
+
+Replay application should be pure:
+
+```text
+RecoveredState apply_committed_transaction(
+  RecoveredState before,
+  ValidatedCommittedTransaction tx
+)
+```
+
+The reducer must not read wall clock, random data, network state, app callbacks,
+external files, scheduler decisions, or mutable process globals.
 
 ## Rebuildable Indexes
 
@@ -609,7 +763,7 @@ sequenceDiagram
     Echo->>Outbox: publish idempotent effect token
     Worker->>Outbox: claim effect token
     Worker->>Host: perform external materialization
-    Worker->>Wal: commit MaterializationEffectObserved
+    Worker->>Wal: record MaterializationEffectObserved in committed tx
 ```
 
 This prevents the bad case:
@@ -623,10 +777,28 @@ recovery says tick never happened
 The outbox does not make every external system exactly once. It makes Echo's
 authorization and observation of effects recoverable and idempotent.
 
+If the process dies after the external artifact is materialized but before
+`MaterializationEffectObserved` is recorded, recovery must not blindly perform
+the effect again. It should read the idempotent effect token, verify the
+expected artifact path, digest, and metadata, and then either record
+`MaterializationEffectObserved`, retry, repair, or obstruct according to policy.
+
+Filesystem materialization should use this shape:
+
+```text
+write temp artifact
+fsync temp artifact
+atomic rename
+fsync containing directory
+verify final artifact digest
+record MaterializationEffectObserved in a committed WAL transaction
+```
+
 ## Checkpoints
 
-Checkpoint is an optimization, not authority. The WAL remains the source of
-truth for committed transactions after the checkpoint's included LSN.
+A checkpoint is a derived replay accelerator. It is usable only if it validates
+against committed WAL history. It does not create, erase, or modify causal
+history.
 
 ```mermaid
 flowchart TD
@@ -635,7 +807,7 @@ flowchart TD
     FsyncTemp[fsync checkpoint temp file]
     Rename[atomic rename]
     FsyncDir[fsync containing directory]
-    WalRecord[Commit CheckpointPublished]
+    WalRecord[Record CheckpointPublicationRecorded]
     Recover[Recovery validates checkpoint + WAL tail]
 
     Live --> Temp --> FsyncTemp --> Rename --> FsyncDir --> WalRecord --> Recover
@@ -656,6 +828,11 @@ Checkpoint should bind:
 Recovery verifies that the checkpoint chain matches the WAL chain. If the
 latest checkpoint is invalid, recovery falls back to an earlier checkpoint or
 full WAL replay.
+
+`CheckpointPublicationRecorded` is audit and index evidence, not the only thing
+that can make a checkpoint usable. A checkpoint file that exists after a crash
+but lacks a publication record may still be used if it cryptographically and
+semantically validates against the committed WAL chain.
 
 ## Filesystem And Object-Store Semantics
 
@@ -705,6 +882,31 @@ Unknown critical causal records block recovery. Unknown non-critical diagnostic
 records may be skipped only if their integrity validates and they are outside
 the causal WAL.
 
+## Security And Revelation Posture
+
+The WAL may reference canonical envelopes, receipts, readings, and retained
+material. It must preserve truth without leaking more than the active policy
+allows.
+
+Minimum rules:
+
+- WAL headers must not leak app payload contents.
+- Payload bytes may be digest-only, retained-ref, encrypted, or redacted.
+- Recovery must preserve redaction posture.
+- Inspectors must distinguish unavailable due to policy from missing due to
+  corruption.
+
+Useful material postures:
+
+| Posture                     | Meaning                                                     |
+| :-------------------------- | :---------------------------------------------------------- |
+| `PRESENT`                   | Material exists and policy allows inspection.               |
+| `REDACTED_BY_POLICY`        | Material exists but cannot be revealed to this observer.    |
+| `ENCRYPTED_KEY_UNAVAILABLE` | Material may exist but the required key is unavailable.     |
+| `MISSING`                   | Material reference exists but bytes are absent.             |
+| `CORRUPT`                   | Material exists but fails digest or semantic validation.    |
+| `OBSTRUCTED`                | Recovery or inspection cannot safely classify the material. |
+
 ## Recovery Certificate
 
 After recovery, Echo should emit a summary that applications and operators can
@@ -731,6 +933,39 @@ Recovered 3 pending submissions, 12 decided submissions, 0 obstructions.
 History verified through LSN 1842.
 ```
 
+`RecoveryCertificate` is a retained/read-model artifact produced by recovery.
+It is not itself causal history unless recovery also commits a runtime posture
+change. If recovery changes future scheduler behavior, Echo should commit an
+explicit runtime-control record such as `RecoveryPostureRecorded`,
+`SchedulerFaultQuarantined`, or `TrustedRuntimeControlRecorded`.
+
+## Debugger Projection Boundary
+
+[warp-ttd] must not treat Echo WAL as a storage source. It must not parse raw
+segments, recover runtime state, truncate tails, or validate commit markers.
+
+[Echo] may project WAL-backed evidence through adapter/read-model facts such
+as:
+
+```text
+CausalCommitEvidence {
+  posture
+  source
+  durabilityMode
+  writerEpoch
+  lsn
+  transactionId
+  commitDigest
+  checkpointDigest?
+  recoveryCertificateDigest?
+  obstruction?
+}
+```
+
+[warp-ttd] inspects those facts through CLI/MCP/read models. Echo remains the
+authority for WAL validation, recovery, runtime admission, scheduler decisions,
+and durable causal commit semantics.
+
 ## WAL Inspector
 
 A future inspector should answer causal questions without replaying the whole
@@ -739,6 +974,7 @@ application in a debugger:
 ```text
 echo wal inspect
 echo wal validate
+echo wal doctor --json
 echo wal recover --read-only
 echo wal explain-submission <id>
 echo wal explain-ticket <id>
@@ -750,8 +986,8 @@ Example explanation:
 ```text
 Accepted at LSN 1042
 Ticket issued at LSN 1057
-Tick receipt committed at LSN 1061
-State delta committed at LSN 1062
+Tick receipt recorded in committed transaction at LSN 1061
+State delta recorded in committed transaction at LSN 1062
 Materialization pending
 ```
 
@@ -784,6 +1020,7 @@ flowchart TD
 Required ugly test names are a feature:
 
 - `crash_after_acceptance_commit_before_ack`
+- `crash_after_submission_commit_before_ack_retry_returns_duplicate_posture`
 - `crash_after_tick_commit_before_publish`
 - `crash_after_material_fsync_before_wal_reference`
 - `crash_during_checkpoint_rename`
@@ -803,25 +1040,22 @@ It should also reject authority leaks such as:
 AppTickCommitted
 ApplicationReceiptIssued
 ClientRuntimeControl
+AppTickRecorded
+JeditEditCommitted
+DocumentStateDelta
 ```
 
-## Initial Slice Order
+## Slice Plan
 
 Implementation should not begin until the ACK contract and recovery validation
 rules are accepted.
 
-Suggested future slices:
-
-1. WAL doctrine, ACK contract, and record grammar.
-2. `WalStorePort` plus deterministic in-memory WAL.
-3. File WAL adapter with segment, checksum, and torn-tail handling.
-4. Witnessed submission WAL integration.
-5. Tick transaction WAL integration.
-6. Retained material reference ordering.
-7. Checkpoint plus WAL-tail recovery.
-8. Recovery certificate and read-only inspector.
-9. Side-effect outbox for materialization.
-10. Crash matrix harness.
+The active forty-five-slice WAL plan lives in `docs/BEARING.md`. The first
+fifteen slices intentionally stop at in-memory WAL grammar, transaction
+building, commit validation, recovery scanning, pure replay, and schema/authority
+linting. Filesystem durability, live submission integration, tick integration,
+checkpointing, outbox materialization, and jedit crash/restart gates remain
+later slices.
 
 ## Release-Gate Witnesses
 
@@ -832,13 +1066,21 @@ The implementation should eventually prove:
 - `crash_after_submission_commit_recovers_pending_submission`
 - `duplicate_submit_after_recovery_returns_duplicate_posture`
 - `same_submission_id_different_envelope_is_protocol_violation`
+- `same_payload_new_submission_id_is_not_duplicate_without_policy`
 - `tick_commit_is_all_or_nothing`
 - `crash_before_tick_commit_commits_no_receipt`
 - `crash_after_tick_commit_recovers_receipt_and_state_delta`
 - `committed_receipt_correlation_rebuilds_after_restart`
 - `torn_wal_tail_after_last_commit_is_truncated`
+- `read_only_recovery_reports_uncommitted_tail_without_truncating`
 - `corrupt_committed_transaction_blocks_recovery`
 - `missing_retained_material_returns_typed_obstruction`
+- `valid_checkpoint_without_checkpoint_published_record_can_be_used_after_validation`
+- `checkpoint_published_without_checkpoint_blocks_or_obstructs_according_to_scope`
+- `materialization_replay_detects_existing_artifact_before_retry`
+- `record_kind_name_does_not_imply_commit_before_transaction_commit`
+- `overlapping_writer_epochs_block_recovery`
+- `strict_object_store_requires_conditional_manifest_commit`
 - `wal_record_schema_contains_no_app_nouns`
 - `application_cannot_append_tick_or_runtime_control_records`
 - `external_effect_requires_committed_outbox_authorization`
@@ -849,22 +1091,31 @@ The implementation should eventually prove:
 Echo's WAL is the durable, append-only commit stream for generic
 causal/runtime transactions.
 
-In strict mode, Echo does not acknowledge accepted submissions, committed tick
-outcomes, or durable runtime posture changes until their WAL transactions are
-flushed under the configured durability policy.
+In strict mode, Echo does not acknowledge accepted submissions, publish tick
+outcomes, or report durable runtime posture changes until the corresponding
+WAL transaction commit has been durably completed under the configured storage
+policy.
 
-Recovery validates and replays only committed transactions, rebuilds indexes
-from WAL/checkpoint material, truncates incomplete tails, and never invents
-half-accepted submissions, half-ticks, uncorrelatable receipts, or invisible
-external side effects.
+Individual WAL records are not history by themselves. History begins at a
+validated WalTransactionCommit.
+
+Recovery validates committed transactions, rejects corrupt committed history,
+ignores or truncates incomplete writable tails according to recovery mode,
+rebuilds indexes from WAL/checkpoint material, and never invents half-accepted
+submissions, half-ticks, uncorrelatable receipts, or unauthorized external
+effects.
 ```
 
 For applications:
 
 ```text
-An application intent submitted through Echo becomes durable only when Echo
-returns accepted submission evidence. After restart, the host can recover that
-intent as not accepted, pending, applied, rejected, or obstructed. External
-artifacts are materialized only from committed Echo history, using idempotent
-side-effect records rather than implicit process-local execution.
+An application intent submitted through Echo becomes Echo-durable only when
+Echo returns accepted submission evidence, or when recovery finds the committed
+acceptance after a crash-before-ack and a retry resolves to stable duplicate
+posture.
+
+After restart, the host can recover that intent as not accepted, accepted
+pending, decided applied, decided rejected, or obstructed. External artifacts
+are materialized only from committed Echo history through explicit idempotent
+side-effect authorization and observation records.
 ```

--- a/docs/design/causal-wal-end-to-end.md
+++ b/docs/design/causal-wal-end-to-end.md
@@ -1,0 +1,870 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Causal WAL End-To-End
+
+Status: design proposal. No implementation is implied by this packet.
+
+## Spine
+
+```text
+A snapshot proves Echo can serialize state.
+A WAL proves Echo can survive interruption between causal events.
+```
+
+Echo may only claim what its WAL can recover.
+
+This document defines an Echo-owned causal write-ahead log for durable generic
+runtime history. It is not an application edit history, debug event stream,
+database feature, undo log, or best-effort append trace. It is the durable
+commit boundary for accepted submissions, scheduler-owned tick outcomes,
+runtime posture changes, retained material references, and recovery evidence.
+
+The central contract is blunt:
+
+```text
+No durable claim without durable evidence.
+No visible outcome without committed history.
+No external effect without committed authorization.
+```
+
+## Goals
+
+- Make accepted submissions recoverable across process death.
+- Make tick outcomes recoverable without half-ticks.
+- Make receipt, ticket, reading, retained material, and runtime posture indexes
+  rebuildable from committed WAL/checkpoint material.
+- Keep application nouns out of Echo WAL schemas.
+- Preserve the authority split: applications submit; trusted runtime ticks.
+- Define the acknowledgement contract before implementation begins.
+- Define filesystem and object-store durability requirements explicitly enough
+  that adapters cannot claim strict durability by accident.
+
+## Non-Goals
+
+- No jedit, file, buffer, cursor, selection, or document semantics in Echo WAL.
+- No user undo or application-level redo.
+- No distributed multi-writer WAL.
+- No hidden retry queue.
+- No application-owned tick, receipt, runtime-control, or recovery record
+  append authority.
+- No claim that WAL alone gives exactly-once external side effects.
+
+## End-To-End Shape
+
+```mermaid
+flowchart TD
+    App[Application or generated adapter]
+    Submit[submit_intent]
+    IntakeTx[Intake WAL transaction]
+    IntakeCommit[Durable commit marker + flush]
+    Ack[Accepted submission evidence]
+    Pending[Recovered pending submission]
+    Scheduler[Trusted scheduler]
+    Stage[Tick-local staging]
+    Material[Durable retained material]
+    TickTx[Tick WAL transaction]
+    TickCommit[Durable commit marker + flush]
+    Publish[Publish runtime indexes]
+    Observe[Observe outcome or reading]
+    Recovery[Recovery replay]
+
+    App --> Submit
+    Submit --> IntakeTx
+    IntakeTx --> IntakeCommit
+    IntakeCommit --> Ack
+    IntakeCommit --> Pending
+    Pending --> Scheduler
+    Scheduler --> Stage
+    Stage --> Material
+    Material --> TickTx
+    TickTx --> TickCommit
+    TickCommit --> Publish
+    Publish --> Observe
+    TickCommit --> Recovery
+    IntakeCommit --> Recovery
+```
+
+The interesting boundary is not the file format. The interesting boundary is
+the acknowledgement line. In strict mode, Echo must not return accepted
+submission evidence until the intake transaction is committed and flushed under
+the active durability policy. A returned acceptance must mean recoverable
+acceptance.
+
+## Authority Planes
+
+```mermaid
+flowchart LR
+    subgraph AppPlane[Application Plane]
+        CanonicalIntent[Canonical intent bytes]
+        AppObserve[Outcome or reading observation]
+    end
+
+    subgraph RuntimePlane[Trusted Runtime Plane]
+        Intake[Intake admission]
+        Scheduler[Scheduler-owned tick]
+        RuntimeControl[Start Stop Cadence Drain Recovery]
+    end
+
+    subgraph WalPlane[Causal WAL Plane]
+        SubmissionRecord[WitnessedSubmissionAccepted]
+        TickRecord[TickReceiptCommitted]
+        ControlRecord[TrustedRuntimeControlRecorded]
+        FaultRecord[SchedulerFaultQuarantined]
+    end
+
+    CanonicalIntent --> Intake
+    Intake --> SubmissionRecord
+    Scheduler --> TickRecord
+    RuntimeControl --> ControlRecord
+    Scheduler --> FaultRecord
+    TickRecord --> AppObserve
+
+    CanonicalIntent -. must not append .-> TickRecord
+    CanonicalIntent -. must not append .-> ControlRecord
+```
+
+Application code may cause a witnessed submission only by passing the canonical
+submit boundary. Application code must never possess append authority for tick,
+receipt, runtime-control, scheduler-fault, or recovery records.
+
+## ACK Contract
+
+Every public API that returns durable evidence must state what was committed
+before return.
+
+| Surface                  | May Return Only After                                           | Meaning Of Return                                            |
+| :----------------------- | :-------------------------------------------------------------- | :----------------------------------------------------------- |
+| Submission intake        | `WitnessedSubmissionAccepted` transaction committed and flushed | Returned accepted evidence is recoverable accepted evidence. |
+| Duplicate submission     | Prior committed submission was found and validated              | Duplicate posture is stable across restart.                  |
+| Tick outcome publication | tick transaction committed and flushed                          | Visible receipt is recoverable receipt.                      |
+| Runtime posture change   | posture transaction committed and flushed                       | Quarantine/control state is recoverable runtime state.       |
+| Retained reading ref     | referenced material durable before WAL reference                | Reading ref is not an empty content-hash guess.              |
+
+Wrong:
+
+```text
+append to memory
+return accepted
+flush later
+```
+
+Right:
+
+```text
+append transaction frames
+append commit marker
+flush under strict policy
+return accepted evidence
+```
+
+Buffered mode may exist for tests and local experimentation, but it must not be
+allowed to satisfy release durability gates.
+
+## WAL Transactions
+
+Initial WAL transactions should be contiguous. Do not interleave transactions
+until a future design proves a need.
+
+```mermaid
+flowchart TD
+    Begin[WalTransactionBegin]
+    R1[Record 1]
+    R2[Record 2]
+    R3[Record 3]
+    Commit[WalTransactionCommit]
+    Flush[Flush durable policy]
+    Ack[Return or publish evidence]
+
+    Begin --> R1 --> R2 --> R3 --> Commit --> Flush --> Ack
+```
+
+Rejected initial shape:
+
+```text
+Begin A
+  record A
+Begin B
+  record B
+Commit B
+  record A
+Commit A
+```
+
+Contiguous transactions keep recovery, truncation, validation, and audit boring.
+Boring survives restarts.
+
+## Sequence: Submission Intake
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App as Application
+    participant Intake as Echo Intake
+    participant Wal as WAL Writer
+    participant Store as WAL Store
+    participant Index as Runtime Indexes
+
+    App->>Intake: submit_intent(canonical envelope)
+    Intake->>Intake: validate envelope and idempotency identity
+    Intake->>Wal: begin intake transaction
+    Wal->>Store: append WitnessedSubmissionAccepted
+    Wal->>Store: append WalTransactionCommit
+    Store-->>Wal: flushed under durability policy
+    Wal-->>Intake: committed transaction
+    Intake->>Index: publish accepted/pending posture
+    Intake-->>App: AcceptedSubmissionEvidence
+```
+
+If the process dies before the commit marker is flushed, the submission was not
+accepted. If it dies after the commit marker is flushed, recovery must restore a
+pending or decided submission posture.
+
+## Sequence: Scheduler Tick
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Host as Trusted Runtime Host
+    participant Sched as Scheduler
+    participant Stage as Tick Staging
+    participant Material as Retained Material Store
+    participant Wal as WAL Writer
+    participant Index as Runtime Indexes
+    participant App as Observer
+
+    Host->>Sched: scheduler opportunity
+    Sched->>Stage: select eligible work
+    Stage->>Stage: compute state deltas and receipts
+    Stage->>Material: write retained materials
+    Material-->>Stage: durable material refs
+    Stage->>Wal: begin tick transaction
+    Wal->>Wal: append receipt, deltas, correlations, refs
+    Wal->>Wal: append WalTransactionCommit
+    Wal-->>Stage: flushed under durability policy
+    Stage->>Index: publish state, receipts, correlations
+    App->>Index: observe outcome
+    Index-->>App: recoverable receipt or reading
+```
+
+A visible receipt implies a recoverable receipt. A recoverable receipt implies
+the required state delta, ticket correlation, retained material refs, and
+semantic coordinates exist or recovery blocks with typed obstruction.
+
+## Sequence: Crash Recovery
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Host as Trusted Host
+    participant Recovery as Recovery Engine
+    participant Checkpoint as Checkpoint Store
+    participant Wal as WAL Segments
+    participant Validator as Semantic Validator
+    participant Index as Rebuilt Indexes
+
+    Host->>Recovery: recover()
+    Recovery->>Checkpoint: load latest valid checkpoint
+    Checkpoint-->>Recovery: checkpoint or fallback
+    Recovery->>Wal: scan segments after checkpoint LSN
+    Wal-->>Recovery: frames and possible torn tail
+    Recovery->>Recovery: group committed contiguous transactions
+    Recovery->>Recovery: truncate uncommitted tail
+    Recovery->>Validator: validate semantic transaction invariants
+    Validator-->>Recovery: valid committed transactions
+    Recovery->>Index: apply pure reducers
+    Recovery-->>Host: RecoveryCertificate
+```
+
+Recovery must replay committed facts. It must not ask the scheduler what should
+have happened. It must not call app code. It must not write files except through
+a separately fenced materialization phase.
+
+## Frame And Transaction Model
+
+```mermaid
+classDiagram
+    class WalFrameHeader {
+        magic
+        wal_version
+        header_len
+        writer_epoch
+        segment_id
+        lsn
+        transaction_id
+        transaction_local_index
+        record_kind
+        payload_len
+        payload_digest
+        previous_frame_digest
+        header_crc
+    }
+
+    class WalFrameTrailer {
+        frame_crc
+    }
+
+    class WalRecordPayload {
+        kind
+        schema_version
+        canonical_bytes
+    }
+
+    class WalTransactionCommit {
+        writer_epoch
+        transaction_id
+        first_lsn
+        last_lsn
+        record_count
+        records_root
+        frontier_before_digest
+        frontier_after_digest
+        previous_committed_transaction_digest
+        durability_mode
+        schema_version
+        commit_digest
+    }
+
+    class WalSegment {
+        segment_id
+        writer_epoch
+        first_lsn
+        sealed_lsn
+    }
+
+    class WriterEpoch {
+        epoch_id
+        started_at_lsn
+        sealed_at_lsn
+        recovered_from_epoch
+    }
+
+    WalSegment "1" --> "1" WriterEpoch
+    WalSegment "1" --> "*" WalFrameHeader
+    WalFrameHeader "1" --> "1" WalRecordPayload
+    WalFrameHeader "1" --> "1" WalFrameTrailer
+    WalTransactionCommit "1" --> "*" WalFrameHeader
+```
+
+Use two integrity mechanisms:
+
+- CRC/checksum for torn-write and corruption detection;
+- cryptographic, domain-separated digests for commitment chains and tamper
+  evidence.
+
+Do not make one mechanism do both jobs.
+
+## Writer Epoch Discipline
+
+The WAL should have one writer actor, but the files must prove that only one
+writer actor was active for a committed range.
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoWriter
+    NoWriter --> EpochActive: WriterEpochStarted
+    EpochActive --> EpochSealed: WriterEpochSealed
+    EpochActive --> RecoveryRequired: crash or unclean shutdown
+    RecoveryRequired --> EpochRecovered: WriterEpochRecovered
+    EpochRecovered --> EpochActive: new writer epoch
+    EpochSealed --> NoWriter
+```
+
+Recovery seeing overlapping writer epochs is a recovery fault. It is not a
+merge opportunity.
+
+## Record Families
+
+```mermaid
+erDiagram
+    WRITER_EPOCH ||--o{ WAL_SEGMENT : owns
+    WAL_SEGMENT ||--o{ WAL_FRAME : contains
+    WAL_TRANSACTION ||--o{ WAL_FRAME : groups
+    WAL_TRANSACTION ||--|| WAL_COMMIT : commits
+    WAL_COMMIT ||--o{ INDEX_FACT : rebuilds
+    WAL_COMMIT ||--o{ RETAINED_REF : references
+    RETAINED_REF ||--|| RETAINED_MATERIAL : requires
+    WAL_COMMIT ||--o{ RECOVERY_CERTIFICATE : contributes_to
+
+    WAL_TRANSACTION {
+      string transaction_id
+      string writer_epoch
+      int first_lsn
+      int last_lsn
+      string transaction_kind
+    }
+
+    WAL_FRAME {
+      int lsn
+      string record_kind
+      string payload_digest
+      string previous_frame_digest
+    }
+
+    WAL_COMMIT {
+      string records_root
+      string frontier_before_digest
+      string frontier_after_digest
+      string commit_digest
+    }
+
+    RETAINED_REF {
+      string material_digest
+      string semantic_coordinate
+      string criticality
+    }
+```
+
+Candidate causal record families:
+
+- `WitnessedSubmissionAccepted`
+- `AdmissionEvidenceRecorded`
+- `LawWitnessRecorded`
+- `AdmissionTicketIssued`
+- `TicketedRuntimeIngressRecorded`
+- `TickReceiptCommitted`
+- `RuntimeStateDeltaCommitted`
+- `ReceiptCorrelationRecorded`
+- `ReadingEnvelopeRetained`
+- `RetainedMaterialRefRecorded`
+- `SchedulerFaultQuarantined`
+- `TrustedRuntimeControlRecorded`
+- `CheckpointPublished`
+- `MaterializationIntentCommitted`
+- `MaterializationEffectObserved`
+
+Diagnostic-only records should live in a separate trace lane. The causal WAL
+should stay clean.
+
+## Causal WAL Versus Diagnostic Trace
+
+```mermaid
+flowchart LR
+    subgraph Causal[Causal WAL]
+        A[Accepted submission]
+        B[Committed tick outcome]
+        C[Runtime posture change]
+        D[Retained material reference]
+        E[Checkpoint publication]
+    end
+
+    subgraph Diagnostic[Diagnostic Trace]
+        F[Tick attempt started]
+        G[Timing sample]
+        H[Debug trace]
+        I[Aborted attempt note]
+    end
+
+    Causal --> Recovery[Recovery and replay]
+    Diagnostic --> Debug[Inspection only]
+```
+
+Failed tick attempts are not causal history. After rollback, Echo may commit a
+runtime posture change such as `SchedulerFaultQuarantined`; that posture is
+causal runtime history because it affects future scheduling.
+
+## Idempotency And Duplicate Submission
+
+Each submission needs a stable idempotency identity:
+
+```text
+submission_id
+client_submission_nonce
+canonical_envelope_digest
+generation
+admission_context_digest
+```
+
+Recovery and retry can then classify:
+
+| Retry Shape                                      | Recovery Posture                                                 |
+| :----------------------------------------------- | :--------------------------------------------------------------- |
+| Same submission id, same canonical envelope      | `AlreadyAcceptedPending`, `AlreadyDecided`, or `AlreadyRejected` |
+| Same submission id, different canonical envelope | protocol violation                                               |
+| New submission id, same canonical envelope       | duplicate semantic submission posture if policy says so          |
+| No committed WAL transaction                     | `NotAccepted`                                                    |
+
+Same id plus different bytes must never overwrite the previous record or become
+a new accepted submission.
+
+## Semantic Validation
+
+Checksums prove bytes survived. They do not prove Echo history is lawful.
+
+Every committed transaction must pass semantic validation before replay.
+
+```mermaid
+flowchart TD
+    Frames[Valid checksums and digest chain]
+    Group[Committed transaction group]
+    Kind[Record kind validator]
+    Authority[Authority validator]
+    Frontier[Frontier validator]
+    Material[Retained material validator]
+    Apply[Apply pure replay reducer]
+    Fault[Recovery fault or typed obstruction]
+
+    Frames --> Group --> Kind --> Authority --> Frontier --> Material --> Apply
+    Kind -. invalid .-> Fault
+    Authority -. invalid .-> Fault
+    Frontier -. mismatch .-> Fault
+    Material -. missing .-> Fault
+```
+
+Examples:
+
+- `WitnessedSubmissionAccepted` requires canonical envelope digest, unique or
+  duplicate-compatible submission identity, and no scheduler-owned records.
+- `TickReceiptCommitted` requires trusted runtime authority, ticket identity,
+  receipt identity, state/correlation records when applicable, and matching
+  `frontier_before_digest`.
+- `RetainedMaterialRefRecorded` requires durable material before the committed
+  WAL reference.
+
+## Rebuildable Indexes
+
+Indexes are caches. WAL plus checkpoints are authoritative.
+
+Rebuildable indexes include:
+
+- `submission_by_id`
+- `pending_submission_queue`
+- `ticket_by_submission`
+- `receipt_by_ticket`
+- `receipt_by_submission`
+- `reading_by_semantic_coordinate`
+- `retained_material_by_digest`
+- `faulted_heads`
+- `runtime_control_posture`
+
+If an index cannot be rebuilt from committed WAL/checkpoint material, it is
+secretly state and should fail review.
+
+## Retained Material Ordering
+
+If a committed WAL record references retained material, the material must
+already be durable.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Stage as Tick Staging
+    participant Material as Material Store
+    participant Wal as WAL Writer
+    participant Recovery as Recovery
+
+    Stage->>Material: write payload or reading bytes
+    Material-->>Stage: durable material digest
+    Stage->>Wal: append retained material ref
+    Wal->>Wal: append transaction commit
+    Wal-->>Stage: flushed commit
+    Recovery->>Wal: replay retained material ref
+    Recovery->>Material: verify material by digest
+    Material-->>Recovery: material exists
+```
+
+Missing material handling should be scoped:
+
+| Missing Material                             | Recovery Response                                         |
+| :------------------------------------------- | :-------------------------------------------------------- |
+| Payload for one recovered pending submission | submission-level obstruction                              |
+| Receipt material for a committed tick        | ticket/submission obstruction or degraded runtime posture |
+| State delta needed to reconstruct frontier   | global recovery fault                                     |
+| Runtime control posture material             | global recovery fault                                     |
+| Diagnostic-only material                     | diagnostic loss, not causal obstruction                   |
+
+## External Side-Effect Fencing
+
+WAL makes Echo history durable. It does not by itself make outside effects
+exactly once.
+
+External effects include:
+
+- writing a file;
+- renaming or deleting a file;
+- updating an external index;
+- notifying another process;
+- exporting a materialized artifact.
+
+Rule:
+
+```text
+No external side effect may be performed before the causal transaction
+authorizing that side effect is durably committed.
+```
+
+Preferred shape:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Echo as Echo Scheduler
+    participant Wal as WAL Writer
+    participant Outbox as Side-Effect Outbox
+    participant Worker as Effect Worker
+    participant Host as Host Filesystem
+
+    Echo->>Wal: commit receipt, state delta, materialization intent
+    Wal-->>Echo: durable commit
+    Echo->>Outbox: publish idempotent effect token
+    Worker->>Outbox: claim effect token
+    Worker->>Host: perform external materialization
+    Worker->>Wal: commit MaterializationEffectObserved
+```
+
+This prevents the bad case:
+
+```text
+file changed
+process died before WAL commit
+recovery says tick never happened
+```
+
+The outbox does not make every external system exactly once. It makes Echo's
+authorization and observation of effects recoverable and idempotent.
+
+## Checkpoints
+
+Checkpoint is an optimization, not authority. The WAL remains the source of
+truth for committed transactions after the checkpoint's included LSN.
+
+```mermaid
+flowchart TD
+    Live[Live recovered state]
+    Temp[Write checkpoint temp file]
+    FsyncTemp[fsync checkpoint temp file]
+    Rename[atomic rename]
+    FsyncDir[fsync containing directory]
+    WalRecord[Commit CheckpointPublished]
+    Recover[Recovery validates checkpoint + WAL tail]
+
+    Live --> Temp --> FsyncTemp --> Rename --> FsyncDir --> WalRecord --> Recover
+```
+
+Checkpoint should bind:
+
+- `checkpoint_id`
+- `writer_epoch`
+- `last_included_lsn`
+- `last_included_commit_digest`
+- `state_root`
+- `index_roots`
+- `retained_material_roots`
+- `schema_version`
+- `created_from_wal_digest`
+
+Recovery verifies that the checkpoint chain matches the WAL chain. If the
+latest checkpoint is invalid, recovery falls back to an earlier checkpoint or
+full WAL replay.
+
+## Filesystem And Object-Store Semantics
+
+Strict filesystem durability must define:
+
+- append frame;
+- flush userspace buffers;
+- fsync WAL file;
+- fsync directory on segment creation or rename;
+- fsync directory on checkpoint rename;
+- handle torn final frame;
+- handle partial segment header;
+- handle missing segment;
+- handle duplicate segment;
+- handle segment gap.
+
+Object stores are not filesystems. A strict object-store adapter must define
+equivalent commit semantics using content-addressed object writes, version or
+ETag verification, conditional manifest publication, and documented
+read-after-write guarantees.
+
+Durability modes:
+
+| Mode                | Meaning                                                    |
+| :------------------ | :--------------------------------------------------------- |
+| `StrictFilesystem`  | File and directory sync semantics satisfy ACK contract.    |
+| `StrictObjectStore` | Object and manifest commit semantics satisfy ACK contract. |
+| `Buffered`          | Development or test mode only; not release durability.     |
+| `ReadOnlyRecovery`  | Recover and inspect without appending.                     |
+| `Disabled`          | Process-local only; cannot claim durable causal history.   |
+
+An adapter must not claim strict durability unless it satisfies the ACK contract
+for the target storage medium.
+
+## Schema Evolution
+
+WAL histories outlive binaries. Every record kind needs:
+
+- kind;
+- version;
+- criticality;
+- canonical encoding version;
+- upgrade rule;
+- unknown-record behavior.
+
+Unknown critical causal records block recovery. Unknown non-critical diagnostic
+records may be skipped only if their integrity validates and they are outside
+the causal WAL.
+
+## Recovery Certificate
+
+After recovery, Echo should emit a summary that applications and operators can
+inspect:
+
+```text
+RecoveryCertificate {
+  checkpoint_used,
+  wal_segments_scanned,
+  first_lsn,
+  last_lsn,
+  committed_transactions_replayed,
+  uncommitted_tail_truncated,
+  obstructions_detected,
+  recovered_frontier_digest,
+  recovered_indexes_digest
+}
+```
+
+For a product such as jedit, this lets the host surface a concrete statement:
+
+```text
+Recovered 3 pending submissions, 12 decided submissions, 0 obstructions.
+History verified through LSN 1842.
+```
+
+## WAL Inspector
+
+A future inspector should answer causal questions without replaying the whole
+application in a debugger:
+
+```text
+echo wal inspect
+echo wal validate
+echo wal recover --read-only
+echo wal explain-submission <id>
+echo wal explain-ticket <id>
+echo wal replay --to-lsn <lsn>
+```
+
+Example explanation:
+
+```text
+Accepted at LSN 1042
+Ticket issued at LSN 1057
+Tick receipt committed at LSN 1061
+State delta committed at LSN 1062
+Materialization pending
+```
+
+## Chaos Harness
+
+The implementation should eventually include crash injection at every critical
+boundary:
+
+```mermaid
+flowchart TD
+    A[after material fsync]
+    B[after WAL append before commit]
+    C[after commit before flush]
+    D[after flush before ack]
+    E[after ack]
+    F[after tick commit before index publish]
+    G[during checkpoint temp write]
+    H[after checkpoint rename before dir fsync]
+
+    A --> RecoverA[recover and assert posture]
+    B --> RecoverB[recover and assert posture]
+    C --> RecoverC[recover and assert posture]
+    D --> RecoverD[recover and assert posture]
+    E --> RecoverE[recover and assert posture]
+    F --> RecoverF[recover and assert posture]
+    G --> RecoverG[recover and assert posture]
+    H --> RecoverH[recover and assert posture]
+```
+
+Required ugly test names are a feature:
+
+- `crash_after_acceptance_commit_before_ack`
+- `crash_after_tick_commit_before_publish`
+- `crash_after_material_fsync_before_wal_reference`
+- `crash_during_checkpoint_rename`
+
+The names should make the boundary visible.
+
+## WAL Schema Linter
+
+The WAL schema should have a mechanical noun guard. Generic record schema may
+contain `canonical_envelope_digest`, `payload_ref`, `semantic_coordinate`,
+`intent_kind`, and `application_namespace`. It must not contain application
+product nouns such as editor, document, cursor, or selection.
+
+It should also reject authority leaks such as:
+
+```text
+AppTickCommitted
+ApplicationReceiptIssued
+ClientRuntimeControl
+```
+
+## Initial Slice Order
+
+Implementation should not begin until the ACK contract and recovery validation
+rules are accepted.
+
+Suggested future slices:
+
+1. WAL doctrine, ACK contract, and record grammar.
+2. `WalStorePort` plus deterministic in-memory WAL.
+3. File WAL adapter with segment, checksum, and torn-tail handling.
+4. Witnessed submission WAL integration.
+5. Tick transaction WAL integration.
+6. Retained material reference ordering.
+7. Checkpoint plus WAL-tail recovery.
+8. Recovery certificate and read-only inspector.
+9. Side-effect outbox for materialization.
+10. Crash matrix harness.
+
+## Release-Gate Witnesses
+
+The implementation should eventually prove:
+
+- `accepted_submission_is_not_returned_before_wal_commit`
+- `crash_before_submission_commit_recovers_not_accepted`
+- `crash_after_submission_commit_recovers_pending_submission`
+- `duplicate_submit_after_recovery_returns_duplicate_posture`
+- `same_submission_id_different_envelope_is_protocol_violation`
+- `tick_commit_is_all_or_nothing`
+- `crash_before_tick_commit_commits_no_receipt`
+- `crash_after_tick_commit_recovers_receipt_and_state_delta`
+- `committed_receipt_correlation_rebuilds_after_restart`
+- `torn_wal_tail_after_last_commit_is_truncated`
+- `corrupt_committed_transaction_blocks_recovery`
+- `missing_retained_material_returns_typed_obstruction`
+- `wal_record_schema_contains_no_app_nouns`
+- `application_cannot_append_tick_or_runtime_control_records`
+- `external_effect_requires_committed_outbox_authorization`
+
+## Final Doctrine
+
+```text
+Echo's WAL is the durable, append-only commit stream for generic
+causal/runtime transactions.
+
+In strict mode, Echo does not acknowledge accepted submissions, committed tick
+outcomes, or durable runtime posture changes until their WAL transactions are
+flushed under the configured durability policy.
+
+Recovery validates and replays only committed transactions, rebuilds indexes
+from WAL/checkpoint material, truncates incomplete tails, and never invents
+half-accepted submissions, half-ticks, uncorrelatable receipts, or invisible
+external side effects.
+```
+
+For applications:
+
+```text
+An application intent submitted through Echo becomes durable only when Echo
+returns accepted submission evidence. After restart, the host can recover that
+intent as not accepted, pending, applied, rejected, or obstructed. External
+artifacts are materialized only from committed Echo history, using idempotent
+side-effect records rather than implicit process-local execution.
+```

--- a/docs/design/causal-wal-hardening-matrix.md
+++ b/docs/design/causal-wal-hardening-matrix.md
@@ -725,3 +725,177 @@ Test plan:
 - `canonical_segment_path_uses_logical_segments_directory`
 - `wall_clock_segment_placement_cannot_be_authoritative`
 - `segment_layout_gate_is_part_of_wal_release_readiness`
+
+## Slice 76: Active Segment Id Enforcement
+
+User story:
+
+As Echo, frames must be appended only to the active logical segment they claim.
+
+Acceptance criteria:
+
+- Filesystem append checks the frame header segment id against the active store
+  segment id.
+- A mismatch returns typed store error instead of writing misleading bytes.
+- Segment id enforcement remains storage-generic and contains no app nouns.
+
+Test plan:
+
+- `filesystem_append_frame_rejects_inactive_segment_id`
+
+## Slice 77: Canonical Segment Rotation
+
+User story:
+
+As Echo, segment rotation should seal the current segment and create the next
+canonical segment under `segments/`.
+
+Acceptance criteria:
+
+- Rotation returns a `WalSegmentSeal` for the previous segment.
+- The active segment id advances monotonically.
+- The new canonical segment file is created under `segments/`.
+- Rotation rejects an existing next segment instead of truncating it.
+- Strict filesystem sync evidence records the new segment file and containing
+  directory sync.
+
+Test plan:
+
+- `filesystem_rotate_segment_creates_next_canonical_segment`
+- `filesystem_rotate_segment_does_not_overwrite_existing_next_segment`
+
+## Slice 78: Rotation Tail Safety
+
+User story:
+
+As Echo, rotation must not seal a segment containing uncommitted frames or a
+torn tail.
+
+Acceptance criteria:
+
+- Rotation inspects the current segment before sealing.
+- Segments with uncommitted frames reject with typed store error.
+- Torn final records reject through the same tail-safety posture.
+
+Test plan:
+
+- `filesystem_rotate_segment_rejects_uncommitted_tail`
+
+## Slice 79: Multi-Segment Recovery
+
+User story:
+
+As recovery, committed transactions split across rotated segments must replay as
+one logical WAL stream.
+
+Acceptance criteria:
+
+- Recovery scans multiple canonical segment files in logical segment-id order.
+- Transactions in later segments recover cleanly.
+- Last committed LSN reflects the logical WAL stream, not one file.
+
+Test plan:
+
+- `filesystem_recovery_reads_transactions_across_rotated_segments`
+
+## Slice 80: Rotation Authority Guard
+
+User story:
+
+As Echo, only the active writer epoch may rotate WAL segments.
+
+Acceptance criteria:
+
+- Rotation requires an active writer epoch.
+- Epoch mismatch rejects before creating the next segment file.
+- The guard preserves the single-writer WAL authority boundary.
+
+Test plan:
+
+- `filesystem_rotate_segment_rejects_epoch_mismatch`
+
+## Slice 81: Manifest Read Roundtrip
+
+User story:
+
+As Echo, published filesystem manifests must be readable as structured WAL
+evidence.
+
+Acceptance criteria:
+
+- Manifest files decode back into `WalManifest`.
+- Decoding uses the same canonical field encoding as publication.
+- Missing manifest remains explicit `None`.
+
+Test plan:
+
+- `filesystem_manifest_read_roundtrips_published_manifest`
+
+## Slice 82: Manifest Segment-Count Validation
+
+User story:
+
+As recovery, a published manifest must not lie about segment count.
+
+Acceptance criteria:
+
+- Validation compares manifest segment count against scanned segment files.
+- Count mismatch returns typed store error.
+- The validation is independent of wall-clock path layout.
+
+Test plan:
+
+- `filesystem_manifest_validation_rejects_segment_count_mismatch`
+- `filesystem_manifest_validation_accepts_matching_segment_summary`
+
+## Slice 83: Manifest Commit-Anchor Validation
+
+User story:
+
+As recovery, a published manifest must match the last committed LSN and commit
+digest recovered from segment contents.
+
+Acceptance criteria:
+
+- Last committed LSN mismatch returns typed store error.
+- Last commit digest mismatch returns typed store error.
+- A matching manifest returns a structured validation report.
+
+Test plan:
+
+- `filesystem_manifest_validation_rejects_last_lsn_mismatch`
+- `filesystem_manifest_validation_rejects_last_digest_mismatch`
+
+## Slice 84: Manifest Tail Safety
+
+User story:
+
+As recovery, a manifest cannot validate while segments contain an uncommitted
+tail.
+
+Acceptance criteria:
+
+- Manifest validation rejects full uncommitted frames after the last commit.
+- Manifest validation rejects torn tails.
+- A manifest never turns incomplete history into accepted disk truth.
+
+Test plan:
+
+- `filesystem_manifest_validation_rejects_uncommitted_tail`
+
+## Slice 85: Manifest Validation Release Gate
+
+User story:
+
+As a maintainer, release readiness must require manifest validation coverage.
+
+Acceptance criteria:
+
+- `WalReleaseReadinessGates` includes `segment_manifest_validation`.
+- Audit output names the missing gate.
+- A fully green readiness report requires manifest validation coverage.
+
+Test plan:
+
+- `segment_manifest_validation_gate_is_part_of_wal_release_readiness`
+- `wal_hardening_gate_passes_when_all_categories_are_green`

--- a/docs/design/causal-wal-hardening-matrix.md
+++ b/docs/design/causal-wal-hardening-matrix.md
@@ -899,3 +899,183 @@ Test plan:
 
 - `segment_manifest_validation_gate_is_part_of_wal_release_readiness`
 - `wal_hardening_gate_passes_when_all_categories_are_green`
+
+## Slice 86: Runtime WAL Adapter Port
+
+User story:
+
+As a trusted runtime host, I need a local WAL adapter at the app-facing ACK
+boundary without giving the application append authority.
+
+Acceptance criteria:
+
+- `TrustedRuntimeHost` owns the runtime WAL adapter.
+- `TrustedRuntimeApp` exposes no WAL append or tick authority.
+- The adapter can be inspected by host tests as read-only evidence.
+
+Test plan:
+
+- `runtime_wal_ack_submit_commits_acceptance_before_returning_handle`
+
+## Slice 87: Submission Acceptance Transaction Wiring
+
+User story:
+
+As a caller, returned accepted submission evidence must be backed by a committed
+submission-intake WAL transaction when using the WAL-backed ACK path.
+
+Acceptance criteria:
+
+- `submit_intent_with_runtime_wal_ack(...)` requires a configured runtime WAL.
+- Accepted submissions record `SubmissionAcceptedRecorded` and acceptance
+  evidence before the handle is returned.
+- The recovered submission index can rebuild the pending submission from WAL.
+
+Test plan:
+
+- `runtime_wal_ack_submit_commits_acceptance_before_returning_handle`
+- Recovered submission index assertion for `AcceptedPending`.
+
+## Slice 88: Duplicate Submit ACK Posture
+
+User story:
+
+As a retrying client, resubmitting the same accepted envelope must not spray
+duplicate WAL acceptance transactions.
+
+Acceptance criteria:
+
+- Duplicate submit returns the original submission id.
+- If WAL evidence already exists, the submission-acceptance transaction count
+  remains unchanged.
+- If the duplicate came from a legacy non-WAL intake path, the WAL ACK path
+  backfills exactly one acceptance transaction before returning.
+
+Test plan:
+
+- `runtime_wal_ack_duplicate_submit_does_not_append_second_acceptance`
+- `runtime_wal_ack_duplicate_without_prior_wal_backfills_acceptance`
+
+## Slice 89: Pre-ACK WAL Failure Rollback
+
+User story:
+
+As Echo, if the WAL cannot commit accepted-submission evidence, the in-memory
+intake mutation must not remain visible.
+
+Acceptance criteria:
+
+- Missing WAL returns an explicit unavailable posture before mutating runtime
+  intake state.
+- WAL build failure restores pre-submit runtime state.
+- Failed WAL ACK does not create witnessed submission history.
+
+Test plan:
+
+- `runtime_wal_ack_path_requires_configured_runtime_wal`
+- `runtime_wal_ack_failure_rolls_back_intake_mutation`
+
+## Slice 90: Tick Receipt Transaction Wiring
+
+User story:
+
+As Echo, visible tick receipts should eventually be backed by committed
+scheduler-tick WAL transactions.
+
+Acceptance criteria:
+
+- Host-owned scheduler runs record receipt and correlation facts before
+  publishing product-facing receipt evidence.
+- The WAL receipt index can rebuild applied/rejected decisions.
+
+Test plan:
+
+- Trusted-host applied-intent fixture.
+- Recovered receipt-index witness.
+
+## Slice 91: Tick Commit-Before-Publish Rollback Guard
+
+User story:
+
+As Echo, a tick WAL failure must not leave a half-visible receipt/outcome.
+
+Acceptance criteria:
+
+- Tick WAL failure either restores runtime/provenance state or blocks receipt
+  publication under typed runtime fault posture.
+- The app-facing outcome cannot observe a receipt whose WAL transaction failed.
+
+Test plan:
+
+- Injected tick-WAL failure fixture.
+- App-facing outcome remains pending or runtime-faulted, never half-decided.
+
+## Slice 92: Runtime Index Rebuild Contract
+
+User story:
+
+As recovery, WAL-backed submission and receipt indexes should rebuild without
+scheduler callbacks.
+
+Acceptance criteria:
+
+- Recovery applies committed WAL facts through pure reducers.
+- No scheduler, wall-clock, app callback, or external I/O participates in index
+  rebuild.
+
+Test plan:
+
+- Pure in-memory recovery fixture for submit plus tick records.
+- Shadow replay comparison for recovered submission/receipt posture.
+
+## Slice 93: WAL-Backed Recovery Certificate In Runtime
+
+User story:
+
+As an operator, restart should produce inspectable evidence about what committed
+history was replayed.
+
+Acceptance criteria:
+
+- Recovery certificate covers checkpoint, LSN range, commit digest, tail
+  posture, and recovered counts.
+- The certificate is evidence, not a new app-domain mutation.
+
+Test plan:
+
+- Recovery certificate fixture over committed and truncated-tail WAL shapes.
+
+## Slice 94: `jedit` Recovery Fixture Contract
+
+User story:
+
+As a real app consumer, `jedit` should be able to distinguish not-accepted,
+accepted-pending, decided, rejected, and obstructed edits from Echo recovery
+evidence.
+
+Acceptance criteria:
+
+- Echo exposes only generic submission/receipt posture.
+- `jedit` maps posture to editor terms outside Echo.
+
+Test plan:
+
+- Sibling `jedit` fixture consumes generic Echo recovery JSON.
+
+## Slice 95: Runtime ACK Drift Gate
+
+User story:
+
+As a maintainer, docs and tests should fail if Echo claims durable ACK semantics
+without a WAL-backed witness.
+
+Acceptance criteria:
+
+- Release readiness names runtime ACK coverage as a distinct gate.
+- Stale claims that accepted submissions are restart-proof without WAL backing
+  are either removed or marked future.
+
+Test plan:
+
+- Runtime ACK readiness gate fixture.
+- Stale-claim grep over docs.

--- a/docs/design/causal-wal-hardening-matrix.md
+++ b/docs/design/causal-wal-hardening-matrix.md
@@ -538,3 +538,190 @@ Test plan:
 - `wal_hardening_gate_includes_app_noun_guard`
 - `wal_hardening_gate_includes_crashpoint_fixture_surface`
 - targeted WAL hardening suite plus app-noun guard and doc checks.
+
+## Slice 66: Canonical Segment Namespace
+
+User story:
+
+As Echo, WAL segment files need a deterministic logical namespace that is not
+derived from wall-clock time.
+
+Acceptance criteria:
+
+- New filesystem WAL roots write segments under a `segments/` directory.
+- Creating the segment namespace syncs the WAL root directory in strict
+  filesystem mode.
+- Segment file names are derived only from logical `WalSegmentId`.
+- Recovery treats logical segment id as the ordering authority.
+- Date or hour partitions are not part of causal recovery truth.
+
+Test plan:
+
+- `canonical_segment_path_uses_logical_segments_directory`
+- `filesystem_segment_namespace_creation_syncs_root_directory`
+- `recovery_scans_canonical_segments_directory`
+
+## Slice 67: Segment Placement Policy Guard
+
+User story:
+
+As Echo, operators may want wall-clock folders for operational convenience, but
+those folders must never become authoritative causal ordering.
+
+Acceptance criteria:
+
+- Authoritative wall-clock placement is rejected.
+- Non-authoritative wall-clock placement may be represented as an adapter-local
+  layout hint.
+- Segment recovery remains manifest/id based, not path-time based.
+
+Test plan:
+
+- `wall_clock_segment_placement_cannot_be_authoritative`
+- `wall_clock_segment_placement_may_be_non_authoritative`
+
+## Slice 68: Legacy Flat Segment Compatibility
+
+User story:
+
+As Echo, existing first-cut WAL roots using flat segment files should remain
+recoverable during migration.
+
+Acceptance criteria:
+
+- Recovery reads flat root-level segment files when no canonical namespace
+  exists.
+- Canonical `segments/` layout is preferred for new writes.
+- Compatibility does not let duplicate segment ids silently win.
+
+Test plan:
+
+- `legacy_flat_segment_scan_remains_readable`
+- `duplicate_segment_id_across_layouts_blocks_recovery`
+
+## Slice 69: Canonical Gap And Rewrite Behavior
+
+User story:
+
+As Echo, segment gap detection and writable recovery rewrites must use the
+canonical namespace consistently.
+
+Acceptance criteria:
+
+- Segment gaps in the canonical namespace block recovery.
+- Writable tail rewrite emits canonical segment paths.
+- Rewrites do not flatten canonical segments back into the root.
+
+Test plan:
+
+- `segment_gap_in_canonical_directory_blocks_recovery`
+- `writable_recovery_rewrite_preserves_canonical_segments_directory`
+
+## Slice 70: Segment Id Rotation Guard
+
+User story:
+
+As Echo, segment rotation must fail explicitly rather than wrapping logical ids.
+
+Acceptance criteria:
+
+- `next_segment_id(None)` starts at logical segment id 1.
+- Incrementing a normal id returns the next logical id.
+- Incrementing `u64::MAX` reports overflow and does not wrap to zero.
+
+Test plan:
+
+- `next_segment_id_overflow_blocks_rotation`
+
+## Slice 71: Segment Manifest Entry Shape
+
+User story:
+
+As Echo, segment manifests should bind logical ids and frame ranges without
+making wall-clock paths authoritative.
+
+Acceptance criteria:
+
+- Manifest entries include segment id, canonical relative path, digest, and LSN
+  bounds.
+- The relative path uses the logical `segments/segment-*.ecwal` shape.
+- Empty segments report no first/last LSN rather than fake zero bounds.
+
+Test plan:
+
+- `segment_manifest_entry_binds_logical_id_not_wall_clock_path`
+
+## Slice 72: Segment Layout Release Gate
+
+User story:
+
+As Echo, release readiness must fail if the WAL segment layout rules are not
+covered.
+
+Acceptance criteria:
+
+- `WalReleaseReadinessGates` includes segment layout coverage.
+- Audit output names the missing `segment_layout_policy` gate.
+- A fully covered hardening gate passes only when this category is green.
+
+Test plan:
+
+- `segment_layout_gate_is_part_of_wal_release_readiness`
+- `wal_hardening_gate_passes_when_all_categories_are_green`
+
+## Slice 73: Manifest-Addressed Placement Doctrine
+
+User story:
+
+As Echo, docs and tests must make the manifest/logical-id model the durable
+truth boundary for segment placement.
+
+Acceptance criteria:
+
+- Segment manifest entries remain logical-id based.
+- Wall-clock partitioning is documented as non-authoritative adapter policy.
+- No test asserts causal meaning from date-derived paths.
+
+Test plan:
+
+- Segment manifest and placement-policy hardening fixtures.
+- `git diff --check`
+
+## Slice 74: Canonical Layout Migration Witness
+
+User story:
+
+As Echo, migration from flat root segment files to `segments/` should be
+test-visible and non-destructive.
+
+Acceptance criteria:
+
+- Flat legacy roots remain readable.
+- Writable recovery rewrites into canonical layout.
+- Duplicate legacy/canonical ids are treated as corruption or obstruction, not
+  as a merge policy.
+
+Test plan:
+
+- `legacy_flat_segment_scan_remains_readable`
+- `writable_recovery_rewrite_preserves_canonical_segments_directory`
+- `duplicate_segment_id_across_layouts_blocks_recovery`
+
+## Slice 75: Segment Layout Drift Gate
+
+User story:
+
+As Echo, future changes must not turn operational path layout into causal
+history.
+
+Acceptance criteria:
+
+- Canonical path tests reject date partitions in durable relative paths.
+- Placement policy validation rejects authoritative wall-clock placement.
+- Release gate coverage fails when segment layout witnesses are missing.
+
+Test plan:
+
+- `canonical_segment_path_uses_logical_segments_directory`
+- `wall_clock_segment_placement_cannot_be_authoritative`
+- `segment_layout_gate_is_part_of_wal_release_readiness`

--- a/docs/design/causal-wal-hardening-matrix.md
+++ b/docs/design/causal-wal-hardening-matrix.md
@@ -1,0 +1,540 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Causal WAL Hardening Matrix
+
+Status: active plan.
+
+This packet is the no-count planning slice for the WAL hardening phase after
+the causal WAL foundation and filesystem recovery gates. The goal is not to
+expand Echo's WAL scope. The goal is to make the existing WAL truth boundary
+harder to fool.
+
+Doctrine:
+
+```text
+Echo may only claim what its WAL can recover.
+No durable claim without durable evidence.
+No visible outcome without committed history.
+No external effect without committed authorization.
+```
+
+The twenty slices below focus on adversarial recovery witnesses, reusable crash
+fixtures, disk-level corruption fixtures, semantic validation negatives, and
+operator/debugger evidence surfaces. They intentionally do not implement WSC,
+distributed WALs, multi-writer replication, user undo, or application-specific
+editing semantics.
+
+## Fixture Surface
+
+The first implementation priority is a reusable fixture surface for hostile WAL
+tests. The fixture surface should let tests assemble repeatable histories and
+then damage them at exact boundaries.
+
+Required fixture capabilities:
+
+- create deterministic temp WAL roots;
+- open a strict filesystem WAL store;
+- append committed submission, tick, checkpoint, retained-reading, and outbox
+  transactions;
+- append uncommitted frames without commit markers;
+- truncate the active segment at named byte boundaries;
+- corrupt record kind, magic, payload, and digest bytes;
+- recover read-only and writable reports;
+- run doctor/inspection without mutating storage;
+- rebuild submission, receipt, retention, outbox, and commit-evidence indexes;
+- compare live state to recovered replay state;
+- report crash scenario name, expected posture, actual posture, and first
+  mismatch.
+
+The first fixture implementation can live in `warp-core` integration tests.
+If the fixture becomes useful outside Rust tests, promote the same shape to a
+CLI/BATS crash runner later. The runner should kill or interrupt Echo at named
+boundaries only after the Rust fixture semantics are stable.
+
+## Test Style
+
+Hardening tests should be ugly and specific. Prefer names that encode the
+failure boundary:
+
+```text
+crash_after_submission_commit_before_ack_retry_returns_duplicate_posture
+read_only_recovery_reports_uncommitted_tail_without_truncating
+corrupt_committed_record_digest_blocks_recovery
+```
+
+Each test should prove one claim. If a fixture helper is needed, add the helper
+first and then add the narrow witness that justifies it.
+
+## No-Count Planning Slice
+
+- [x] Write this hardening plan.
+- [x] Link the plan from `docs/BEARING.md`.
+- [x] Define slices 46-65 with user stories, acceptance criteria, and test
+      plans.
+- [ ] Keep slice checkboxes updated in `docs/BEARING.md` before committing each
+      completed slice.
+
+## Slice 46: WAL Hardening Fixture Surface
+
+User story:
+
+As an Echo maintainer, I need a deterministic fixture surface that can construct
+valid WAL histories and damage them at exact byte/transaction boundaries.
+
+Acceptance criteria:
+
+- A new hardening test fixture can create deterministic filesystem WAL roots.
+- The fixture can append committed submissions and append uncommitted tails.
+- The fixture can truncate active segment files without going through recovery.
+- The fixture can recover read-only and writable reports.
+- The fixture names every crash/corruption scenario in assertion failures.
+
+Test plan:
+
+- `hardening_fixture_recovers_committed_submission`
+- `hardening_fixture_appends_uncommitted_tail`
+- `hardening_fixture_truncates_segment_for_torn_tail`
+- `hardening_fixture_read_only_recovery_does_not_mutate_segment`
+
+## Slice 47: WAL Recovery Golden Corpus
+
+User story:
+
+As Echo, I need a fixed corpus of minimal WAL shapes that proves recovery
+posture across clean, partial, and corrupt histories.
+
+Acceptance criteria:
+
+- Golden fixtures cover clean committed segment, empty WAL, uncommitted tail,
+  torn record, corrupt digest, bad magic, and unknown record kind.
+- Each corpus case asserts transaction count, first/last committed LSN, tail
+  posture, and whether recovery blocks or remains inspectable.
+- Corpus helpers are deterministic and do not depend on wall clock.
+
+Test plan:
+
+- `wal_recovery_golden_clean_committed_segment`
+- `wal_recovery_golden_empty_store`
+- `wal_recovery_golden_uncommitted_tail`
+- `wal_recovery_golden_torn_record`
+- `wal_recovery_golden_corrupt_digest`
+- `wal_recovery_golden_bad_magic`
+- `wal_recovery_golden_unknown_record_kind`
+
+## Slice 48: Submission ACK Crash Matrix
+
+User story:
+
+As an application retrying after a crash, I need Echo to distinguish never
+accepted from accepted-before-ACK.
+
+Acceptance criteria:
+
+- Crash points around submission intake are modeled explicitly.
+- Recovery never invents accepted evidence before commit.
+- Retry after commit-before-ACK returns stable duplicate posture.
+- Same submission id with a different envelope is a protocol violation.
+- New submission id with the same envelope is a new submission unless an
+  explicit policy says otherwise.
+
+Test plan:
+
+- `crash_before_submission_commit_recovers_not_accepted`
+- `crash_after_submission_commit_before_ack_recovers_pending`
+- `crash_after_submission_commit_before_ack_retry_returns_duplicate_posture`
+- `crash_after_submission_commit_before_ack_different_envelope_is_protocol_violation`
+- `new_submission_id_same_envelope_is_not_duplicate_without_policy`
+
+## Slice 49: Tick Commit And Publish Crash Matrix
+
+User story:
+
+As Echo, visible tick outcomes must imply committed recoverable history.
+
+Acceptance criteria:
+
+- Tick receipt, runtime delta, receipt correlation, and index publication
+  boundaries are tested separately.
+- Commit-before-publish recovers receipts and rebuilds indexes.
+- Publish-before-commit is impossible or rejected by the fixture.
+- Failed/uncommitted tick attempt does not advance frontier or become history.
+
+Test plan:
+
+- `crash_before_tick_commit_recovers_no_receipt`
+- `crash_after_tick_commit_before_publish_rebuilds_receipt_indexes`
+- `tick_publish_requires_committed_transaction`
+- `uncommitted_tick_tail_does_not_advance_frontier`
+- `failed_tick_tail_does_not_create_success_receipt`
+
+## Slice 50: Segment Corruption Matrix
+
+User story:
+
+As recovery, segment corruption must produce deterministic posture instead of
+panic, silent skip, or partial history.
+
+Acceptance criteria:
+
+- Torn header, torn payload, torn digest, bad magic, corrupt digest, unknown disk
+  kind, segment gap, and duplicate segment cases are tested.
+- Read-only recovery never mutates files.
+- Writable recovery only truncates incomplete tails.
+- Corrupt committed records block recovery rather than being skipped.
+
+Test plan:
+
+- `torn_segment_header_reports_tail`
+- `torn_segment_payload_reports_tail`
+- `torn_segment_digest_reports_tail`
+- `bad_segment_magic_blocks_recovery`
+- `corrupt_committed_record_digest_blocks_recovery`
+- `unknown_disk_record_kind_blocks_recovery`
+- `segment_gap_blocks_or_obstructs_recovery`
+- `duplicate_segment_id_blocks_recovery`
+
+## Slice 51: Writer Epoch Fencing Matrix
+
+User story:
+
+As Echo, recovery must detect split-writer evidence instead of merging
+conflicting histories.
+
+Acceptance criteria:
+
+- Writer epoch metadata includes fencing evidence in all strict fixtures.
+- Overlapping epochs block recovery.
+- Unknown previous epoch blocks new writer acquisition.
+- Epoch closure and next-epoch continuity are validated.
+- Fencing token mismatch is a recovery fault, not a warning.
+
+Test plan:
+
+- `overlapping_writer_epochs_block_recovery`
+- `unknown_previous_writer_epoch_rejected`
+- `writer_epoch_chain_requires_previous_final_commit_digest`
+- `writer_epoch_fencing_token_mismatch_blocks_recovery`
+- `closed_epoch_allows_next_epoch_with_matching_fence_evidence`
+
+## Slice 52: Transaction Contiguity And Commit Semantics
+
+User story:
+
+As Echo, only complete contiguous committed WAL transactions become history.
+
+Acceptance criteria:
+
+- Transaction frames must be contiguous for the current WAL version.
+- Commit marker binds first LSN, last LSN, record count, and records root.
+- Per-record names never imply commit.
+- Interleaved transactions are rejected.
+
+Test plan:
+
+- `interleaved_transactions_rejected`
+- `commit_record_count_mismatch_rejected`
+- `commit_lsn_range_gap_rejected`
+- `commit_records_root_mismatch_rejected`
+- `record_kind_name_does_not_imply_history_before_commit`
+
+## Slice 53: Semantic Validator Negative Cases
+
+User story:
+
+As Echo, byte-valid WAL transactions must still be rejected if they violate
+runtime law.
+
+Acceptance criteria:
+
+- Digest-valid but semantically invalid transactions are rejected.
+- Submission acceptance cannot include scheduler-owned records.
+- Tick transaction requires trusted scheduler authority.
+- Runtime-control records require runtime authority.
+- Frontier transition kind must match the transaction kind.
+
+Test plan:
+
+- `byte_valid_submission_with_tick_record_rejected`
+- `byte_valid_tick_without_scheduler_authority_rejected`
+- `runtime_control_record_without_runtime_authority_rejected`
+- `frontier_transition_kind_mismatch_rejected`
+- `submission_transaction_with_runtime_posture_record_rejected`
+
+## Slice 54: Checkpoint Crash Matrix
+
+User story:
+
+As recovery, checkpoints must accelerate replay without creating or erasing
+history.
+
+Acceptance criteria:
+
+- Crash before checkpoint rename leaves no usable checkpoint.
+- Crash after checkpoint rename before publication can use the checkpoint if it
+  validates against committed WAL.
+- Published checkpoint with missing material obstructs precisely.
+- Corrupt latest checkpoint falls back or blocks according to documented scope.
+
+Test plan:
+
+- `crash_before_checkpoint_rename_uses_prior_checkpoint_or_full_replay`
+- `valid_checkpoint_without_publication_record_can_be_used`
+- `published_checkpoint_missing_material_obstructs`
+- `corrupt_latest_checkpoint_falls_back_to_prior_valid_checkpoint`
+- `checkpoint_ahead_of_wal_chain_is_rejected`
+
+## Slice 55: Retained Material Before Reference Matrix
+
+User story:
+
+As Echo, committed references must not point at unavailable retained material
+without typed obstruction.
+
+Acceptance criteria:
+
+- Missing submission payload, receipt material, state delta, reading envelope,
+  and checkpoint material map to documented scope.
+- Missing diagnostic-only material does not block causal recovery.
+- Missing state-delta material blocks global recovery if needed to reconstruct
+  frontier.
+- Missing reading material returns obstruction, not empty success.
+
+Test plan:
+
+- `missing_submission_payload_recovers_submission_obstruction`
+- `missing_tick_receipt_material_recovers_receipt_obstruction`
+- `missing_tick_state_delta_blocks_frontier_recovery`
+- `missing_reading_material_returns_obstruction`
+- `missing_diagnostic_material_does_not_block_recovery`
+
+## Slice 56: Side-Effect Outbox Crash Matrix
+
+User story:
+
+As Echo, external effects must never escape before committed authorization and
+must be idempotent after crash.
+
+Acceptance criteria:
+
+- External effect cannot run without committed outbox intent.
+- Existing artifact is detected before retry.
+- Existing mismatched artifact obstructs.
+- Observation commit records already-performed effect.
+- Crash after effect before observation recovers as existing artifact match, not
+  blind retry.
+
+Test plan:
+
+- `external_effect_requires_committed_outbox_authorization`
+- `crash_after_effect_before_observation_detects_existing_artifact`
+- `existing_artifact_digest_mismatch_obstructs`
+- `materialization_observation_marks_effect_already_observed`
+- `outbox_replay_uses_idempotency_token`
+
+## Slice 57: Recovery Reducer Determinism
+
+User story:
+
+As Echo, replay must apply committed facts without scheduler callbacks, wall
+clock, random, network, or app code.
+
+Acceptance criteria:
+
+- Recovery reducer is tested as a pure function.
+- Replaying the same committed transactions twice yields identical roots.
+- Different transaction order rejects or yields a different validated chain; it
+  never silently normalizes.
+- Recovery does not require scheduler or app callback surfaces.
+
+Test plan:
+
+- `pure_replay_same_transactions_same_roots`
+- `pure_replay_order_is_commit_chain_order`
+- `pure_replay_rejects_frontier_mismatch`
+- `recovery_reducer_does_not_require_scheduler`
+- `recovery_reducer_does_not_require_app_callbacks`
+
+## Slice 58: Shadow Replay Harness
+
+User story:
+
+As a maintainer, every mutating WAL path should prove live state equals
+recovered state.
+
+Acceptance criteria:
+
+- Add a reusable helper that runs a live scenario, recovers from WAL, and
+  compares roots/indexes/receipts/readings.
+- Integrate the helper into selected WAL integration tests.
+- Divergence reports enough context to diagnose the first mismatch.
+- Harness remains deterministic and service-free.
+
+Test plan:
+
+- `shadow_replay_submission_path_matches_live`
+- `shadow_replay_tick_path_matches_live`
+- `shadow_replay_retention_path_matches_live`
+- `shadow_replay_outbox_path_matches_live`
+- `shadow_replay_reports_first_mismatch`
+
+## Slice 59: Causal Commit Evidence Projection Matrix
+
+User story:
+
+As [warp-ttd] or an operator, I need commit evidence posture without raw WAL
+ownership.
+
+Acceptance criteria:
+
+- Echo projects causal commit evidence for accepted pending, decided applied,
+  decided rejected, obstructed, and recovery-faulted cases.
+- Projection exposes commit anchor, durability mode, LSN, transaction id, writer
+  epoch, and digest.
+- Projection does not require raw segment paths or recovery authority.
+- Absent durability evidence is explicit.
+
+Test plan:
+
+- `commit_evidence_projects_accepted_pending`
+- `commit_evidence_projects_decided_applied`
+- `commit_evidence_projects_decided_rejected`
+- `commit_evidence_projects_obstructed`
+- `commit_evidence_absent_is_explicit`
+
+## Slice 60: WAL Doctor And Inspector Contract Tests
+
+User story:
+
+As an operator, I need inspection commands/read models to report truth without
+mutating storage.
+
+Acceptance criteria:
+
+- Read-only doctor reports clean, would-truncate, obstructed, corrupt, and
+  missing-material postures.
+- Doctor never truncates or rewrites files.
+- JSON/report shape has stable field names for agents.
+- Recovery certificate fields are present and deterministic.
+
+Test plan:
+
+- `wal_doctor_clean_report_is_stable`
+- `wal_doctor_would_truncate_does_not_mutate`
+- `wal_doctor_corrupt_committed_record_reports_obstructed`
+- `wal_doctor_missing_material_reports_obstruction`
+- `recovery_certificate_has_stable_json_shape`
+
+## Slice 61: Crashpoint Runner Contract
+
+User story:
+
+As Echo, I need a future CLI/BATS crash runner contract that mirrors the Rust
+fixture semantics before it shells out to real processes.
+
+Acceptance criteria:
+
+- Rust crash fixtures define canonical crashpoint names.
+- A test-visible crashpoint manifest lists supported boundaries.
+- The manifest distinguishes simulated in-process cuts from future process-kill
+  cuts.
+- No CLI runner claims more than the Rust fixture proves.
+
+Test plan:
+
+- `crashpoint_manifest_lists_submission_boundaries`
+- `crashpoint_manifest_lists_tick_boundaries`
+- `crashpoint_manifest_lists_checkpoint_boundaries`
+- `crashpoint_manifest_marks_process_kill_as_future_until_runner_exists`
+
+## Slice 62: Filesystem Strict Sync Evidence
+
+User story:
+
+As Echo, strict filesystem mode must make sync boundaries inspectable enough for
+tests to prove ACK ordering.
+
+Acceptance criteria:
+
+- Tests prove commit flushing syncs the WAL file before the caller can observe
+  accepted evidence.
+- Segment creation and manifest/checkpoint rename sync the containing
+  directory.
+- The filesystem adapter does not claim strict durability if any required sync
+  step is bypassed.
+
+Test plan:
+
+- `filesystem_commit_flush_is_ack_boundary`
+- `filesystem_segment_creation_syncs_directory`
+- `filesystem_manifest_rename_syncs_directory`
+- `filesystem_checkpoint_rename_syncs_directory`
+- `filesystem_strict_mode_rejects_missing_sync_evidence`
+
+## Slice 63: Object-Store Manifest Negative Matrix
+
+User story:
+
+As Echo, strict object-store mode must reject adapters that cannot prove
+conditional manifest semantics.
+
+Acceptance criteria:
+
+- Every missing capability has a distinct validation error.
+- Read-after-write uncertainty blocks strict mode.
+- Conditional manifest commit is modeled as compare-and-swap, not overwrite.
+- Object-store strict validation remains mechanism-neutral and app-noun-free.
+
+Test plan:
+
+- `strict_object_store_requires_content_addressed_objects`
+- `strict_object_store_requires_object_version_verification`
+- `strict_object_store_requires_conditional_manifest_commit`
+- `strict_object_store_requires_verified_read_after_write`
+- `strict_object_store_rejects_unconditional_manifest_overwrite`
+
+## Slice 64: Security And Redaction Posture Matrix
+
+User story:
+
+As Echo, recovery and inspection must distinguish missing material from
+policy-hidden or encrypted material.
+
+Acceptance criteria:
+
+- Postures include present, redacted by policy, encrypted-key-unavailable,
+  missing, corrupt, and obstructed.
+- Inspector output distinguishes unavailable-by-policy from missing-by-corrupt
+  storage.
+- Redaction posture does not become success, empty payload, or silent skip.
+
+Test plan:
+
+- `redacted_material_is_policy_posture_not_missing`
+- `encrypted_key_unavailable_is_policy_posture_not_corruption`
+- `missing_material_is_not_redaction`
+- `corrupt_material_is_not_redaction`
+- `inspector_reports_redaction_posture_explicitly`
+
+## Slice 65: WAL Hardening Release Gate
+
+User story:
+
+As Echo, I need one gate that tells us whether the WAL is trustworthy enough for
+the next real-app persistence push.
+
+Acceptance criteria:
+
+- A readiness check aggregates all hardening witnesses.
+- Gate reports blocked and passed categories.
+- Gate includes app-noun guard, shadow replay, crash matrix, doctor, outbox,
+  semantic validator, filesystem, object-store, and projection coverage.
+- `docs/BEARING.md` marks exactly what is complete and what remains future.
+
+Test plan:
+
+- `wal_hardening_gate_reports_blocked_categories`
+- `wal_hardening_gate_passes_when_all_witnesses_green`
+- `wal_hardening_gate_includes_app_noun_guard`
+- `wal_hardening_gate_includes_crashpoint_fixture_surface`
+- targeted WAL hardening suite plus app-noun guard and doc checks.

--- a/docs/man/echo-cli-wal-doctor.1
+++ b/docs/man/echo-cli-wal-doctor.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wal-doctor 1  "echo-cli-wal-doctor "
+.SH NAME
+echo\-cli\-wal\-doctor \- Report read\-only WAL recovery posture
+.SH SYNOPSIS
+\fBecho\-cli\-wal\-doctor\fR [\fB\-h\fR|\fB\-\-help\fR] [\fIROOT\fR]
+.SH DESCRIPTION
+Report read\-only WAL recovery posture
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+[\fIROOT\fR] [default: .]
+Filesystem WAL root to inspect

--- a/docs/man/echo-cli-wal.1
+++ b/docs/man/echo-cli-wal.1
@@ -1,0 +1,20 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wal 1  "echo-cli-wal "
+.SH NAME
+echo\-cli\-wal \- Inspect Echo WAL recovery posture without mutating storage
+.SH SYNOPSIS
+\fBecho\-cli\-wal\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Inspect Echo WAL recovery posture without mutating storage
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.SH SUBCOMMANDS
+.TP
+echo\-cli\-wal\-doctor(1)
+Report read\-only WAL recovery posture
+.TP
+echo\-cli\-wal\-help(1)
+Print this message or the help of the given subcommand(s)

--- a/docs/man/echo-cli.1
+++ b/docs/man/echo-cli.1
@@ -27,5 +27,8 @@ Run benchmarks and format results
 .TP
 echo\-cli\-inspect(1)
 Inspect a WSC snapshot
+.TP
+echo\-cli\-wal(1)
+Inspect Echo WAL recovery posture without mutating storage
 .SH VERSION
 v0.1.0

--- a/scripts/check-no-app-nouns-in-core.sh
+++ b/scripts/check-no-app-nouns-in-core.sh
@@ -21,6 +21,8 @@ CORE_SOURCE_DIRS=(
   "$ROOT_DIR/crates/echo-wasm-abi/src"
 )
 
+# Scope is intentional: production core source must stay generic. Tests and
+# docs may still carry app-shaped fixtures as external-consumer examples.
 matches=0
 for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
   if rg -n --fixed-strings "$pattern" "${CORE_SOURCE_DIRS[@]}"; then

--- a/scripts/check-no-app-nouns-in-core.sh
+++ b/scripts/check-no-app-nouns-in-core.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+FORBIDDEN_PATTERNS=(
+  'Stack Witness'
+  'createBuffer'
+  'replaceRange'
+  'textWindow'
+  'TextBufferOptic'
+  'jedit'
+)
+
+CORE_SOURCE_DIRS=(
+  "$ROOT_DIR/crates/warp-core/src"
+  "$ROOT_DIR/crates/warp-wasm/src"
+  "$ROOT_DIR/crates/echo-wasm-abi/src"
+)
+
+matches=0
+for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+  if rg -n --fixed-strings "$pattern" "${CORE_SOURCE_DIRS[@]}"; then
+    matches=1
+  fi
+done
+
+if [[ "$matches" -ne 0 ]]; then
+  echo "Echo production core source contains app-specific fixture nouns." >&2
+  echo "Keep app nouns in authored contracts, generated adapters, or app repos." >&2
+  exit 1
+fi

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6179,28 +6179,32 @@ fn render_man_pages() -> Result<Vec<(String, Vec<u8>)>> {
     let cmd = warp_cli::cli::Cli::command();
     let mut pages = Vec::new();
 
+    render_man_page_tree(&mut pages, cmd, "echo-cli".to_owned())?;
+    Ok(pages)
+}
+
+fn render_man_page_tree(
+    pages: &mut Vec<(String, Vec<u8>)>,
+    mut cmd: clap::Command,
+    page_name: String,
+) -> Result<()> {
+    // Leak is fine: xtask is short-lived and we need 'static for clap::Str.
+    let static_page_name: &'static str = Box::leak(page_name.clone().into_boxed_str());
+    cmd = cmd.name(static_page_name);
+
     let man = clap_mangen::Man::new(cmd.clone());
     let mut buf: Vec<u8> = Vec::new();
     man.render(&mut buf)
-        .context("failed to render echo-cli.1")?;
+        .with_context(|| format!("failed to render {page_name}.1"))?;
     trim_trailing_ascii_whitespace(&mut buf);
-    pages.push(("echo-cli.1".to_string(), buf));
+    pages.push((format!("{page_name}.1"), buf));
 
     for sub in cmd.get_subcommands() {
         let sub_name = sub.get_name().to_string();
-        // Leak is fine: xtask is short-lived and we need 'static for clap::Str.
-        let prefixed_name: &'static str =
-            Box::leak(format!("echo-cli-{sub_name}").into_boxed_str());
-        let prefixed = sub.clone().name(prefixed_name);
-        let man = clap_mangen::Man::new(prefixed);
-        let mut buf: Vec<u8> = Vec::new();
-        man.render(&mut buf)
-            .with_context(|| format!("failed to render echo-cli-{sub_name}.1"))?;
-        trim_trailing_ascii_whitespace(&mut buf);
-        pages.push((format!("echo-cli-{sub_name}.1"), buf));
+        render_man_page_tree(pages, sub.clone(), format!("{page_name}-{sub_name}"))?;
     }
 
-    Ok(pages)
+    Ok(())
 }
 
 fn trim_trailing_ascii_whitespace(bytes: &mut Vec<u8>) {


### PR DESCRIPTION
## Summary

This PR adds Echo's causal WAL foundation and hardening surface through the first runtime ACK integration cut.

Highlights:
- adds Echo-owned causal WAL primitives, transaction commit markers, writer epochs, record authority checks, recovery indexes, checkpoint/materialization/outbox records, recovery certificates, commit evidence projection, and doctor/inspector surfaces;
- adds filesystem WAL recovery gates, canonical segment layout, rotation, manifest publication/readback, and manifest validation;
- adds app-noun guard coverage so WAL/core record schemas remain generic and free of app/editor nouns;
- adds trusted-runtime WAL ACK integration for submission intake: `submit_intent_with_runtime_wal_ack(...)` commits submission acceptance evidence before returning, backfills exactly one WAL record for legacy duplicate retries, reports missing WAL explicitly, and rolls back intake on pre-ACK WAL failure;
- records the next Runtime WAL ACK slices in `docs/BEARING.md` and `docs/design/causal-wal-hardening-matrix.md`.

## Current Slice Progress

```text
[####################] [Echo] Causal WAL Foundation [45/45 slices]
[####################] [Echo] WAL Hardening Matrix [20/20 slices]
[####################] [Echo] Segment Layout / Rotation / Manifest Hardening [20/20 slices]
[########------------] [Echo] Runtime WAL ACK Integration [4/10 slices]
```

## Validation

- `cargo test -p warp-core --features native_rule_bootstrap,trusted_runtime,host_test --test trusted_runtime_host_loop_tests`
- `cargo clippy -p warp-core --features native_rule_bootstrap,trusted_runtime,host_test --test trusted_runtime_host_loop_tests -- -D warnings`
- `cargo test -p warp-core --test causal_wal_tests`
- `cargo test -p warp-core --test causal_wal_hardening_tests`
- `cargo check -p warp-core`
- `scripts/check-no-app-nouns-in-core.sh`
- `pnpm exec markdownlint-cli2 docs/BEARING.md docs/design/causal-wal-hardening-matrix.md`
- `git diff --check`

Pre-push also ran exact configured slices and passed.

## Next PR Boundary

The next PR should continue Runtime WAL ACK Integration with scheduler/tick receipt publication:
- tick receipt transaction wiring;
- tick commit-before-publish guard;
- pure runtime index rebuild contract;
- runtime recovery certificate integration;
- jedit recovery fixture contract;
- runtime ACK drift gate.
