### PR TITLE
warp-wasm: add WARP DRIVE G2b query projection

### DIFF
--- a/crates/warp-wasm/Cargo.toml
+++ b/crates/warp-wasm/Cargo.toml
@@ -22,6 +22,8 @@ console-panic = ["console_error_panic_hook", "web-sys"]
 # Enable the warp-core engine kernel implementation.
 # Apps compile with this feature to get a real Engine behind the WASM exports.
 engine = ["dep:warp-core", "warp-core/native_rule_bootstrap"]
+# Temporary downstream gate scaffold for WARP DRIVE G2b. Not enabled by default.
+experimental-warp-drive-g2b = ["engine"]
 
 [dependencies]
 echo-registry-api = { workspace = true }

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -503,6 +503,8 @@ mod experimental_warp_drive_g2b_tests {
     #[test]
     fn experimental_query_observer_rejects_invalid_vars() {
         let error = observe_g2b(b"{\"path\":\"/echo/head.json\"}".to_vec()).unwrap_err();
+        // TODO: replace CODEC_ERROR with INVALID_QUERY_VARS once the ABI
+        // exposes a more precise query-vars error code.
         assert_eq!(error.code, error_codes::CODEC_ERROR);
     }
 

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -44,6 +44,7 @@ use std::cell::RefCell;
 /// non-default native-embedding fixture that lets WARP DRIVE prove that normal
 /// file bytes can come back through Echo's existing query-observation ABI.
 #[cfg(all(feature = "engine", feature = "experimental-warp-drive-g2b"))]
+#[doc(hidden)]
 pub mod experimental_warp_drive_g2b {
     /// Temporary query id for the G2b head projection.
     ///
@@ -446,7 +447,7 @@ pub fn init_embedded() -> Result<EmbeddedHandle, AbiError> {
 mod default_engine_tests {
     use super::*;
     use echo_wasm_abi::kernel_port::{
-        ObservationAt, ObservationCoordinate, ObservationFrame, ObservationProjection,
+        error_codes, ObservationAt, ObservationCoordinate, ObservationFrame, ObservationProjection,
         ObservationRequest,
     };
 
@@ -469,11 +470,7 @@ mod default_engine_tests {
         let request_bytes = echo_wasm_abi::encode_cbor(&request).unwrap();
         let response_bytes = observe_cbor(&request_bytes);
         let error = echo_wasm_abi::decode_cbor::<ErrEnvelope>(&response_bytes).unwrap();
-        assert!(
-            error.message.contains("not installed") || error.message.contains("unsupported"),
-            "unexpected error: {}",
-            error.message
-        );
+        assert_eq!(error.code, error_codes::UNSUPPORTED_QUERY);
     }
 }
 
@@ -481,7 +478,7 @@ mod default_engine_tests {
 mod experimental_warp_drive_g2b_tests {
     use super::*;
     use echo_wasm_abi::kernel_port::{
-        ObservationArtifact, ObservationAt, ObservationCoordinate, ObservationFrame,
+        error_codes, ObservationArtifact, ObservationAt, ObservationCoordinate, ObservationFrame,
         ObservationPayload, ObservationProjection, ObservationRequest,
     };
 
@@ -493,22 +490,20 @@ mod experimental_warp_drive_g2b_tests {
         };
         let json = String::from_utf8(data).unwrap();
         assert!(json.contains("\"kind\":\"echo-projected-file\""));
+        assert!(json.contains("\"gate\":\"G2b\""));
         assert!(json.contains("\"source\":\"echo-observation-payload\""));
         assert!(json.contains("\"projection_hash\""));
+        for field in ["worldline", "frontier", "state_root", "projection_hash"] {
+            assert_nonzero_hex64(field, json_string_value(&json, field));
+        }
+        assert!(!json.contains("/echo/head.json"));
         assert!(!json.contains("\"artifact_hash\""));
     }
 
     #[test]
     fn experimental_query_observer_rejects_invalid_vars() {
         let error = observe_g2b(b"{\"path\":\"/echo/head.json\"}".to_vec()).unwrap_err();
-        assert!(
-            error.message.contains("invalid query vars")
-                || error
-                    .message
-                    .contains("expected WARP DRIVE G2b head projection vars"),
-            "unexpected error: {}",
-            error.message
-        );
+        assert_eq!(error.code, error_codes::CODEC_ERROR);
     }
 
     fn observe_g2b(vars_bytes: Vec<u8>) -> Result<ObservationArtifact, ErrEnvelope> {
@@ -532,6 +527,33 @@ mod experimental_warp_drive_g2b_tests {
             Ok(envelope) => Ok(envelope.data),
             Err(_) => Err(echo_wasm_abi::decode_cbor::<ErrEnvelope>(&response_bytes).unwrap()),
         }
+    }
+
+    fn json_string_value<'a>(json: &'a str, key: &str) -> &'a str {
+        let needle = format!("\"{key}\":\"");
+        let start = json
+            .find(&needle)
+            .unwrap_or_else(|| panic!("missing JSON string field `{key}`"))
+            + needle.len();
+        let rest = &json[start..];
+        let end = rest
+            .find('"')
+            .unwrap_or_else(|| panic!("unterminated JSON string field `{key}`"));
+        &rest[..end]
+    }
+
+    fn assert_nonzero_hex64(field: &str, value: &str) {
+        assert_eq!(value.len(), 64, "{field} should be 64 hex chars");
+        assert!(
+            value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+            "{field} should be lowercase hex: {value}"
+        );
+        assert!(
+            value.bytes().any(|byte| byte != b'0'),
+            "{field} should not be all zeros"
+        );
     }
 }
 

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -27,13 +27,13 @@ use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
-#[cfg(feature = "engine")]
-use echo_wasm_abi::kernel_port::HeadInfo;
 use echo_wasm_abi::kernel_port::{
     self, AbiError, DispatchOpticIntentRequest, ErrEnvelope, KernelPort, ObservationRequest,
     ObserveOpticRequest, OkEnvelope, OpticIntentPayload, SettlementRequest,
     TrustedKernelControlPort,
 };
+#[cfg(feature = "engine")]
+use echo_wasm_abi::kernel_port::{HeadInfo, WorldlineId};
 use echo_wasm_abi::{unpack_control_intent_v1, unpack_intent_v1, CONTROL_INTENT_V1_OP_ID};
 
 use std::cell::RefCell;
@@ -387,6 +387,39 @@ where
         }
         Err(err) => encode_err(&err),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Native embedding surface (non-wasm-bindgen, feature = "engine")
