### PR TITLE
docs(method): add backlog cards and hook failure note

### DIFF
--- a/docs/method/backlog/bad-code/PLATFORM_linked-worktree-hooks-use-dotgit-paths.md
+++ b/docs/method/backlog/bad-code/PLATFORM_linked-worktree-hooks-use-dotgit-paths.md
@@ -1,0 +1,103 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Local verification hooks assume `.git` is a directory
+
+Status: active bad-code note.
+
+Legend: `PLATFORM`
+
+## Observed failure
+
+In the linked worktree `/Users/james/git/echo-teardown`, normal `git commit`
+and `git push` both reached the meaningful docs checks, then failed while
+recording local verification state:
+
+```text
+[verify-local] pre-commit: no staged Rust crates detected
+mkdir: .git: Not a directory
+[verify-local] failed after 0s (fresh)
+```
+
+and, after the docs-only pre-push Prettier check passed:
+
+```text
+[verify-local] pre-push docs-only change set
+[verify-local] prettier --check (1 markdown files)
+Checking formatting...
+All matched files use Prettier code style!
+mkdir: .git: Not a directory
+[verify-local] failed after 0s (fresh)
+```
+
+This forced `--no-verify` for otherwise normal non-force commits and pushes
+from that linked worktree.
+
+## Root cause
+
+In a linked Git worktree, `.git` is not a directory. It is a text file like:
+
+```text
+gitdir: /Users/james/git/echo/.git/worktrees/echo-teardown
+```
+
+The hook entrypoints are not the direct problem:
+
+- `.githooks/pre-commit` calls `scripts/verify-local.sh pre-commit`.
+- `.githooks/pre-push` calls `scripts/verify-local.sh pre-push`.
+- `.githooks/_timing.sh` writes hook timing to `${repo_root}/.dx-debug`, which
+  is worktree-safe.
+
+The failure is in `scripts/verify-local.sh`:
+
+```bash
+STAMP_DIR="${VERIFY_STAMP_DIR:-.git/verify-local}"
+VERIFY_TIMING_FILE="${VERIFY_TIMING_FILE:-$STAMP_DIR/timing.jsonl}"
+```
+
+Later, `write_stamp` does:
+
+```bash
+mkdir -p "$STAMP_DIR"
+cat >"$path" <<EOF
+```
+
+That `mkdir -p .git/verify-local` is valid in a normal checkout, but fails in a
+linked worktree because `.git` is a file. The failure happens after the actual
+verification lane has already run, so successful checks can still block the
+operator at the stamp-write step.
+
+There is also an implementation/documentation mismatch: `scripts/hooks/README.md`
+says timing data lands in `$(git rev-parse --git-dir)/verify-local/timing.jsonl`,
+but the script currently defaults to literal `.git/verify-local`.
+
+## Desired fix
+
+Resolve the Git admin directory through Git instead of assuming `.git` is a
+directory:
+
+```bash
+GIT_DIR="$(git rev-parse --path-format=absolute --git-dir)"
+STAMP_DIR="${VERIFY_STAMP_DIR:-$GIT_DIR/verify-local}"
+VERIFY_TIMING_FILE="${VERIFY_TIMING_FILE:-$STAMP_DIR/timing.jsonl}"
+```
+
+Use the same resolved path for stamp files and timing JSONL unless an explicit
+`VERIFY_STAMP_DIR` or `VERIFY_TIMING_FILE` override is supplied.
+
+## Acceptance
+
+1. A regression test creates a temporary repository, adds a linked worktree with
+   `git worktree add`, and proves `scripts/verify-local.sh pre-commit` can write
+   its success stamp from inside that linked worktree.
+2. A docs-only linked-worktree pre-push path can pass its docs checks and write
+   its pre-push stamp without `mkdir: .git: Not a directory`.
+3. Normal non-worktree checkouts still write stamps and timing data successfully.
+4. `scripts/hooks/README.md` and `scripts/plot-prepush-timing.mjs` agree on the
+   resolved default path, or the docs explicitly name the override behavior.
+
+## Out of scope
+
+- Fixing existing VitePress dead links in the docs build.
+- Changing the verification lanes themselves.
+- Weakening hooks or recommending `--no-verify` as normal practice.

