### PR TITLE
docs(method): formalize leash files as a backlog lane for temporary scaffolds

### DIFF
--- a/crates/method/src/graph.rs
+++ b/crates/method/src/graph.rs
@@ -18,6 +18,7 @@ const GRAPH_LANES: &[&str] = &[
     "inbox",
     "cool-ideas",
     "bad-code",
+    "leash",
 ];
 
 const TASK_SECTION_PREFIX: &str = "## T-";
@@ -1210,6 +1211,10 @@ fn lane_colors(lane: &str) -> (&'static str, &'static str) {
         "inbox" => ("#e5e7eb", "#4b5563"),
         "cool-ideas" => ("#ede9fe", "#7c3aed"),
         "bad-code" => ("#fee2e2", "#b91c1c"),
+        // Amber + dark-orange: "tied, on a clock." Distinct from asap's
+        // soft yellow (urgent but open-ended) — leash files are
+        // structurally committed-to-deletion, not just prioritized.
+        "leash" => ("#fed7aa", "#9a3412"),
         _ => ("#f8fafc", "#64748b"),
     }
 }

--- a/crates/method/src/workspace.rs
+++ b/crates/method/src/workspace.rs
@@ -6,6 +6,18 @@
 use std::path::{Path, PathBuf};
 
 /// Known backlog lane names.
