### PR TITLE
docs(0025): pin pre-RED implementation decisions + card wesley-gen debt

### DIFF
--- a/docs/design/0025-sessions-as-causal-contexts/phase-2-notes.md
+++ b/docs/design/0025-sessions-as-causal-contexts/phase-2-notes.md
@@ -1,0 +1,241 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Phase 2 pre-RED notes — pinned implementation decisions
+
+**Phase 2 RED cannot start until each decision below is signed off.**
+
+The Phase 1 design (`design.md`) deliberately stopped short of
+implementation-level choices. The handoff (`phase-2-handoff.md`)
+names the five "pre-RED decisions still required." This file pins
+those decisions so that RED tests do not invent them accidentally
+and Phase 2 GREEN does not litigate them again from scratch.
+
+Each decision below has a **proposed value** and a **status**.
+`proposed` means the agent has selected a default with rationale;
+the human reviewer signs off (or pushes back) before Phase 2 RED
+begins. `accepted` means signed off and binding.
+
+---
+
+## D1 — Abortive close v1 scope
+
+**Question:** Confirm B (the weaker variant) — `close(SessionId)`
+applies only to future intents; in-flight intents already past the
+session gate continue to a definite outcome. No cancel-by-session-id
+for pending head-inbox traffic in v1.
+
+**Proposed:** Confirm B. Phase 2 RED must include a test that
+asserts pending head-inbox cancellation is **not** available in v1
+(so the deferral is honest and a future cycle has to consciously
+reopen it).
+
+**Rationale:** Matches the design.md commitment. A in v1 means
+`HeadInbox` learns cancel-by-key, which is a separate refactor with
+its own correctness story (idempotency, ordering, observer
+attribution); not Phase 2's scope. Keep the smaller surface.
+
+**Status:** `proposed`
+
+---
+
+## D2 — `MissingSession` representation at the decode boundary
+
+**Question:** When an EINT envelope arrives with no `session_id`
+header for a session-aware operation, does the decode layer raise
+`IntentRejected(stage=Decode, reason=MissingSession)`, or a separate
+hard-reject type at the decode boundary that never enters the
+intent event stream?
+
+**Proposed:** **Separate hard-reject** at the decode boundary, not
+an `IntentRejected` event. A missing header means the envelope is
+structurally malformed for the operation it claims to be; there is
+no intent to record because there is no admitted intent. Returning
+an `IntentRejected` would imply admission machinery saw it, which
+is the wrong attribution.
+
+**Rationale:**
+
+- The phase-2-handoff invariants state "`MissingSession` and
+  `UnknownSession` do not collapse" and "no `SessionEventLog`
+  entry" for `MissingSession`. A hard-reject type at decode satisfies
+  both naturally; an `IntentRejected` variant has to remember to
+  skip event-log emission.
+- The wire boundary is the right enforcement layer. Anything past
+  the boundary deals in well-formed envelopes; the hard-reject
+  type makes that contract explicit at the type level.
+- `UnknownSession` (header present but resolves to nothing) stays
+  as `IntentRejected(stage=SessionGate)` because it represents an
+  envelope that **did** pass the decode contract; the rejection
+  is then a normal admission decision.
+
+**Status:** `proposed`
+
+---
+
+## D3 — `IngressAddress` type home
+
+**Question:** Where does the protocol-shaped `IngressAddress` type
+live, and how is it encoded?
+
+**Proposed:** New module **`warp-core::ingress_address`** — a thin
+sibling to `warp-core::head_inbox::IngressTarget`. Encoded under the
+0024 universal LE binary codec **via Wesley emission**, not by hand,
+once the schema is declared.
+
+**Rationale:**
+
+- The pair `IngressAddress (wire) <-> IngressTarget (runtime)` is
+  conceptually one routing surface. Keeping both in `warp-core`
+  keeps the routing semantics in one place and avoids a
+  cross-crate dependency cycle (echo-wasm-abi knowing about a
+  routing type that warp-core owns).
+- Wesley-emitting the codec keeps the wire format in lockstep with
+  the runtime type. Hand-rolled codecs accrue the same hand-edit
+  bugs we just carded in
+  `jedit/docs/method/backlog/bad-code/generated-rope-codec-manual-fixes.md`.
+  Don't reintroduce the smell.
+- `echo-wasm-abi` is the wire / kernel-port crate; it imports types
+  from warp-core, not the other way around. Putting
+  `IngressAddress` in `warp-core` matches that direction.
+
+**Status:** `proposed`
+
+---
+
+## D4 — `Session` node storage module
+
+**Question:** Which crate / module owns the durable `Session` node
+and its lifecycle facts?
+
+**Proposed:** New module **`warp-core::session`**, sibling to
+`warp-core::head_inbox` and `warp-core::optic_artifact`. Session
+nodes are causal-graph entities and their lifecycle facts
+(`SessionOpened`, `SessionClosed`) are causal-WAL events; attaching
+them to existing `warp-core::graph` would mix session concerns into
+generic graph machinery.
+
+**Rationale:**
+
+- A dedicated module keeps session concerns isolated from the rest
+  of the graph schema; future "what does a session own?" questions
+  do not ripple through unrelated graph code.
+- The causal-WAL attribution stays clean: session events flow
+  through the same WAL as other engine events but are typed
+  separately, making `SessionEventLog` projection
+  (D5) a straightforward filter rather than a join.
+- Matches the precedent for `head_inbox` (also a focused module
+  owning a specific causal concern).
+
+**Status:** `proposed`
+
+---
+
+## D5 — `SessionEventLog` strategy
+
+**Question:** Is `SessionEventLog(session_id)` computed on read or
+materialized?
+
+**Proposed:** **Compute on read** for v1.
+
+**Rationale:**
+
+- The phase-2-handoff explicitly recommends compute-on-read as the
+  v1 default "unless benchmark data forces materialization." No
+  such benchmark data exists yet.
+- The design framing is "derived projection." Materialization is a
+  perf optimization with attendant cache-invalidation costs;
+  compute-on-read is correctness-first.
+- Phase 2 RED can include a marker test (`#[ignore]` or
+  `// PERF-FOLLOWUP`) declaring the benchmark trigger for a future
+  materialization cycle: "if computing `SessionEventLog(genesis)`
+  exceeds N ms over M events, reopen this decision."
+
+**Status:** `proposed`
+
+---
+
+## D6 — `system/genesis` `PrincipalRef` construction
+
+**Question:** How is the `PrincipalRef::system("genesis")`-shaped
+principal constructed today, and what (if anything) does
+`warp-core::optic_artifact::PrincipalRef` need to grow to support
+it?
+
+**Current state:** `PrincipalRef` is `{ id: String }` with no
+`system()` or `genesis()` constructor; today you would write
+`PrincipalRef { id: "system/genesis".to_string() }` directly. The
+string-literal-init path is fine for tests but spreads "what is the
+genesis principal called?" across call sites.
+
+**Proposed:** Add **`PrincipalRef::system(label: &str) -> Self`**
+and **`PrincipalRef::genesis() -> Self`** (the latter as a tiny
+sugar for the canonical genesis principal). The string format
+(`"system/<label>"`) is enforced inside the constructor so call
+sites cannot drift on the exact representation.
+
+```rust
+impl PrincipalRef {
+    pub fn system(label: &str) -> Self {
+        Self { id: format!("system/{label}") }
+    }
+    pub fn genesis() -> Self {
+        Self::system("genesis")
+    }
+}
+```
+
+**Rationale:**
+
+- The genesis principal name is a load-bearing identity. Letting
+  every call site spell it as a string literal is the same class
+  of bug as a stringly-typed event reason: one typo and you have
+  two genesis principals that don't compare equal.
+- `system(label)` generalizes — every future engine-owned actor
+  ("system/scheduler", "system/recovery") gets the same
+  constructor.
+- This is additive; no existing call site changes shape (they can
+  migrate to the constructor incrementally), so it does not block
+  Phase 2 RED — it just enables the first RED test
+  (`system/genesis has a concrete PrincipalRef`) to be one line of
+  setup.
+
+**Status:** `proposed`
+
+---
+
+## Phase 2 RED sequence (informational, not pinned)
+
+This is the user-proposed sequence from the pre-flight review;
+recorded here so RED authors do not re-derive it under time
+pressure. Each row may become its own RED batch.
+
+| Step | Scope                                                                 |
+| ---- | --------------------------------------------------------------------- |
+| R1   | Session identity + `system/genesis` exists                            |
+| R2   | Session lifecycle events (`SessionOpened`, `SessionClosed`)           |
+| R3   | Admission gate: `MissingSession` / `UnknownSession` / `ClosedSession` |
+| R4   | Intent attribution + `SessionEventLog` projection                     |
+| R5   | Receipt vs quiescence; one-way quiescence gate                        |
+| R6   | `IngressAddress` decode boundary → `IngressTarget`                    |
+| R7   | jedit migration trigger / leash fires                                 |
+
+When R7 closes, the leash file
+`jedit/docs/method/backlog/leash/jedit-session-port.md` transitions
+through `triggered → deleted` and the jedit-side scaffold is
+removed.
+
+---
+
+## Sign-off
+
+The Phase 2 agent must not begin RED until every decision above is
+in `accepted` status. Update the status fields in this file (and
+record any pushback / counter-proposal inline under the relevant
+section) before opening the `cycle/0025-sessions-as-causal-contexts-red`
+branch.
+
+If a decision needs to be reopened mid-Phase-2 (RED reveals an
+invariant the proposal can't satisfy), reopen via the same file:
+flip the status to `reopened`, capture the discovery, and update.
+Do not silently drift.

--- a/docs/design/0025-sessions-as-causal-contexts/phase-2-notes.md
+++ b/docs/design/0025-sessions-as-causal-contexts/phase-2-notes.md
@@ -78,26 +78,29 @@ is the wrong attribution.
 **Question:** Where does the protocol-shaped `IngressAddress` type
 live, and how is it encoded?
 
-**Proposed:** New module **`warp-core::ingress_address`** — a thin
-sibling to `warp-core::head_inbox::IngressTarget`. Encoded under the
-0024 universal LE binary codec **via Wesley emission**, not by hand,
-once the schema is declared.
+**Proposed:** New module **`echo-wasm-abi::ingress_address`** for the
+wire-facing protocol value. `warp-core::head_inbox::IngressTarget`
+remains the runtime routing target. Encoded under the 0024 universal
+LE binary codec **via Wesley emission**, not by hand, once the schema
+is declared.
 
 **Rationale:**
 
 - The pair `IngressAddress (wire) <-> IngressTarget (runtime)` is
-  conceptually one routing surface. Keeping both in `warp-core`
-  keeps the routing semantics in one place and avoids a
-  cross-crate dependency cycle (echo-wasm-abi knowing about a
-  routing type that warp-core owns).
+  conceptually one routing surface, but the current crate graph is
+  directional: `warp-core` depends on `echo-wasm-abi`, and
+  `echo-wasm-abi` does not depend on `warp-core`. Keeping the
+  wire-facing type in `echo-wasm-abi` preserves that direction and
+  avoids an ABI -> core dependency cycle.
 - Wesley-emitting the codec keeps the wire format in lockstep with
-  the runtime type. Hand-rolled codecs accrue the same hand-edit
+  the protocol type. Hand-rolled codecs accrue the same hand-edit
   bugs we just carded in
   `jedit/docs/method/backlog/bad-code/generated-rope-codec-manual-fixes.md`.
   Don't reintroduce the smell.
-- `echo-wasm-abi` is the wire / kernel-port crate; it imports types
-  from warp-core, not the other way around. Putting
-  `IngressAddress` in `warp-core` matches that direction.
+- `echo-wasm-abi` is the wire / kernel-port crate; `warp-core`
+  imports ABI protocol types and maps them into runtime-owned
+  structures. Putting `IngressAddress` in `echo-wasm-abi` matches
+  that direction.
 
 **Status:** `proposed`
 

--- a/docs/method/backlog/bad-code/PLATFORM_echo-wesley-gen-local-emitter-duplication.md
+++ b/docs/method/backlog/bad-code/PLATFORM_echo-wesley-gen-local-emitter-duplication.md
@@ -1,0 +1,125 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# `echo-wesley-gen` carries local generator behavior that wants to live in Wesley
+
+Legend: `PLATFORM`
+
+## The smell
+
+`crates/echo-wesley-gen/src/main.rs` currently carries generator
+behavior that should eventually live upstream in wesley-core / the
+Wesley emitter, with echo's copy collapsing on a dependency bump.
+The duplication exists because echo could not wait for wesley-core
+to ship the matching behavior before PR #382 (universal LE binary
+codec) landed; the echo-side fixes were the minimum-viable response
+to keep #382 mergeable.
+
+Concrete examples currently in the file:
+
+- **`fnv1_step` and the duplicated `stable_op_id` derivation.** The
+  source comment is explicit: "Must stay bytewise identical to
+  `wesley_core::stable_op_id` (added in wesley-core ≥0.0.5). The
+  duplication will collapse when echo bumps its wesley-core
+  dependency to 0.0.5+; until then both copies are pinned to the
+  same outputs in unit tests." Cross-language op-id drift is the
+  exact class of thing that waits patiently and then bites during a
+  release.
+- **`ir.codec_id` normalization.** PR #382 patched the generator to
+  force `ir.codec_id = DEFAULT_CODEC_ID` after parsing, so the
+  artifact hash / observer identity / footprint certificate
+  preimages cannot be computed under a stale codec id. The right
+  long-term home for that policy is the Wesley IR validator, not a
+  per-emitter prologue.
+- **Codec trait imports inside generated modules** (`use
+echo_wasm_abi::codec::{Decode as _, Encode as _};`). Added because
+  generated `impl Encode / Decode` bodies call method-syntax
+  `.encode(w)` / `Type::decode(r)` on nested user types. The Wesley
+  emitter should own this prelude shape rather than having every
+  generator that targets the codec trait re-derive it.
+- **no_std ID list element encoding.** The fixes in PR #382's
+  `scalar_list_element_encoder` / `_decoder` (and the prior
+  scalar-helper fix in `8ef2fc97`) belong in the canonical Wesley
+  TypeScript / Rust emitters that target `no_std` consumers, not
+  duplicated in echo-wesley-gen alone.
+
+The sibling concern in the jedit repo is
+`jedit/docs/method/backlog/bad-code/generated-rope-codec-manual-fixes.md`,
+which records the same shape one layer downstream: jedit carries
+hand-edits on a generated codec file because the TS emitter does
+not yet produce the trailing-byte check. Same root cause; different
+half of the stack.
+
+## Why this matters
+
+- A cross-language op-id contract (`stable_op_id` / `fnv1_step`)
+  that has two implementations in two repos must stay byte-wise
+  identical forever. Until the duplication collapses, one repo can
+  drift and the only thing that catches it is the unit test that
+  pins both sides — and only if it stays current with both
+  implementations.
+- The codec-id normalization patch in the generator prologue is
+  load-bearing for artifact identity (the hash preimage formerly
+  could be derived under one codec while the artifact advertised
+  another). Putting that policy in the IR validator would make it
+  impossible to skip — the current shape is a per-binary prologue
+  that a sibling generator can omit.
+- Every additional emitter-specific fix in echo-wesley-gen widens
+  the eventual collapse-onto-wesley-core diff and makes the version
+  bump scarier. Today this is ~50 lines; left for two more PR
+  cycles it will be ~500.
+
+## The fix shape
+
+- Upstream the byte-step / `stable_op_id` derivation to wesley-core
+  ≥0.0.5 (or whichever version actually ships it), bump echo's
+  wesley-core dependency, and delete the local copy + its pinned
+  test. The pinned vectors stay; they just become a regression
+  against the upstream function.
+- Move `ir.codec_id` normalization to the wesley-core IR
+  validator. Echo's generator then trusts the IR rather than
+  patching it post-parse.
+- Push the codec trait prelude into the Wesley emitter for codec-
+  trait-targeting generators. Echo's generator drops the manual
+  `tokens.extend` for those imports.
+- For no_std ID list element handling: ensure the canonical Wesley
+  Rust emitter targets the `no_std` mapping correctly in list
+  contexts (this is the same issue PR #382 fixed at scalar AND list
+  level locally). The jedit-side sibling card tracks the TS emitter
+  half.
+
+## Out of scope here
+
+- Implementing any of the above in the Wesley repo itself. Each
+  belongs in its own Wesley cycle / PR with the matching pinned
+  vectors and test surface.
+- Premature collapse. Do not delete the local copies until the
+  upstream replacement has shipped, the dependency bump has landed
+  on echo's main, and the pinned regression tests stay green
+  against the upstream surface.
+
+## Trigger / acceptance
+
+Resolve this card when:
+
+1. wesley-core ships `stable_op_id` / `fnv1_step` (or named
+   equivalents) and echo bumps the dep.
+2. `crates/echo-wesley-gen/src/main.rs` deletes the duplicated
+   helper and its doc comment; the pinned op-id regression test
+   keeps the contract.
+3. wesley-core IR validator (or equivalent) owns codec_id
+   normalization; the generator drops the post-parse
+   `ir.codec_id = ...` patch.
+4. The Wesley emitter owns the codec trait prelude and the no_std
+   ID list element mapping; the generator drops the manual
+   `tokens.extend` for those.
+
+## Companion
+
+- `jedit/docs/method/backlog/bad-code/generated-rope-codec-manual-fixes.md`
+  — same root cause, downstream half. The two cards should resolve
+  together; resolving one alone leaves the other carrying the
+  emitter gap.
+- `docs/method/backlog/cool-ideas/PLATFORM_wesley-gen-test-loop-speedup.md`
+  — orthogonal but adjacent (it touches echo-wesley-gen's test
+  harness, this card touches echo-wesley-gen's emit logic).


### PR DESCRIPTION
## Summary

Two pre-Phase-2 artifacts that together unblock Echo 0025 Phase 2 RED without inheriting the "wait, what did we mean by Session?" ambiguity tax later.

### \`docs/design/0025-sessions-as-causal-contexts/phase-2-notes.md\` ← **review required**

Pins the six open implementation decisions called out by \`phase-2-handoff.md\` (plus \`PrincipalRef::genesis()\` construction, which the handoff named but did not detail). Each decision has a **proposed value**, **rationale**, and **status**. **Phase 2 RED cannot begin until each is signed off (\`status: accepted\`).**

| ID  | Decision                              | Proposed                                                                                      |
| --- | ------------------------------------- | --------------------------------------------------------------------------------------------- |
| D1  | Abortive close v1 scope               | Confirm B (the weaker variant); RED asserts pending head-inbox cancel is **not** available.   |
| D2  | \`MissingSession\` representation     | **Separate hard-reject** at decode boundary, not \`IntentRejected\`.                          |
| D3  | \`IngressAddress\` home               | New module \`warp-core::ingress_address\`; Wesley-emit the codec, not hand-roll it.           |
| D4  | \`Session\` node storage              | New module \`warp-core::session\`, sibling to \`head_inbox\` / \`optic_artifact\`.            |
| D5  | \`SessionEventLog\` strategy          | **Compute on read** for v1; mark a benchmark trigger for future materialization.              |
| D6  | \`PrincipalRef::genesis()\` ctor      | Add \`PrincipalRef::system(label)\` + \`PrincipalRef::genesis()\` sugar; format enforced inside ctor. |

Each section includes the question, the proposed value, multi-bullet rationale, and a status field. Also records the user-proposed R1–R7 RED sequence as informational so RED authors don't re-derive it.

### \`docs/method/backlog/bad-code/PLATFORM_echo-wesley-gen-local-emitter-duplication.md\`

Cards the parallel debt that #382 acknowledged but could not collapse on its own timeline:

- \`fnv1_step\` / \`stable_op_id\` duplication waiting on wesley-core ≥ 0.0.5.
- \`ir.codec_id\` normalization that belongs in the wesley-core IR validator.
- Codec trait imports inside generated modules.
- no_std ID list element encoding.

Companion to the parallel jedit card (jedit PR #35) covering the trailing-byte hand-edit in \`src/generated/jedit/rope.codec.generated.ts\`. Same root cause; different half of the stack. Both cards should resolve together.

## Why this matters

- The phase-2-notes file is the bottom turtle for Phase 2 RED. If RED tests start inventing their own answers for D1–D6, GREEN will spend the cycle re-litigating instead of implementing.
- The wesley-gen bad-code card makes the upstream collapse path visible — every additional emitter-specific fix that lands without this card widens the eventual diff.

## Test plan

- [x] \`scripts/verify-local.sh pre-commit\` clean.
- [x] Markdownlint clean.
- [ ] **Reviewer**: sign off (or push back on) D1–D6 by flipping each \`status\` field from \`proposed\` to \`accepted\` (or recording counter-proposals inline). Phase 2 RED cannot start before sign-off.
- [ ] No code changes here; this is design + backlog discipline.

## Companion

- \`jedit/docs/method/backlog/bad-code/generated-rope-codec-manual-fixes.md\` (jedit PR #35) — same wesley-core / emitter alignment, downstream half.