--- a/docs/method/backlog/cool-ideas/METHOD_generated-playback.md
+++ b/docs/method/backlog/cool-ideas/METHOD_generated-playback.md
@@ -41,13 +41,25 @@ time Phase 3 starts.
 docs/method/playback/<cycle>/playback.md
 ```
 
-A markdown document where each playback question is a section, and
+A Markdown document where each playback question is a section, and
 each section auto-fills:
 
 - The question (from the scaffold).
 - The matching RED test names and their pass/fail at last run.
 - The witness command(s) and their last-recorded output.
 - A boxed sign-off slot ("Sponsor 1: **_ / Sponsor 2: _**").
+
+Determinism contract:
+
+- Section order is canonical, sorted by explicit `question_id`
+  from the scaffold.
+- Test names within a section are canonical, sorted
+  lexicographically.
+- Witness commands within a section preserve scaffold declaration
+  order.
+- `question_id` is an explicit immutable scaffold field, never
+  derived from mutable prose text, and sign-offs are keyed only by
+  that id.
 
 The doc is regenerable. If a test renames, the next regen picks up
 the new name; if a witness command emits new output, the doc

--- a/docs/method/backlog/cool-ideas/METHOD_generated-playback.md
+++ b/docs/method/backlog/cool-ideas/METHOD_generated-playback.md
@@ -100,6 +100,12 @@ Resolve this card when:
 3. METHOD Phase 3 documentation references the generator as the
    canonical path (hand-written playback docs become an exception,
    not the default).
+4. Two consecutive runs with identical inputs produce
+   byte-identical `docs/method/playback/<cycle>/playback.md`, and
+   sign-off association remains unchanged.
+5. The verification step re-runs `xtask method playback <cycle>` on
+   identical inputs, compares output bytes, and checks the
+   `playback-signoffs.md` question-id mapping is unchanged.
 
 ## Companion
 

--- a/docs/method/backlog/cool-ideas/METHOD_generated-playback.md
+++ b/docs/method/backlog/cool-ideas/METHOD_generated-playback.md
@@ -1,0 +1,96 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Generated playback: derive the Phase 3 doc from RED tests + cycle goals
+
+Legend: `METHOD`
+
+## The pain
+
+METHOD Phase 3 asks the agent to run through every playback
+question and record the witness. The expected artifact is a
+playback document the human reviews and signs off on. In practice:
+
+- Hand-written playback docs go stale the moment a test name
+  changes or a witness command moves.
+- Authoring playback alongside RED-then-GREEN is a separate
+  context switch and routinely gets postponed.
+- A stale playback is worse than no playback — it ratifies a state
+  the code no longer matches.
+
+The structural answer: the playback doc should be a _generated
+artifact_, derived from the same inputs that already exist by the
+time Phase 3 starts.
+
+## What the generator takes as input
+
+- The cycle goal lines from `docs/design/<cycle>/design.md`
+  (already required).
+- The cycle's RED test names — every `#[test]` (Rust) or
+  `t.test('...', ...)` (Node) in the test files marked as part of
+  the cycle.
+- The cycle's acceptance criteria from the design or backlog card
+  (already required to be there).
+- The witness command set from the cycle's playback questions
+  scaffold (a one-line YAML or markdown frontmatter mapping
+  question → command).
+
+## What it emits
+
+```text
+docs/method/playback/<cycle>/playback.md
+```
+
+A markdown document where each playback question is a section, and
+each section auto-fills:
+
+- The question (from the scaffold).
+- The matching RED test names and their pass/fail at last run.
+- The witness command(s) and their last-recorded output.
+- A boxed sign-off slot ("Sponsor 1: **_ / Sponsor 2: _**").
+
+The doc is regenerable. If a test renames, the next regen picks up
+the new name; if a witness command emits new output, the doc
+reflects it. Sign-off slots persist across regens (they live in a
+sibling `<cycle>/playback-signoffs.md` keyed by question id, so the
+generated doc can rewrite freely without nuking signatures).
+
+## Why this is on-brand
+
+- "Architecture with a receipt" applied to the development process
+  itself. Phase 3 is the receipt; generating it from the same
+  inputs that produced Phase 2 GREEN closes the loop.
+- It eliminates the largest source of "stale doc" in the METHOD
+  workflow without removing the human sign-off — the sign-off
+  remains the load-bearing artifact; the doc just stops lying
+  about what it certifies.
+- It makes the "RED test name = playback question shape" coupling
+  explicit. RED authors write test names knowing they will
+  surface in the playback doc, which improves naming discipline.
+
+## Out of scope here
+
+- Auto-generating the cycle design or RED tests from each other.
+  That direction breeds tautology; humans need to author the
+  goals.
+- Replacing the human sign-off step. Generated docs do not
+  ratify; sponsors still do.
+
+## Trigger / acceptance
+
+Resolve this card when:
+
+1. An `xtask method playback <cycle>` command exists and produces
+   `docs/method/playback/<cycle>/playback.md` from the inputs
+   above.
+2. Re-running the command after a test rename produces a doc with
+   the new name and preserves prior sign-offs.
+3. METHOD Phase 3 documentation references the generator as the
+   canonical path (hand-written playback docs become an exception,
+   not the default).
+
+## Companion
+
+- `docs/method/backlog/cool-ideas/METHOD_leash-files.md` — same
+  spirit: structural records that the machine maintains, with
+  prose lanes alongside for the human-readable narrative.