+///
+/// `leash` is the structural-deletion-contract lane defined in
+/// `docs/method/backlog/cool-ideas/METHOD_leash-files.md`. Each file
+/// in `docs/method/backlog/leash/` is a small YAML-frontmatter record
+/// tying a temporary scaffold to its deletion trigger (typically a
+/// cycle/phase) and the symbols whose disappearance proves the
+/// scaffold is gone. Registered here so `cargo xtask method status`
+/// surfaces leash files alongside other backlog lanes; the dedicated
+/// `xtask leash-audit` that walks the trigger / symbol / status
+/// machinery lands separately, after the second leash file gets
+/// created (the "you only need a Tool when you have two of the
+/// thing" rule).
 pub(crate) const LANES: &[&str] = &[
     "inbox",
     "asap",
@@ -13,6 +25,7 @@ pub(crate) const LANES: &[&str] = &[
     "up-next",
     "cool-ideas",
     "bad-code",
+    "leash",
 ];
 
 /// A validated METHOD workspace rooted at a filesystem path.

--- a/crates/method/tests/graph_tests.rs
+++ b/crates/method/tests/graph_tests.rs
@@ -17,6 +17,7 @@ fn scaffold(root: &std::path::Path) {
         "up-next",
         "cool-ideas",
         "bad-code",
+        "leash",
     ] {
         fs::create_dir_all(root.join(format!("docs/method/backlog/{lane}"))).expect("create lane");
     }

--- a/crates/method/tests/status_tests.rs
+++ b/crates/method/tests/status_tests.rs
@@ -18,6 +18,7 @@ fn scaffold(root: &std::path::Path) {
         "up-next",
         "cool-ideas",
         "bad-code",
+        "leash",
     ] {
         fs::create_dir_all(root.join(format!("docs/method/backlog/{lane}"))).ok();
     }
@@ -75,7 +76,29 @@ fn status_counts_lane_files() {
     assert_eq!(report.lanes.get("up-next"), Some(&0));
     assert_eq!(report.lanes.get("cool-ideas"), Some(&0));
     assert_eq!(report.lanes.get("bad-code"), Some(&0));
+    assert_eq!(report.lanes.get("leash"), Some(&0));
     assert_eq!(report.total_items, 5);
+}
+
+#[test]
+fn status_counts_leash_lane_files() {
+    // Regression for the convention registration in
+    // crates/method/src/workspace.rs LANES and graph.rs GRAPH_LANES:
+    // a leash file in docs/method/backlog/leash/ must be visible to
+    // `xtask method status` from day one, so the lane is not invisible
+    // tooling waiting for `xtask leash-audit` to ship.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    scaffold(tmp.path());
+
+    let leash = tmp.path().join("docs/method/backlog/leash");
+    touch_md(&leash.join("PLATFORM_some-scaffold.md"));
+    touch_md(&leash.join("KERNEL_other-scaffold.md"));
+
+    let ws = MethodWorkspace::discover(tmp.path()).expect("discover");
+    let report = StatusReport::build(&ws).expect("status");
+
+    assert_eq!(report.lanes.get("leash"), Some(&2));
+    assert_eq!(report.total_items, 2);
 }
 
 // ── Active cycle detection ──────────────────────────────────────────

--- a/docs/method/backlog/cool-ideas/METHOD_leash-files.md
+++ b/docs/method/backlog/cool-ideas/METHOD_leash-files.md
@@ -91,21 +91,35 @@ context.
 
 ## What tooling has to do
 
-A single script (proposed: `xtask leash-audit`) runs in CI / locally:
+This card lands the lane registration so existing tooling sees
+leash files from day one:
 
-- Parse every `docs/method/backlog/leash/*.md` frontmatter.
+- `crates/method/src/workspace.rs` `LANES` includes `"leash"` so
+  `cargo xtask method status` counts leash files alongside other
+  backlog lanes.
+- `crates/method/src/graph.rs` `GRAPH_LANES` includes `"leash"`
+  and `lane_colors()` gives it an amber + dark-orange palette
+  ("tied, on a clock" — distinct from asap's soft yellow).
+- `crates/method/tests/status_tests.rs` includes
+  `status_counts_leash_lane_files` as a regression so a future
+  refactor cannot silently drop the lane.
+
+The deeper trigger machinery is proposed as a follow-up:
+`xtask leash-audit` runs in CI / locally and:
+
+- Parses every `docs/method/backlog/leash/*.md` frontmatter.
 - For each `active` leash:
     - If the `deletion_trigger.cycle` has closed (look at
       `docs/method/retro/<cycle>/`), promote to `triggered`.
 - For each `triggered` leash:
-    - Grep the leash's repo for every entry in `symbols`. If zero
+    - Greps the leash's repo for every entry in `symbols`. If zero
       hits, promote to `deleted` and move to graveyard. If any hits,
       surface as a warning.
 - For `triggered` leashes older than the configured grace window
   (default: 1 cycle), promote to `escalated`.
 
-The script is dumb on purpose. The hard work is keeping the leash
-records honest, not the matching.
+The audit script is dumb on purpose. The hard work is keeping the
+leash records honest, not the matching.
 
 ## Why this is the right size of mechanism
 
@@ -138,9 +152,11 @@ Phase 2 GREEN.
 
 ## Not in scope here
 
-- The `xtask leash-audit` implementation. Land the convention
-  first; build the audit when the second leash file gets created
-  (the universal "you only need a Tool when you have two of the
+- The `xtask leash-audit` implementation (the trigger / symbol /
+  status transition machinery). This card ships the lane
+  registration so leash files are visible to existing tooling from
+  day one; the audit gets built when the second leash file shows
+  up (the universal "you only need a Tool when you have two of the
   thing" rule).
 - Cross-repo automation that opens deletion PRs automatically. That
   is the natural next step but adds blast radius; ship the manual

--- a/docs/method/backlog/cool-ideas/METHOD_leash-files.md
+++ b/docs/method/backlog/cool-ideas/METHOD_leash-files.md
@@ -1,0 +1,156 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Leash files: a structural lane for temporary scaffolds
+
+Legend: `METHOD`
+
+## The problem
+
+Cross-repo or cross-cycle work routinely produces _temporary scaffolds_:
+client-side mirrors of unfinished engine APIs, transitional adapters,
+"good for now" boundary shims. They are deliberate decisions, not
+mistakes. The failure mode is not introducing them — it is forgetting
+to delete them when their reason expires.
+
+The natural pressure on a working scaffold is to accrete features,
+become depended on, and resist removal. Prose-only backlog cards
+("we'll remember to delete this") rely on humans being the system
+that nags. Humans are goldfish with keyboards.
+
+The 2026-05-30 jedit PR #33 review-resolution session ended with
+exactly this concern about `JeditWorldlineSessionPort` and friends
+("Temporary things love to buy furniture. Don't let it."). The
+prototype response — `jedit/docs/method/backlog/asap/sessions-migration.md`
+— is prose-heavy and human-friendly but not _machine-naggable_.
+
+## The shape
+
+Promote a new backlog lane:
+
+```text
+docs/method/backlog/leash/<scaffold-slug>.md
+```
+
+Each leash file is a small structured record naming a scaffold, the
+event that should free it, and the symbols whose disappearance is the
+deletion proof. The lane sits alongside `asap/`, `bad-code/`,
+`cool-ideas/`, and `graveyard/`; it does not replace any of them. A
+leash and a prose `asap/` card cross-reference each other when both
+exist.
+
+## Required frontmatter
+
+```yaml
+---
+scaffold: JeditWorldlineSessionPort
+repo: jedit
+introduced_by:
+    pr: 33
+    merged_sha: 90245c73
+    date: 2026-05-30
+reason: |
+    Engine-side Session/WorldlineId types do not exist yet; the client
+    carries a transitional mirror so the EINT cutover can ship without
+    blocking on echo cycle 0025 Phase 2.
+deletion_trigger:
+    repo: echo
+    cycle: "0025-sessions-as-causal-contexts"
+    phase: "Phase 2 GREEN"
+symbols:
+    - JeditWorldlineSessionPort
+    - JeditTransportSeam
+    - createInMemoryJeditWorldlineSessionPort
+    - installed-jedit-eint-bridge
+status: active
+companion_cards:
+    - jedit/docs/method/backlog/asap/sessions-migration.md
+---
+```
+
+Required fields: `scaffold`, `repo`, `introduced_by`, `reason`,
+`deletion_trigger`, `symbols`, `status`. Optional but encouraged:
+`companion_cards`, `notes` body section after the frontmatter for
+context.
+
+`status` is one of `active`, `triggered`, `deleted`, `escalated`.
+
+## Lifecycle
+
+1. **`active`** — the scaffold is in production, the trigger has not
+   fired. The leash exists. No action.
+2. **`triggered`** — the deletion trigger condition has been met
+   (e.g. the named cycle/phase closed). Tooling moves the file into
+   `triggered` and surfaces it on the next cycle-close summary.
+3. **`deleted`** — the named symbols are gone from the repo. Tooling
+   confirms via grep and moves the leash file into
+   `docs/method/graveyard/` with the deletion SHA appended.
+4. **`escalated`** — the deletion trigger fired but the symbols
+   still exist after a defined grace window. Tooling promotes the
+   leash to `asap/` and tags the next cycle.
+
+## What tooling has to do
+
+A single script (proposed: `xtask leash-audit`) runs in CI / locally:
+
+- Parse every `docs/method/backlog/leash/*.md` frontmatter.
+- For each `active` leash:
+    - If the `deletion_trigger.cycle` has closed (look at
+      `docs/method/retro/<cycle>/`), promote to `triggered`.
+- For each `triggered` leash:
+    - Grep the leash's repo for every entry in `symbols`. If zero
+      hits, promote to `deleted` and move to graveyard. If any hits,
+      surface as a warning.
+- For `triggered` leashes older than the configured grace window
+  (default: 1 cycle), promote to `escalated`.
+
+The script is dumb on purpose. The hard work is keeping the leash
+records honest, not the matching.
+
+## Why this is the right size of mechanism
+
+- It does not introduce a new project-management tool. It is a
+  backlog lane, same as every other lane.
+- It does not require humans to remember anything. The trigger
+  condition is encoded; tooling notices.
+- It scales: a repo with five active leashes still produces a
+  five-line audit summary.
+- It composes with `asap/`: prose explanations stay where prose
+  explanations belong; structural records stay where structural
+  records belong.
+- It composes with `graveyard/`: completed leashes become a
+  historical record of "we said this was temporary, here is the SHA
+  that proved it."
+
+## Prototype
+
+The first concrete leash, landing alongside this card, is in the
+jedit repo at:
+
+```text
+jedit/docs/method/backlog/leash/jedit-session-port.md
+```
+
+It names `JeditWorldlineSessionPort` + `JeditTransportSeam` +
+`createInMemoryJeditWorldlineSessionPort` + the installed EINT
+bridge as scaffolds whose deletion is bound to Echo cycle 0025
+Phase 2 GREEN.
+
+## Not in scope here
+
+- The `xtask leash-audit` implementation. Land the convention
+  first; build the audit when the second leash file gets created
+  (the universal "you only need a Tool when you have two of the
+  thing" rule).
+- Cross-repo automation that opens deletion PRs automatically. That
+  is the natural next step but adds blast radius; ship the manual
+  audit first.
+
+## Companion memory
+
+The 2026-05-30 session captured the leash-pattern motivation as a
+project memory in the agent's own store; see
+`project-jedit-session-port-leash` in the agent's memory index. That
+memory and this card are the same idea at two altitudes: the memory
+keeps the agent honest in casual touches of the codebase; this card
+keeps METHOD honest at the cycle/process level.


### PR DESCRIPTION
## Summary

Promotes the prototype pattern from jedit PR #33's session-port scaffold ("temporary thing tied to a deletion trigger") into an explicit METHOD lane: \`docs/method/backlog/leash/\`. Companion concrete leash for \`JeditWorldlineSessionPort\` lands separately in the jedit repo.

## What lands

- \`docs/method/backlog/cool-ideas/METHOD_leash-files.md\` — defines the lane, required frontmatter (\`scaffold\`, \`repo\`, \`introduced_by\`, \`reason\`, \`deletion_trigger\`, \`symbols\`, \`status\`), the four-state lifecycle (\`active\` → \`triggered\` → \`deleted\`, with \`escalated\` as the failure mode), and the future \`xtask leash-audit\` shape.

## Why

Cross-repo / cross-cycle work routinely produces deliberate temporary scaffolds. The failure mode is forgetting to delete them when their reason expires. Prose backlog cards rely on humans nagging themselves. Leash files make the machine the nag.

The 2026-05-30 jedit PR #33 review-resolution session ended with exactly this watchout: "Temporary things love to buy furniture. Don't let it." This is the smallest possible mechanism that prevents the furniture-buying.

## Composes with existing lanes

- \`asap/\` keeps prose, structural record lives in \`leash/\`; the \`companion_cards\` field cross-references.
- \`graveyard/\` receives completed leashes with their deletion SHA — historical proof of "we said this was temporary, here is the SHA that proved it."

## Test plan

- [x] Markdownlint clean (0 errors).
- [ ] Reviewer: confirm the frontmatter schema is acceptable before the first concrete leash lands in jedit. If schema needs tweaking, easier to fix here than to migrate two repos.
- [ ] \`xtask leash-audit\` implementation is explicitly out of scope; defer until the second leash file gets created (the "you only need a Tool when you have two of the thing" rule).

## Cross-repo

Companion PR will follow in jedit creating \`jedit/docs/method/backlog/leash/jedit-session-port.md\` using this schema.