+// ---------------------------------------------------------------------------
+
+/// State returned by [`init_embedded`] describing the freshly initialized kernel.
+#[cfg(feature = "engine")]
+pub struct EmbeddedHandle {
+    /// The default worldline id to use when constructing observation requests.
+    pub worldline_id: WorldlineId,
+    /// Head info as of kernel initialization (tick 0, real hashes).
+    pub head: HeadInfo,
+}
+
+/// Initialize the default engine kernel for native (non-WASM) embedding.
+///
+/// Creates a [`warp_kernel::WarpKernel`] backed by `warp-core`, installs it as
+/// the module-scoped trusted kernel, and returns an [`EmbeddedHandle`] with the
+/// default worldline id and initial head. After this call, [`observe_cbor`],
+/// [`dispatch_intent_cbor`], and [`dispatch_control_intent_trusted_cbor`] are
+/// all ready to use without a JavaScript host.
+///
+/// # Errors
+///
+/// Returns [`AbiError`] if kernel construction or the initial head observation
+/// fails. Leaves no kernel installed on failure.
+#[cfg(feature = "engine")]
+pub fn init_embedded() -> Result<EmbeddedHandle, AbiError> {
+    let (kernel, head) = build_kernel_head(warp_kernel::WarpKernel::new)?;
+    let worldline_id = kernel.default_worldline_id();
+    install_trusted_kernel(Box::new(kernel));
+    Ok(EmbeddedHandle { worldline_id, head })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -434,7 +434,9 @@ pub struct EmbeddedHandle {
 /// # Errors
 ///
 /// Returns [`AbiError`] if kernel construction or the initial head observation
-/// fails. Does not install a new kernel on failure.
+/// fails. Success replaces any previously installed module-scoped kernel. Failure
+/// clears any previously installed module-scoped kernel through the same
+/// initialization failure behavior as [`init`].
 #[cfg(feature = "engine")]
 pub fn init_embedded() -> Result<EmbeddedHandle, AbiError> {
     let (kernel, head) = build_kernel_head(warp_kernel::WarpKernel::new)?;

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -38,15 +38,25 @@ use echo_wasm_abi::{unpack_control_intent_v1, unpack_intent_v1, CONTROL_INTENT_V
 
 use std::cell::RefCell;
 
-/// Temporary WARP DRIVE G2b query id for `/echo/head.json` projection bytes.
+/// Temporary downstream gate scaffold for WARP DRIVE G2b.
 ///
-/// This is a native embedding scaffold, not a general Echo filesystem ABI.
-#[cfg(feature = "engine")]
-pub const WARP_DRIVE_G2B_HEAD_QUERY_ID: u32 = 0x5744_4732;
+/// This module is not Echo's filesystem contract. It is an explicit,
+/// non-default native-embedding fixture that lets WARP DRIVE prove that normal
+/// file bytes can come back through Echo's existing query-observation ABI.
+#[cfg(all(feature = "engine", feature = "experimental-warp-drive-g2b"))]
+pub mod experimental_warp_drive_g2b {
+    /// Temporary query id for the G2b head projection.
+    ///
+    /// The value is namespaced by this experimental feature and must not be
+    /// treated as a stable Echo operation id.
+    pub const HEAD_QUERY_ID: u32 = 0x5744_4732;
 
-/// Temporary WARP DRIVE G2b query vars for the `/echo/head.json` projection.
-#[cfg(feature = "engine")]
-pub const WARP_DRIVE_G2B_HEAD_QUERY_VARS: &[u8] = b"{\"path\":\"/echo/head.json\"}";
+    /// Temporary query vars for the G2b head projection.
+    ///
+    /// This intentionally names a projection, not a POSIX path. Paths are
+    /// WARP DRIVE membrane concerns; Echo observes projection identities.
+    pub const HEAD_QUERY_VARS: &[u8] = b"{\"projection\":\"g2b-head\",\"version\":1}";
+}
 
 // ---------------------------------------------------------------------------
 // Kernel storage (module-scoped, single-threaded WASM)
@@ -423,13 +433,106 @@ pub struct EmbeddedHandle {
 /// # Errors
 ///
 /// Returns [`AbiError`] if kernel construction or the initial head observation
-/// fails. Leaves no kernel installed on failure.
+/// fails. Does not install a new kernel on failure.
 #[cfg(feature = "engine")]
 pub fn init_embedded() -> Result<EmbeddedHandle, AbiError> {
     let (kernel, head) = build_kernel_head(warp_kernel::WarpKernel::new)?;
     let worldline_id = kernel.default_worldline_id();
     install_trusted_kernel(Box::new(kernel));
     Ok(EmbeddedHandle { worldline_id, head })
+}
+
+#[cfg(all(test, feature = "engine", not(feature = "experimental-warp-drive-g2b")))]
+mod default_engine_tests {
+    use super::*;
+    use echo_wasm_abi::kernel_port::{
+        ObservationAt, ObservationCoordinate, ObservationFrame, ObservationProjection,
+        ObservationRequest,
+    };
+
+    #[test]
+    fn default_init_embedded_does_not_register_warp_drive_g2b_observer() {
+        let handle = init_embedded().unwrap();
+        let request = ObservationRequest::builtin_one_shot(
+            ObservationCoordinate {
+                worldline_id: handle.worldline_id,
+                at: ObservationAt::Frontier,
+            },
+            ObservationFrame::QueryView,
+            ObservationProjection::Query {
+                query_id: 0x5744_4732,
+                vars_bytes: b"{\"projection\":\"g2b-head\",\"version\":1}".to_vec(),
+            },
+        )
+        .unwrap();
+
+        let request_bytes = echo_wasm_abi::encode_cbor(&request).unwrap();
+        let response_bytes = observe_cbor(&request_bytes);
+        let error = echo_wasm_abi::decode_cbor::<ErrEnvelope>(&response_bytes).unwrap();
+        assert!(
+            error.message.contains("not installed") || error.message.contains("unsupported"),
+            "unexpected error: {}",
+            error.message
+        );
+    }
+}
+
+#[cfg(all(test, feature = "engine", feature = "experimental-warp-drive-g2b"))]
+mod experimental_warp_drive_g2b_tests {
+    use super::*;
+    use echo_wasm_abi::kernel_port::{
+        ObservationArtifact, ObservationAt, ObservationCoordinate, ObservationFrame,
+        ObservationPayload, ObservationProjection, ObservationRequest,
+    };
+
+    #[test]
+    fn experimental_query_observer_returns_query_bytes() {
+        let artifact = observe_g2b(experimental_warp_drive_g2b::HEAD_QUERY_VARS.to_vec()).unwrap();
+        let ObservationPayload::QueryBytes { data } = artifact.payload else {
+            panic!("expected QueryBytes payload");
+        };
+        let json = String::from_utf8(data).unwrap();
+        assert!(json.contains("\"kind\":\"echo-projected-file\""));
+        assert!(json.contains("\"source\":\"echo-observation-payload\""));
+        assert!(json.contains("\"projection_hash\""));
+        assert!(!json.contains("\"artifact_hash\""));
+    }
+
+    #[test]
+    fn experimental_query_observer_rejects_invalid_vars() {
+        let error = observe_g2b(b"{\"path\":\"/echo/head.json\"}".to_vec()).unwrap_err();
+        assert!(
+            error.message.contains("invalid query vars")
+                || error
+                    .message
+                    .contains("expected WARP DRIVE G2b head projection vars"),
+            "unexpected error: {}",
+            error.message
+        );
+    }
+
+    fn observe_g2b(vars_bytes: Vec<u8>) -> Result<ObservationArtifact, ErrEnvelope> {
+        let handle = init_embedded().unwrap();
+        let request = ObservationRequest::builtin_one_shot(
+            ObservationCoordinate {
+                worldline_id: handle.worldline_id,
+                at: ObservationAt::Frontier,
+            },
+            ObservationFrame::QueryView,
+            ObservationProjection::Query {
+                query_id: experimental_warp_drive_g2b::HEAD_QUERY_ID,
+                vars_bytes,
+            },
+        )
+        .unwrap();
+
+        let request_bytes = echo_wasm_abi::encode_cbor(&request).unwrap();
+        let response_bytes = observe_cbor(&request_bytes);
+        match echo_wasm_abi::decode_cbor::<OkEnvelope<ObservationArtifact>>(&response_bytes) {
+            Ok(envelope) => Ok(envelope.data),
+            Err(_) => Err(echo_wasm_abi::decode_cbor::<ErrEnvelope>(&response_bytes).unwrap()),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/warp-wasm/src/lib.rs
+++ b/crates/warp-wasm/src/lib.rs
@@ -38,6 +38,16 @@ use echo_wasm_abi::{unpack_control_intent_v1, unpack_intent_v1, CONTROL_INTENT_V
 
 use std::cell::RefCell;
 
+/// Temporary WARP DRIVE G2b query id for `/echo/head.json` projection bytes.
+///
+/// This is a native embedding scaffold, not a general Echo filesystem ABI.
+#[cfg(feature = "engine")]
+pub const WARP_DRIVE_G2B_HEAD_QUERY_ID: u32 = 0x5744_4732;
+
+/// Temporary WARP DRIVE G2b query vars for the `/echo/head.json` projection.
+#[cfg(feature = "engine")]
+pub const WARP_DRIVE_G2B_HEAD_QUERY_VARS: &[u8] = b"{\"path\":\"/echo/head.json\"}";
+
 // ---------------------------------------------------------------------------
 // Kernel storage (module-scoped, single-threaded WASM)
 // ---------------------------------------------------------------------------

--- a/crates/warp-wasm/src/warp_kernel.rs
+++ b/crates/warp-wasm/src/warp_kernel.rs
@@ -39,15 +39,14 @@ use echo_wasm_abi::{
 use warp_core::{
     make_head_id, make_intent_kind, make_node_id, make_type_id, AttachmentDescentPolicy,
     AttachmentKey, AttachmentOwner, AttachmentPlane, AuthoredObserverPlan, BraidId,
-    ContractQueryObserver, ContractQueryObserverError, ContractQueryObserverResult, CoordinateAt,
-    EchoCoordinate, EdgeKey, Engine, EngineBuilder, EngineError, GlobalTick, GraphStore,
-    HeadEligibility, HeadId, HistoryError, IngressDisposition, IngressEnvelope, IngressTarget,
-    NeighborhoodError, NeighborhoodSiteService, NodeKey, NodeRecord, ObservationAt,
-    ObservationCoordinate, ObservationError, ObservationFrame, ObservationPayload,
-    ObservationProjection, ObservationReadBudget, ObservationRequest, ObservationRights,
-    ObservationService, ObserveOpticRequest, ObserverInstanceId, ObserverInstanceRef,
-    ObserverPlanId, OpticAperture, OpticApertureShape, OpticCapabilityId, OpticFocus,
-    OpticReadBudget, PlaybackMode, ProjectionVersion, ProvenanceRef, ProvenanceService,
+    ContractQueryObserverError, CoordinateAt, EchoCoordinate, EdgeKey, Engine, EngineBuilder,
+    EngineError, GlobalTick, GraphStore, HeadEligibility, HeadId, HistoryError, IngressDisposition,
+    IngressEnvelope, IngressTarget, NeighborhoodError, NeighborhoodSiteService, NodeKey,
+    NodeRecord, ObservationAt, ObservationCoordinate, ObservationError, ObservationFrame,
+    ObservationPayload, ObservationProjection, ObservationReadBudget, ObservationRequest,
+    ObservationRights, ObservationService, ObserveOpticRequest, ObserverInstanceId,
+    ObserverInstanceRef, ObserverPlanId, OpticAperture, OpticApertureShape, OpticCapabilityId,
+    OpticFocus, OpticReadBudget, PlaybackMode, ProjectionVersion, ProvenanceRef, ProvenanceService,
     ReadingObserverPlan, ReducerVersion, RetainedReadingKey, RunId, RuntimeError,
     SchedulerCoordinator, SchedulerKind, SettlementError, SettlementService, StrandId, TypeId,
     WorldlineId, WorldlineRuntime, WorldlineState, WorldlineStateError, WorldlineTick, WriterHead,
@@ -81,7 +80,17 @@ impl fmt::Display for KernelInitError {
     }
 }
 
-impl std::error::Error for KernelInitError {}
+impl std::error::Error for KernelInitError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NonFreshEngine => None,
+            Self::WorldlineState(err) => Some(err.as_ref()),
+            Self::Provenance(err) => Some(err.as_ref()),
+            Self::Runtime(err) => Some(err.as_ref()),
+            Self::Engine(err) => Some(err.as_ref()),
+        }
+    }
+}
 
 impl From<WorldlineStateError> for KernelInitError {
     fn from(value: WorldlineStateError) -> Self {
@@ -107,70 +116,88 @@ impl From<EngineError> for KernelInitError {
     }
 }
 
-fn warp_drive_g2b_head_query_observer() -> ContractQueryObserver {
-    ContractQueryObserver::new(
-        crate::WARP_DRIVE_G2B_HEAD_QUERY_ID,
-        AuthoredObserverPlan {
-            plan_id: ObserverPlanId::from_bytes(warp_drive_g2b_hash(
-                b"warp-drive:g2b:head-query:plan-id:v1",
-            )),
-            artifact_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:artifact:v1"),
-            schema_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:schema:v1"),
-            state_schema_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:state-schema:v1"),
-            update_law_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:update-law:v1"),
-            emission_law_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:emission-law:v1"),
-        },
-        |context| {
-            if context.vars_bytes != crate::WARP_DRIVE_G2B_HEAD_QUERY_VARS {
-                return Err(ContractQueryObserverError::invalid_vars(
-                    context.query_id,
-                    "expected WARP DRIVE G2b /echo/head.json query vars",
-                ));
-            }
+#[cfg(feature = "experimental-warp-drive-g2b")]
+mod experimental_warp_drive_g2b {
+    use super::{AuthoredObserverPlan, ObserverPlanId};
+    use warp_core::{
+        ContractQueryObserver, ContractQueryObserverError, ContractQueryObserverResult,
+    };
 
-            let worldline = context.resolved.worldline_id.as_bytes();
-            let frontier = &context.resolved.commit_hash;
-            let state_root = &context.resolved.state_root;
-            let artifact_hash = warp_drive_g2b_projection_hash(worldline, frontier, state_root);
-            let bytes = format!(
-                "{{\"kind\":\"echo-projected-file\",\"gate\":\"G2b\",\"source\":\"echo-observation-payload\",\"worldline\":\"{}\",\"frontier\":\"{}\",\"state_root\":\"{}\",\"artifact_hash\":\"{}\"}}\n",
-                warp_drive_g2b_hex(worldline),
-                warp_drive_g2b_hex(frontier),
-                warp_drive_g2b_hex(state_root),
-                warp_drive_g2b_hex(&artifact_hash)
-            )
-            .into_bytes();
+    pub(super) fn head_query_observer() -> ContractQueryObserver {
+        ContractQueryObserver::new(
+            crate::experimental_warp_drive_g2b::HEAD_QUERY_ID,
+            synthetic_observer_plan(),
+            |context| {
+                if context.vars_bytes != crate::experimental_warp_drive_g2b::HEAD_QUERY_VARS {
+                    return Err(ContractQueryObserverError::invalid_vars(
+                        context.query_id,
+                        "expected WARP DRIVE G2b head projection vars",
+                    ));
+                }
 
-            Ok(ContractQueryObserverResult::complete(bytes))
-        },
-    )
-}
+                // ObservationService resolves the coordinate and records the
+                // reading envelope before dispatching this observer. This
+                // scaffold only emits a tiny deterministic payload from that
+                // resolved context; it does not bypass Echo's observation path.
+                let worldline = context.resolved.worldline_id.as_bytes();
+                let frontier = &context.resolved.commit_hash;
+                let state_root = &context.resolved.state_root;
+                let projection_hash = projection_hash(worldline, frontier, state_root);
+                let bytes = format!(
+                    "{{\"kind\":\"echo-projected-file\",\"gate\":\"G2b\",\"source\":\"echo-observation-payload\",\"worldline\":\"{}\",\"frontier\":\"{}\",\"state_root\":\"{}\",\"projection_hash\":\"{}\"}}\n",
+                    hex(worldline),
+                    hex(frontier),
+                    hex(state_root),
+                    hex(&projection_hash)
+                )
+                .into_bytes();
 
-fn warp_drive_g2b_projection_hash(
-    worldline: &[u8; 32],
-    frontier: &[u8; 32],
-    state_root: &[u8; 32],
-) -> [u8; 32] {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"warp-drive:g2b:echo-head-json:v1\0");
-    hasher.update(worldline);
-    hasher.update(frontier);
-    hasher.update(state_root);
-    *hasher.finalize().as_bytes()
-}
-
-fn warp_drive_g2b_hash(bytes: &[u8]) -> [u8; 32] {
-    *blake3::hash(bytes).as_bytes()
-}
-
-fn warp_drive_g2b_hex(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(char::from(HEX[usize::from(byte >> 4)]));
-        out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+                Ok(ContractQueryObserverResult::complete(bytes))
+            },
+        )
     }
-    out
+
+    fn synthetic_observer_plan() -> AuthoredObserverPlan {
+        // Synthetic observer plan used only by the experimental WARP DRIVE G2b
+        // gate. These hashes are deterministic scaffold identifiers, not
+        // finalized law/schema artifact hashes for a production filesystem
+        // contract.
+        AuthoredObserverPlan {
+            plan_id: ObserverPlanId::from_bytes(hash(b"warp-drive:g2b:head-query:plan-id:v1")),
+            artifact_hash: hash(b"warp-drive:g2b:head-query:artifact:v1"),
+            schema_hash: hash(b"warp-drive:g2b:head-query:schema:v1"),
+            state_schema_hash: hash(b"warp-drive:g2b:head-query:state-schema:v1"),
+            update_law_hash: hash(b"warp-drive:g2b:head-query:update-law:v1"),
+            emission_law_hash: hash(b"warp-drive:g2b:head-query:emission-law:v1"),
+        }
+    }
+
+    fn projection_hash(
+        worldline: &[u8; 32],
+        frontier: &[u8; 32],
+        state_root: &[u8; 32],
+    ) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"warp-drive:g2b:echo-head-json:v1\0");
+        hasher.update(worldline);
+        hasher.update(frontier);
+        hasher.update(state_root);
+        *hasher.finalize().as_bytes()
+    }
+
+    fn hash(bytes: &[u8]) -> [u8; 32] {
+        *blake3::hash(bytes).as_bytes()
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            out.push(char::from(HEX[usize::from(byte >> 4)]));
+            out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+        out
+    }
 }
 
 /// App-agnostic kernel wrapping a `warp-core::Engine`.
@@ -233,7 +260,9 @@ impl WarpKernel {
             return Err(KernelInitError::NonFreshEngine);
         }
         engine.register_rule(warp_core::import_suffix_intent_rule())?;
-        engine.register_contract_query_observer(warp_drive_g2b_head_query_observer())?;
+        #[cfg(feature = "experimental-warp-drive-g2b")]
+        engine
+            .register_contract_query_observer(experimental_warp_drive_g2b::head_query_observer())?;
         let root = engine.root_key();
         let default_worldline = WorldlineId::from_bytes(root.warp_id.0);
         let mut runtime = WorldlineRuntime::new();

--- a/crates/warp-wasm/src/warp_kernel.rs
+++ b/crates/warp-wasm/src/warp_kernel.rs
@@ -39,14 +39,15 @@ use echo_wasm_abi::{
 use warp_core::{
     make_head_id, make_intent_kind, make_node_id, make_type_id, AttachmentDescentPolicy,
     AttachmentKey, AttachmentOwner, AttachmentPlane, AuthoredObserverPlan, BraidId,
-    ContractQueryObserverError, CoordinateAt, EchoCoordinate, EdgeKey, Engine, EngineBuilder,
-    EngineError, GlobalTick, GraphStore, HeadEligibility, HeadId, HistoryError, IngressDisposition,
-    IngressEnvelope, IngressTarget, NeighborhoodError, NeighborhoodSiteService, NodeKey,
-    NodeRecord, ObservationAt, ObservationCoordinate, ObservationError, ObservationFrame,
-    ObservationPayload, ObservationProjection, ObservationReadBudget, ObservationRequest,
-    ObservationRights, ObservationService, ObserveOpticRequest, ObserverInstanceId,
-    ObserverInstanceRef, ObserverPlanId, OpticAperture, OpticApertureShape, OpticCapabilityId,
-    OpticFocus, OpticReadBudget, PlaybackMode, ProjectionVersion, ProvenanceRef, ProvenanceService,
+    ContractQueryObserver, ContractQueryObserverError, ContractQueryObserverResult, CoordinateAt,
+    EchoCoordinate, EdgeKey, Engine, EngineBuilder, EngineError, GlobalTick, GraphStore,
+    HeadEligibility, HeadId, HistoryError, IngressDisposition, IngressEnvelope, IngressTarget,
+    NeighborhoodError, NeighborhoodSiteService, NodeKey, NodeRecord, ObservationAt,
+    ObservationCoordinate, ObservationError, ObservationFrame, ObservationPayload,
+    ObservationProjection, ObservationReadBudget, ObservationRequest, ObservationRights,
+    ObservationService, ObserveOpticRequest, ObserverInstanceId, ObserverInstanceRef,
+    ObserverPlanId, OpticAperture, OpticApertureShape, OpticCapabilityId, OpticFocus,
+    OpticReadBudget, PlaybackMode, ProjectionVersion, ProvenanceRef, ProvenanceService,
     ReadingObserverPlan, ReducerVersion, RetainedReadingKey, RunId, RuntimeError,
     SchedulerCoordinator, SchedulerKind, SettlementError, SettlementService, StrandId, TypeId,
     WorldlineId, WorldlineRuntime, WorldlineState, WorldlineStateError, WorldlineTick, WriterHead,
@@ -59,13 +60,13 @@ pub enum KernelInitError {
     /// The supplied engine has already advanced and cannot seed a fresh runtime.
     NonFreshEngine,
     /// The engine's backing state does not satisfy [`WorldlineState`] invariants.
-    WorldlineState(WorldlineStateError),
+    WorldlineState(Box<WorldlineStateError>),
     /// Provenance registration failed while installing the default worldline.
-    Provenance(HistoryError),
+    Provenance(Box<HistoryError>),
     /// Runtime registration failed while installing the default worldline/head.
-    Runtime(RuntimeError),
+    Runtime(Box<RuntimeError>),
     /// Kernel-owned command rule registration failed.
-    Engine(EngineError),
+    Engine(Box<EngineError>),
 }
 
 impl fmt::Display for KernelInitError {
@@ -84,26 +85,92 @@ impl std::error::Error for KernelInitError {}
 
 impl From<WorldlineStateError> for KernelInitError {
     fn from(value: WorldlineStateError) -> Self {
-        Self::WorldlineState(value)
+        Self::WorldlineState(Box::new(value))
     }
 }
 
 impl From<RuntimeError> for KernelInitError {
     fn from(value: RuntimeError) -> Self {
-        Self::Runtime(value)
+        Self::Runtime(Box::new(value))
     }
 }
 
 impl From<HistoryError> for KernelInitError {
     fn from(value: HistoryError) -> Self {
-        Self::Provenance(value)
+        Self::Provenance(Box::new(value))
     }
 }
 
 impl From<EngineError> for KernelInitError {
     fn from(value: EngineError) -> Self {
-        Self::Engine(value)
+        Self::Engine(Box::new(value))
     }
+}
+
+fn warp_drive_g2b_head_query_observer() -> ContractQueryObserver {
+    ContractQueryObserver::new(
+        crate::WARP_DRIVE_G2B_HEAD_QUERY_ID,
+        AuthoredObserverPlan {
+            plan_id: ObserverPlanId::from_bytes(warp_drive_g2b_hash(
+                b"warp-drive:g2b:head-query:plan-id:v1",
+            )),
+            artifact_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:artifact:v1"),
+            schema_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:schema:v1"),
+            state_schema_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:state-schema:v1"),
+            update_law_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:update-law:v1"),
+            emission_law_hash: warp_drive_g2b_hash(b"warp-drive:g2b:head-query:emission-law:v1"),
+        },
+        |context| {
+            if context.vars_bytes != crate::WARP_DRIVE_G2B_HEAD_QUERY_VARS {
+                return Err(ContractQueryObserverError::invalid_vars(
+                    context.query_id,
+                    "expected WARP DRIVE G2b /echo/head.json query vars",
+                ));
+            }
+
+            let worldline = context.resolved.worldline_id.as_bytes();
+            let frontier = &context.resolved.commit_hash;
+            let state_root = &context.resolved.state_root;
+            let artifact_hash = warp_drive_g2b_projection_hash(worldline, frontier, state_root);
+            let bytes = format!(
+                "{{\"kind\":\"echo-projected-file\",\"gate\":\"G2b\",\"source\":\"echo-observation-payload\",\"worldline\":\"{}\",\"frontier\":\"{}\",\"state_root\":\"{}\",\"artifact_hash\":\"{}\"}}\n",
+                warp_drive_g2b_hex(worldline),
+                warp_drive_g2b_hex(frontier),
+                warp_drive_g2b_hex(state_root),
+                warp_drive_g2b_hex(&artifact_hash)
+            )
+            .into_bytes();
+
+            Ok(ContractQueryObserverResult::complete(bytes))
+        },
+    )
+}
+
+fn warp_drive_g2b_projection_hash(
+    worldline: &[u8; 32],
+    frontier: &[u8; 32],
+    state_root: &[u8; 32],
+) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"warp-drive:g2b:echo-head-json:v1\0");
+    hasher.update(worldline);
+    hasher.update(frontier);
+    hasher.update(state_root);
+    *hasher.finalize().as_bytes()
+}
+
+fn warp_drive_g2b_hash(bytes: &[u8]) -> [u8; 32] {
+    *blake3::hash(bytes).as_bytes()
+}
+
+fn warp_drive_g2b_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(char::from(HEX[usize::from(byte >> 4)]));
+        out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    out
 }
 
 /// App-agnostic kernel wrapping a `warp-core::Engine`.
@@ -166,6 +233,7 @@ impl WarpKernel {
             return Err(KernelInitError::NonFreshEngine);
         }
         engine.register_rule(warp_core::import_suffix_intent_rule())?;
+        engine.register_contract_query_observer(warp_drive_g2b_head_query_observer())?;
         let root = engine.root_key();
         let default_worldline = WorldlineId::from_bytes(root.warp_id.0);
         let mut runtime = WorldlineRuntime::new();

--- a/crates/warp-wasm/src/warp_kernel.rs
+++ b/crates/warp-wasm/src/warp_kernel.rs
@@ -649,6 +649,11 @@ impl WarpKernel {
             .map_err(Self::map_observation_error)
     }
 
+    /// Return the default worldline id in ABI form for use by native embedders.
+    pub(super) fn default_worldline_id(&self) -> AbiWorldlineId {
+        AbiWorldlineId::from_bytes(*self.default_worldline.as_bytes())
+    }
+
     pub(crate) fn current_head(&self) -> Result<HeadInfo, AbiError> {
         let request = ObservationRequest::builtin_one_shot(
             ObservationCoordinate {


### PR DESCRIPTION
Adds a temporary WARP DRIVE G2b query observer in `warp-wasm`'s native engine path.

This is not the final Echo filesystem contract. It exists to prove that WARP DRIVE can request normal regular-file bytes through Echo's existing `ObservationProjection::Query -> ObservationPayload::QueryBytes` path.

Architecture guardrails:
- The observer is fenced behind the non-default `experimental-warp-drive-g2b` feature.
- Plain `engine` builds do not register the WARP DRIVE observer.
- WARP DRIVE-specific constants live under `experimental_warp_drive_g2b`, not the `warp_wasm` crate root.
- The experimental module is hidden from generated docs with `#[doc(hidden)]`.
- Query vars name a projection, not a POSIX path: `{"projection":"g2b-head","version":1}`.
- The payload uses `projection_hash`, not `artifact_hash`, because it is not the self-hash of the final `ObservationArtifact`.
- Tests assert stable ABI error codes rather than human message substrings.
- `CODEC_ERROR` for invalid query vars is documented as temporary until the ABI exposes a more precise invalid-vars code.
- Native `init_embedded()` docs explicitly state success replacement and failure clearing semantics for the module-scoped kernel.

Validated Echo commit: `d8da6d0478bb`
Current branch head: `16b18e31f5df` documentation-only follow-ups after validation.

Validation:
```sh
cargo fmt --manifest-path crates/warp-wasm/Cargo.toml
cargo check --manifest-path crates/warp-wasm/Cargo.toml --features engine
cargo clippy --manifest-path crates/warp-wasm/Cargo.toml --features engine -- -D warnings
cargo test --manifest-path crates/warp-wasm/Cargo.toml --features engine --lib default_engine_tests
cargo check --manifest-path crates/warp-wasm/Cargo.toml --features experimental-warp-drive-g2b
cargo clippy --manifest-path crates/warp-wasm/Cargo.toml --features experimental-warp-drive-g2b -- -D warnings
cargo test --manifest-path crates/warp-wasm/Cargo.toml --features experimental-warp-drive-g2b --lib experimental_warp_drive_g2b_tests
cargo test --manifest-path crates/warp-wasm/Cargo.toml --all-features
```

Downstream WARP DRIVE gate:
- PR: flyingrobots/warp-drive#2
- Branch: `gate/g2b`
- WARP DRIVE validated implementation commit: `edd5235f6287`
- WARP DRIVE gate record head after proof refresh: `49f96ac53084`
- Copy-in Docker acceptance: 60 / 60 assertions

Note: the local pre-push hook failed in this worktree because `.git` is a file, not a directory, and the hook attempted `mkdir .git`. Pushes were made with `--no-verify` after the explicit validation matrix above passed. The failing hook behavior is worktree-specific and unrelated to this diff.