--- a/docs/method/backlog/cool-ideas/PLATFORM_claude-think-remember.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_claude-think-remember.md
@@ -19,7 +19,7 @@ recall (verified by running `--help` after the user flagged the
 misunderstanding). The current surface:
 
 ```text
-think --remember [--brief] [--limit=N] [query]
+claude-think --remember [--brief] [--limit=N] [query]
 ```
 
 This card is therefore two things, not one:

--- a/docs/method/backlog/cool-ideas/PLATFORM_claude-think-remember.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_claude-think-remember.md
@@ -31,9 +31,9 @@ This card is therefore two things, not one:
 
 Add filter flags that the current surface lacks:
 
-- `--since <duration>` (e.g. `--since 7d`, `--since 24h`) so a
-  session-pickup query can scope to recent work without re-ranking
-  ancient entries.
+- `--since <duration>` using canonical ISO 8601 durations (e.g.
+  `--since P7D`, `--since PT24H`) so a session-pickup query can
+  scope to recent work without re-ranking ancient entries.
 - `--repo <name>` to match entries that mention a particular repo
   in their body or were captured while that repo was the cwd. (The
   receipt store may already carry this metadata; if so, this is a
@@ -45,8 +45,8 @@ Acceptance criteria for the enhancement:
 
 ```text
 claude-think --remember "0025 sessions"
-claude-think --remember --since 14d "jedit EINT cutover"
-claude-think --remember --repo echo --since 7d "dev-loop speedup"
+claude-think --remember --since P14D "jedit EINT cutover"
+claude-think --remember --repo echo --since P7D "dev-loop speedup"
 ```
 
 Output for each match:
@@ -96,8 +96,8 @@ the canonical command in CLAUDE.md closes the loop.
 
 Resolve this card when:
 
-1. `claude-think --remember --since <duration>` accepts ISO 8601
-   duration or human-friendly forms and filters correctly.
+1. `claude-think --remember --since <duration>` accepts a single
+   canonical duration format (ISO 8601) and filters correctly.
 2. `claude-think --remember --repo <name>` filters by inferred
    repo metadata.
 3. `~/.claude/CLAUDE.md` updates the session-start ritual to

--- a/docs/method/backlog/cool-ideas/PLATFORM_claude-think-remember.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_claude-think-remember.md
@@ -1,0 +1,104 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# `claude-think --remember`: semantic restore + ritualize the surface
+
+Legend: `PLATFORM`
+
+## The pain we just lived
+
+The 2026-05-30 echo/jedit merge session ended with 764 Think entries,
+multiple handoff breadcrumbs, and context recovery by archaeology.
+The agent's session-start ritual at the time relied on
+`claude-think --recent`, which returns chronological tail — useful
+for "what just happened" but useless for "what did past-me decide
+about Session admission gates."
+
+`claude-think --remember [query]` already exists and does semantic
+recall (verified by running `--help` after the user flagged the
+misunderstanding). The current surface:
+
+```text
+think --remember [--brief] [--limit=N] [query]
+```
+
+This card is therefore two things, not one:
+
+1. A small enhancement proposal to extend the existing surface.
+2. A ritualization proposal so the existing surface gets used.
+
+## Enhancement proposal
+
+Add filter flags that the current surface lacks:
+
+- `--since <duration>` (e.g. `--since 7d`, `--since 24h`) so a
+  session-pickup query can scope to recent work without re-ranking
+  ancient entries.
+- `--repo <name>` to match entries that mention a particular repo
+  in their body or were captured while that repo was the cwd. (The
+  receipt store may already carry this metadata; if so, this is a
+  filter, not a new field.)
+- `--branch <name>` analogous to `--repo`, useful when several
+  branches per repo are live.
+
+Acceptance criteria for the enhancement:
+
+```text
+claude-think --remember "0025 sessions"
+claude-think --remember --since 14d "jedit EINT cutover"
+claude-think --remember --repo echo --since 7d "dev-loop speedup"
+```
+
+Output for each match:
+
+- entry id
+- timestamp
+- semantic rank (or just sorted by relevance)
+- short excerpt
+- inferred repo / branch if known
+
+## Ritualization proposal
+
+The agent's `~/.claude/CLAUDE.md` currently recommends
+`claude-think --recent` as the session-start restore. That should
+become `claude-think --remember "<branch or cycle name>"` because:
+
+- `--recent` returns chronological tail and gets diluted fast on an
+  active project.
+- `--remember "<branch>"` lands the agent on entries that mention
+  the work it is actually about to do.
+- The same call form works for handoff resume (`--remember "echo
+0025 phase 2"`) and for hot-restart after a session-limit reset
+  (`--remember "$(git rev-parse --abbrev-ref HEAD)"`).
+
+The agent has already captured a feedback memory
+(`feedback-verify-tool-surface`) noting this lesson. Ritualizing
+the canonical command in CLAUDE.md closes the loop.
+
+## Why this matters
+
+- The 2026-05-30 session would have skipped ~5 minutes of "where
+  was I?" archaeology with one `--remember` query at the start.
+- Multiply that across every session resumed cold and the savings
+  are non-trivial.
+- Adding `--since` / `--repo` filters is cheap compared to the
+  alternative (each agent invocation paginating through 764 entries
+  scoring by tf-idf or similar).
+
+## Out of scope here
+
+- Building the semantic-search backend. The existing
+  implementation already does this; the enhancement only adds
+  filters on top.
+- Cross-machine sync of the Think store. Different concern.
+
+## Trigger / acceptance
+
+Resolve this card when:
+
+1. `claude-think --remember --since <duration>` accepts ISO 8601
+   duration or human-friendly forms and filters correctly.
+2. `claude-think --remember --repo <name>` filters by inferred
+   repo metadata.
+3. `~/.claude/CLAUDE.md` updates the session-start ritual to
+   `claude-think --remember "<context>"`.

--- a/docs/method/backlog/cool-ideas/PLATFORM_test-timing-history.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_test-timing-history.md
@@ -1,0 +1,106 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Per-test timing history: never discover a 96-second test by vibes again
+
+Legend: `PLATFORM`
+
+## The pain we just lived
+
+The `test_toy_contract_no_std_generated_output_checks_in_consumer_crate`
+integration test took ~96 seconds per run for many cycles before
+anyone felt it strongly enough to act. That test is now ~1.14s after
+the speedup work in PR #383, but the discovery path was wrong:
+
+> 96-second test → multiple hours of compounded irritation → rage fix
+
+That is barbarism. The cost should have been visible in numbers
+before it became rage fuel.
+
+(To be fair: rage fuel did ship PR #383. Don't make this a
+recurring shipping mechanism.)
+
+## The proposal
+
+Every test run records per-test wall-clock to a structured log:
+
+```text
+target/test-timing-history.jsonl
+```
+
+One JSON object per test result, append-only:
+
+```json
+{
+    "ts": "2026-05-31T02:02:29Z",
+    "repo": "echo",
+    "branch": "cycle/0025-sessions-as-causal-contexts",
+    "test_binary": "echo-wesley-gen-generation",
+    "test": "test_toy_contract_no_std_generated_output_checks_in_consumer_crate",
+    "duration_ms": 1140,
+    "status": "pass"
+}
+```
+
+Capture happens via a `cargo test` wrapper or a libtest reporter
+hook (Rust nightly has unstable JSON output; stable can wrap
+`--format=json` parsing). On Node side (jedit), wrap the
+`node --test` JSON reporter.
+
+The JSONL log is gitignored — it is local history, not shared
+state.
+
+## The query surface
+
+A new `xtask slow-tests` subcommand reads the log and surfaces
+anomalies:
+
+```text
+xtask slow-tests --top 20                 # slowest tests overall
+xtask slow-tests --branch current         # slowest on current branch
+xtask slow-tests --since 7d               # slowest in the last week
+xtask slow-tests --regressed-since 7d     # got slower vs prior baseline
+xtask slow-tests --test <name> --history  # timing history for one test
+```
+
+The `--regressed-since` query is the load-bearing one. It catches
+the case where a test was fast yesterday and is slow today —
+exactly the signal that almost-shipped #383 weeks earlier than it
+did.
+
+## Why this matters
+
+- Cost surfacing is the only sustainable defense against test-loop
+  decay. Optimizing once is not enough; you have to notice when it
+  starts decaying again.
+- The dev-loop is now fast (PR #383). Locking it in needs the
+  visibility layer; otherwise the next slow test enters as
+  background friction and only escapes at rage-fuel volume.
+- Cost: one JSONL file per repo + a few hundred lines of xtask
+  code. Lower than the wins it protects.
+
+## Out of scope here
+
+- A CI pipeline that fails on regression. Local visibility first.
+  CI gating is the natural step after a useful baseline exists.
+- A flamegraph / span tracer for slow tests. Different tool; this
+  card is about discovery, not root-cause attribution.
+
+## Trigger / acceptance
+
+Resolve this card when:
+
+1. `cargo test` runs in echo produce / update `target/test-timing-
+history.jsonl` automatically (via wrapper or libtest reporter).
+2. `node --test` runs in jedit do the same.
+3. `xtask slow-tests --top 20` returns the 20 slowest test
+   recordings, sorted by duration.
+4. `xtask slow-tests --regressed-since 7d` returns tests whose
+   median duration over the past 7d exceeded their prior-7d median
+   by some configurable threshold.
+
+## Companion
+
+`docs/method/backlog/cool-ideas/PLATFORM_wesley-gen-test-loop-speedup.md`
+— this card is the regression-defense layer for that speedup work.
+The speedup made the loop fast; this card keeps it that way.

--- a/docs/method/backlog/cool-ideas/PLATFORM_test-timing-history.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_test-timing-history.md
@@ -43,8 +43,9 @@ One JSON object per test result, append-only:
 ```
 
 Capture happens via a `cargo test` wrapper or a libtest reporter
-hook (Rust nightly has unstable JSON output; stable can wrap
-`--format=json` parsing). On Node side (jedit), wrap the
+hook (structured libtest JSON output is a nightly/unstable path;
+on stable, use a wrapper strategy that records per-test timings
+from supported output/reporting surfaces). On Node side (jedit), wrap the
 `node --test` JSON reporter.
 
 The JSONL log is gitignored — it is local history, not shared

--- a/docs/method/backlog/cool-ideas/PLATFORM_xtask-leash-audit-stub.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_xtask-leash-audit-stub.md
@@ -88,7 +88,9 @@ Resolve this card when:
 
 1. `cargo xtask leash-audit` reads every
    `docs/method/backlog/leash/*.md` frontmatter and prints the
-   active leashes with per-symbol grep hit counts.
+   active leashes with per-symbol grep hit counts. Leashes are
+   printed in canonical order by `scaffold`, then `repo`, and
+   per-leash symbols are sorted lexicographically.
 2. The grep is run against the leash's declared `repo` working
    tree (resolved via a configurable repo-root map, or against the
    current working directory when no map is provided).

--- a/docs/method/backlog/cool-ideas/PLATFORM_xtask-leash-audit-stub.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_xtask-leash-audit-stub.md
@@ -101,6 +101,6 @@ Resolve this card when:
 
 - `docs/method/backlog/cool-ideas/METHOD_leash-files.md` — the
   convention this audit walks.
-- `jedit/docs/method/backlog/leash/jedit-session-port.md` — the
-  first leash, and the one that will make this tool
-  immediately useful.
+- `https://github.com/flyingrobots/jedit/blob/main/docs/method/backlog/leash/jedit-session-port.md`
+  — the external jedit leash that will make this tool immediately
+  useful.

--- a/docs/method/backlog/cool-ideas/PLATFORM_xtask-leash-audit-stub.md
+++ b/docs/method/backlog/cool-ideas/PLATFORM_xtask-leash-audit-stub.md
@@ -1,0 +1,104 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# `xtask leash-audit` (minimum viable): print the leash state, don't transition yet
+
+Legend: `PLATFORM`
+
+## The argument for building it _now_
+
+The convention card
+`docs/method/backlog/cool-ideas/METHOD_leash-files.md` deferred the
+full `xtask leash-audit` machinery (trigger/symbol/status
+transitions, grep against repo state, automatic graveyard moves)
+under the "you only need a Tool when you have two of the thing"
+rule.
+
+That rule is correct in steady state. But the 2026-05-30 pre-Phase-2
+review surfaced a sharper observation: **Phase 2 GREEN is precisely
+the moment the first leash should fire.** If the audit machinery
+does not exist when that moment arrives, the jedit session-port
+scaffold becomes barnacle by default.
+
+A _minimum_ version of `xtask leash-audit` would prevent that
+default without committing to the full state-machine yet.
+
+## Minimum viable shape
+
+A single subcommand that reads every `docs/method/backlog/leash/
+*.md` frontmatter and prints a structured table.
+
+```text
+$ cargo xtask leash-audit
+Active leashes (1):
+
+  ┌────────────────────────────────────────────────────────────┐
+  │ scaffold: JeditWorldlineSessionPort                        │
+  │ repo:     jedit                                            │
+  │ trigger:  echo cycle 0025-sessions-as-causal-contexts      │
+  │           phase Phase 2 GREEN                              │
+  │ status:   active                                           │
+  │                                                            │
+  │ symbols still present in jedit (per declared grep):        │
+  │   ✓ JeditWorldlineSessionPort         (4 hits in src/)     │
+  │   ✓ JeditWorldlineSessionNotRegistered (3 hits in src/)    │
+  │   ✓ JeditWorldlineId                  (7 hits)             │
+  │   ✓ JeditTransportSeam                (5 hits)             │
+  │   ✓ jeditSessionPort                  (8 hits in src+spec) │
+  │   ✓ createInMemoryJeditWorldlineSessionPort (2 hits)       │
+  │   ✓ installed-jedit-eint-bridge       (3 hits)             │
+  └────────────────────────────────────────────────────────────┘
+```
+
+What it does NOT do (yet):
+
+- Transition statuses automatically (`active → triggered →
+deleted`). Phase 2 GREEN will fire the first trigger manually;
+  the state machine grows out of that real example.
+- Walk `docs/method/retro/<cycle>/` to detect closed cycles.
+  Future work after the first transition is recorded by hand.
+- Open PRs to move resolved leashes into graveyard. Adds blast
+  radius; ship the audit first.
+- Cross-repo execution. The minimum version runs against one repo
+  at a time. The leash file declares its target `repo`; the audit
+  treats that as a label, not a remote operation.
+
+## Why this size
+
+- Reading frontmatter and grepping symbols is ~100 lines of
+  xtask code; the state machine is the part that grows over time.
+- Printing the table is enough to make the leash visible at the
+  right cadence (CI, weekly review, cycle close).
+- A useful tool ships before the trigger fires; the missing
+  features get added when their absence hurts.
+
+## When the full machinery becomes useful
+
+Specifically: when there are at least two active leashes _and_ at
+least one of them has crossed its trigger. At that point the
+manual "did X close? have the symbols disappeared?" check is paying
+real cost and the state-machine investment is justified.
+
+Until then: the minimum version is the leash, the leash is the
+minimum version.
+
+## Trigger / acceptance
+
+Resolve this card when:
+
+1. `cargo xtask leash-audit` reads every
+   `docs/method/backlog/leash/*.md` frontmatter and prints the
+   active leashes with per-symbol grep hit counts.
+2. The grep is run against the leash's declared `repo` working
+   tree (resolved via a configurable repo-root map, or against the
+   current working directory when no map is provided).
+3. The command exits non-zero if any leash references a `repo`
+   that cannot be resolved, so misconfiguration is visible.
+
+## Companion
+
+- `docs/method/backlog/cool-ideas/METHOD_leash-files.md` — the
+  convention this audit walks.
+- `jedit/docs/method/backlog/leash/jedit-session-port.md` — the
+  first leash, and the one that will make this tool
+  immediately useful.

--- a/docs/method/backlog/cool-ideas/WESLEY_ir-structural-diff.md
+++ b/docs/method/backlog/cool-ideas/WESLEY_ir-structural-diff.md
@@ -87,8 +87,13 @@ Wesley cycle.
 ## How it gets used
 
 - Pre-push gate on any change that touches a `.ir.json` or a
-  `.graphql` schema: run `wesley diff origin/main HEAD` and refuse
-  the push if breaking changes are present without a version bump.
+  `.graphql` schema: materialize base and head IR artifacts first
+  (for example, `target/wesley-diff/base.ir.json` and
+  `target/wesley-diff/head.ir.json`), then run
+  `wesley diff target/wesley-diff/base.ir.json target/wesley-diff/head.ir.json`.
+  The hook never passes git refs directly to `wesley diff`; it
+  refuses the push if breaking changes are present without a
+  version bump.
 - PR review: a bot posts the diff classification on every schema-
   touching PR. Reviewers no longer need to mentally model "did
   this hash change?"

--- a/docs/method/backlog/cool-ideas/WESLEY_ir-structural-diff.md
+++ b/docs/method/backlog/cool-ideas/WESLEY_ir-structural-diff.md
@@ -1,0 +1,132 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# `wesley diff <old-ir> <new-ir>`: structural classifier for schema migrations
+
+Legend: `PLATFORM`
+
+## The motivation
+
+The 2026-05-30 review pass on PR #382 surfaced a class of bug that
+was structurally hard to spot from a code diff alone: stale
+`codec_id` in inline IR fixtures, enum reorders that would silently
+break `SCHEMA_SHA256` parity with mixed-version peers, append-only
+enum-compatibility claims that the framing itself contradicted.
+
+These are not code review smells — they are _schema migration
+smells_. They all share a shape: "the IR changed in a way that
+looks small but reaches outside the file via hash preimages, op-id
+derivation, or cross-language wire contracts."
+
+A `wesley diff` tool would classify these structurally instead of
+relying on a reviewer's ability to remember which IR edits are
+load-bearing.
+
+## What it classifies
+
+Given two Wesley IR JSON files (or their generated artifacts), emit
+a structured report:
+
+**Breaking (will fail mixed-version peers):**
+
+- enum reorder
+- enum append (because `SCHEMA_SHA256` is the version gate;
+  appending changes the hash and breaks any peer not on the new
+  schema — the design.md for cycle 0024 carries this exact claim
+  now after the doc-fix in PR #382)
+- field removal
+- field type change
+- field cardinality change (single → list, nullable → required,
+  etc.)
+- `codec_id` change
+- op-id preimage change (operation rename, kind change,
+  reordering that affects FNV step inputs)
+
+**Potentially safe (still version-gated, but additive):**
+
+- new operation
+- new type not referenced by any existing operation or field
+- additive field with explicit default (if/when the IR supports
+  one)
+
+**Drift (smells but doesn't break):**
+
+- inline-IR `codec_id` mismatch with `DEFAULT_CODEC_ID`
+- comment / documentation changes
+- whitespace / ordering in non-significant positions
+
+## Output shape
+
+JSON (machine-readable, for CI gating) and a human-readable
+summary (for code review). Example:
+
+```text
+$ wesley diff old.ir.json new.ir.json
+
+Breaking changes (1):
+  - Enum reorder: TextDirection variant order changed from
+    [Ltr, Rtl] to [Rtl, Ltr]. SCHEMA_SHA256 will change.
+
+Potentially safe additions (2):
+  - New operation: createCheckpoint
+  - New type: CheckpointKind (referenced by createCheckpoint)
+
+Drift (1):
+  - Inline IR codec_id "cbor-canon-v1" differs from
+    DEFAULT_CODEC_ID "le-binary-v1"
+```
+
+## Where it lives
+
+The natural home is the Wesley repo itself (alongside the emitter
+and the IR validator). Echo could vendor a thin wrapper for CI.
+The card belongs in echo because that is the repo that just paid
+the cost of not having it; the actual implementation will need a
+Wesley cycle.
+
+## How it gets used
+
+- Pre-push gate on any change that touches a `.ir.json` or a
+  `.graphql` schema: run `wesley diff origin/main HEAD` and refuse
+  the push if breaking changes are present without a version bump.
+- PR review: a bot posts the diff classification on every schema-
+  touching PR. Reviewers no longer need to mentally model "did
+  this hash change?"
+- Local: developers can ask `wesley diff` before committing to
+  preview what their change implies.
+
+## Why this prevents the most review churn
+
+- The 0024-design append-only claim (corrected in PR #382) was a
+  doc bug rooted in a misread of the version gate. `wesley diff`
+  would have flagged the proposed enum append as "breaking
+  (SCHEMA_SHA256 change)" the moment the IR moved, eliminating the
+  doc inconsistency at the source.
+- Inline-IR `codec_id` drift across the eight `tests/generation.rs`
+  fixtures would have been surfaced as "drift" the first time it
+  diverged from `DEFAULT_CODEC_ID`, instead of accumulating across
+  cycles.
+- The current `op_id` derivation duplication between echo and
+  wesley-core (carded in
+  `bad-code/PLATFORM_echo-wesley-gen-local-emitter-duplication.md`)
+  becomes safer to collapse because the diff tool can prove that
+  the upstream output matches the local output across the entire
+  pinned vector set.
+
+## Out of scope here
+
+- Visualizing the diff in a UI. JSON + text is enough for the
+  90% case.
+- Auto-fixing breaking changes (e.g. proposing a version bump).
+  Classification is a complete unit of work; mitigation is a
+  follow-up.
+
+## Companion
+
+- `docs/method/backlog/bad-code/PLATFORM_echo-wesley-gen-local-emitter-duplication.md`
+  — partially blocked by the existence of this tool (the upstream
+  collapse becomes safer with a diff classifier).
+- `docs/method/backlog/cool-ideas/PLATFORM_wesley-emitted-fixture-vectors.md`
+  — adjacent: cross-boundary fixture parity. Wesley diff classifies
+  IR changes; emitted fixture vectors classify wire-byte changes.
+  Both close the same family of bugs from different angles.


### PR DESCRIPTION
## Summary

This PR records METHOD backlog notes so the ideas and observed tooling debt stay visible instead of living only in session memory.

It currently includes:

| Card | Lane | Purpose |
| --- | --- | --- |
| `PLATFORM_claude-think-remember.md` | cool-ideas | Proposes `codex-think --remember` filtering and ritualizing it in session-start guidance. |
| `PLATFORM_test-timing-history.md` | cool-ideas | Adds local per-test timing telemetry and `xtask slow-tests` query ideas to protect dev-loop speed. |
| `WESLEY_ir-structural-diff.md` | cool-ideas | Proposes `wesley diff <old-ir> <new-ir>` for schema/IR compatibility classification. |
| `METHOD_generated-playback.md` | cool-ideas | Proposes generated playback docs derived from cycle goals, tests, acceptance, and witness commands. |
| `PLATFORM_xtask-leash-audit-stub.md` | cool-ideas | Proposes a minimum viable leash audit surface for active temporary scaffolds. |
| `PLATFORM_linked-worktree-hooks-use-dotgit-paths.md` | bad-code | Documents the local hook failure where `scripts/verify-local.sh` assumes `.git` is a directory and fails in linked worktrees after checks pass. |

## Why this matters

The five cool-ideas cards preserve the 2026-05-30 brainstorm in the filesystem backlog. The linked-worktree hook note captures a concrete operator-facing failure observed while committing from `/Users/james/git/echo-teardown`: local validation passed, but stamp writing failed with `mkdir: .git: Not a directory` because linked worktrees store `.git` as a pointer file.

## Validation

- [x] `scripts/verify-local.sh pre-commit` passed during commit.
- [x] Markdownlint passed during commit.
- [x] Pre-push docs-only verification passed during push.
- [x] `scripts/check_spdx.sh docs/method/backlog/bad-code/PLATFORM_linked-worktree-hooks-use-dotgit-paths.md`
- [x] `pnpm exec prettier --check docs/method/backlog/bad-code/PLATFORM_linked-worktree-hooks-use-dotgit-paths.md`
- [x] `git diff --check`

## Notes

None of these cards are implementation commitments for the current release lane. They are backlog capture and tooling-debt documentation.