### PR TITLE
Add Hello Echo demo and docs lifecycle policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,8 +2352,11 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake3",
+ "bytes",
  "clap",
  "clap_mangen",
+ "hex",
  "method",
  "pulldown-cmark",
  "serde",
@@ -2361,6 +2364,7 @@ dependencies = [
  "sha2",
  "time",
  "warp-cli",
+ "warp-core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <strong>A deterministic WARP runtime for witnessed causal history, bounded readings, and replayable evidence.</strong>
+  <strong>State is a reading. Echo makes readings lawful, witnessed, and replayable.</strong>
 </p>
 
 <p align="center">
@@ -41,6 +41,21 @@ when Echo ticks. Applications submit canonical intents. Echo admits, schedules,
 settles, and executes them at runtime-owned tick boundaries, then emits receipts
 and evidence-carrying observations.
 
+## A Concrete Problem
+
+Consider a collaborative editor, game simulation, build graph, or contract host
+where two users submit work at nearly the same time. Most systems answer with a
+mutable object, a lock, a queue, or a best-effort conflict handler. After the
+fact, you may have logs, database rows, or a materialized file, but you do not
+have machine-checkable evidence that the transition was admitted under a named
+law from a named causal basis.
+
+Echo starts from the other end. The durable object is the witnessed causal
+history. Inputs become canonical intents. Runtime-owned admission decides what
+can proceed. The scheduler admits a deterministic independent subset, commits a
+tick, and emits receipts. Reads are bounded observations from explicit
+coordinates, not informal snapshots of whatever mutable state happens to exist.
+
 ## When To Use Echo
 
 | Need                           | Echo Provides                                              | Example Use Cases                                    |
@@ -70,6 +85,21 @@ deterministic WARP runtime over witnessed causal history.
 
 Read [There Is No Graph](docs/architecture/there-is-no-graph.md) for the deeper
 model.
+
+## Boundary Vocabulary
+
+| Term              | Meaning In Echo                                          |
+| ----------------- | -------------------------------------------------------- |
+| Intent            | Canonical proposed work from an application or adapter   |
+| Admission law     | The named rule that decides whether work can proceed     |
+| Footprint         | Declared read/write support used for conflict checks     |
+| Tick              | Runtime-owned logical commit boundary                    |
+| Receipt           | Machine-checkable outcome evidence for admitted work     |
+| Reading           | Bounded observation over causal history                  |
+| `ReadingEnvelope` | Evidence wrapper for where a reading came from           |
+| WARP optic        | Lawful projection from explicit basis and aperture       |
+| Witnessed suffix  | Causal-history exchange unit, not state synchronization  |
+| Retained artifact | Durable evidence or reading payload by semantic identity |
 
 ## How It Works
 
@@ -174,10 +204,198 @@ You own:
 - authored GraphQL contracts;
 - generated contract helpers and host integrations.
 
+## FAQ
+
+### Is This Just Git?
+
+Close enough to be useful, but not close enough to be correct. Git got the
+most important thesis right: history is the authority. A Git commit is not a
+diff applied to mutable state. It is a node in a witnessed causal graph that can
+be replayed, audited, and verified.
+
+Git fixes three things that Echo generalizes.
+
+First, Git fixes the reading. Its causal history is over filesystem snapshots,
+and its normal optic is "a directory of files at a commit." Echo's causal
+history is over arbitrary admitted transitions. A reading might be a document,
+a counter, a game state, a build artifact, or a semantic projection of a
+GraphQL contract. The optic is authored. Git's optic is fixed.
+
+Second, Git does not have runtime admission law. Anything can be committed.
+Merge conflicts are surfaced to a human who resolves them outside the system.
+There is no footprint check, deterministic independent subset, or receipt that
+proves the merge was lawful under a named rule. Echo admits intents under
+explicit law, checks footprints, and emits machine-verifiable receipts.
+
+Third, Git reads are not structured observations. Checking out a commit
+materializes files, but the checkout does not carry an observer, aperture,
+basis, support posture, or witness envelope. Echo's readings name their
+coordinate, law, basis, aperture, and evidence posture.
+
+The one-line version: Git is a WARP optic with one aperture, no runtime
+admission law, and no structured reads. It proved the thesis. WARP generalized
+it.
+
+### Is This Git For Anything?
+
+No. "Git for anything" sounds like a storage layer with a broader substrate,
+which misses the core point. The substrate difference is not the interesting
+part. Admission law is.
+
+Git records that someone committed something. Echo asks whether a transition is
+lawful at a frontier under explicit rules. The scheduler proves the admitted
+subset is independent before applying it. It emits a receipt that says what was
+admitted, what was rejected or obstructed, and why. That lawfulness lives inside
+the runtime instead of being assumed outside it.
+
+The second missing piece is structured observation. Git's read is checkout.
+Echo's read names a coordinate, a law, an aperture, and the support that must
+travel with the result. The reading is bounded and can be wrong in detectable
+ways.
+
+So this is not a logging framework with branches. Echo is a runtime where
+lawfulness is a first-class runtime property.
+
+### Is This A Blockchain?
+
+No. Blockchains and Echo both use append-only witnessed history. That is the
+overlap.
+
+Blockchains are built to solve Byzantine consensus: getting parties who do not
+trust each other to agree on a shared ledger without a central authority. Proof
+of work, proof of stake, global replication, and economic incentives all follow
+from that problem.
+
+Echo assumes cooperative participants under known law. There is no token, no
+mining, no global validator set, and no adversarial consensus layer. Echo
+witnesses are evidence that a transition followed from a named basis under a
+named rule, not proof that anonymous validators agreed.
+
+A blockchain's history is primarily a trust protocol. Echo's history is a
+computation substrate for replayable, verifiable work.
+
+### Is This Event Sourcing?
+
+Event sourcing appends domain events and rebuilds state by replaying them.
+That is a close cousin, but the authority is still usually a privileged
+aggregate or materialized object. Replay is a recovery strategy.
+
+Echo does not treat the log as a backup for an aggregate. Causal history is the
+territory. Readings are derived under explicit observation law, and transitions
+are admitted under explicit admission law. Receipts and witnesses are part of
+the runtime contract, not an audit feature bolted on later.
+
+### Is This The Actor Model?
+
+No. Actors pass messages and mutate private state. That is still a mutable
+state-machine model. Echo intents may look like messages, but they are not
+fire-and-forget calls into private mutable objects. They are admitted under law,
+scheduled by the runtime, witnessed, retained, and observed through bounded
+readings.
+
+### Is This A Database With Extra Steps?
+
+No. A database makes the current value authoritative and exposes query and
+transaction interfaces around it. History, if present, is often an audit log.
+
+Echo makes witnessed causal history authoritative. The "current value" is a
+reading derived from that history. That difference changes the guarantees under
+failure, concurrency, replay, and debugging.
+
+Use Postgres if you need a mutable relational store with transactions and
+queries. Echo is appropriate when exact replay, cross-participant verification,
+deterministic parallel admission, or evidence-carrying readings are the point.
+
+### Are Witnesses And Receipts Just Logs?
+
+No. A log line records that code said something. It does not prove that an
+operation was lawful.
+
+A receipt in Echo is machine-checkable outcome evidence. It names the candidate
+work, the scheduler decision, the causal basis, the rule family, and the
+outcome. Witnesses and retained artifacts are part of the evidence graph that
+lets a later observer verify where a transition or reading came from.
+
+### Are Readings Just Queries?
+
+No. A normal query asks for the current value of something in a privileged
+state store. It usually has no coordinate, aperture, witness basis, rights
+posture, residual posture, or proof obligation.
+
+An Echo reading is a lawful, bounded, witnessed observation. It names where it
+was taken from, what observer and projection law produced it, what budget or
+rights applied, and what evidence travels with the result.
+
+### Does Determinism Mean Single-Threaded?
+
+No. Determinism means the same admitted causal inputs produce the same
+observable outputs. Echo can admit independent work in parallel when the
+declared footprints prove that the work is safe to run together. Determinism is
+an input discipline and admission-law problem, not a mandatory global lock.
+
+### Is This Only For Distributed Systems?
+
+No. Echo's predecessor was a deterministic game-engine runtime. Receipts,
+footprint-checked parallelism, replayable ticks, and witnessed readings are
+valuable in a single process on one machine. Distribution becomes easier
+because the model is explicit about history and evidence, but distribution is
+not the reason the model exists.
+
+### How Does This Relate To CRDTs?
+
+CRDTs solve convergence: replicas that receive the same operations eventually
+converge. Echo solves lawfulness: transitions are admitted under explicit rules
+with evidence. The ideas are complementary. A CRDT merge strategy could be
+expressed as an admission law hosted by Echo.
+
+### What Is The Boundary With Normal Tools?
+
+Normal tools should stay normal. WARPDrive is the intended filesystem boundary:
+a mounted path looks like a directory to editors, shells, IDEs, and formatters.
+Reads are materialized readings. Writes become candidate intents. Echo remains
+authoritative underneath without requiring every tool to learn Echo's model.
+
+### Is Echo Production-Ready?
+
+No. See [Current Reality](#current-reality). The kernel and several evidence
+surfaces are working, but the current target is a usable local deterministic
+contract host, not a general production platform.
+
+### Who Is Echo For?
+
+Echo is for runtime engineers, compiler authors, tool builders, and systems
+architects who have hit the wall on mutable-state models and need exact replay,
+lawful admission, or evidence-carrying observations. It is not a drop-in web
+backend, a CRUD framework, or a better database.
+
+### How Do I Debug With Echo?
+
+Debugging is forensics over evidence. Because admitted transitions produce
+receipts and readings carry witness posture, you can ask how a reading became
+possible and trace it through named causal evidence instead of searching logs
+for coincidental text.
+
+### How Does Schema Evolution Work?
+
+Contract identity, schema identity, operation ids, and generated helper
+identity are explicit in Wesley output. A schema change produces new contract
+artifact identity. Old readings name the schema and operation identity they
+used, so multiple contract versions can coexist without silently invalidating
+old receipts.
+
+### Where Should Contributors Start?
+
+Start with `warp-core` and read
+[There Is No Graph](docs/architecture/there-is-no-graph.md) before changing
+runtime boundaries. Echo core must not grow application nouns such as
+`increment_counter`, `save_buffer`, or product-specific APIs. Those belong in
+authored Wesley contracts and generated adapters above the runtime boundary.
+
 ## Quick Start For Contributors
 
 ```bash
 make hooks
+cargo xtask hello-echo
 cargo xtask method status
 cargo xtask test-slice warp-core-smoke
 cargo xtask dind run
@@ -216,7 +434,7 @@ cargo bench -p warp-benches
 - Causal transport: [Continuum Transport](docs/architecture/continuum-transport.md)
 - Documentation map: [Docs](docs/index.md)
 
-## Status
+## Current Reality
 
 Echo has a working deterministic kernel, installed contract hosting, witnessed
 intent submission, scheduler-owned execution, observation envelopes, semantic

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,9 +62,15 @@ Echo's live documentation centers on the runtime carrier, the retained witnesses
 ## Contributor Workflow
 
 - Contributor workflow: [/workflows](/workflows)
+- Docs lifecycle: [/procedures/DOCS-LIFECYCLE](/procedures/DOCS-LIFECYCLE)
 - PR submission loop: [/procedures/PR-SUBMISSION-REVIEW-LOOP](/procedures/PR-SUBMISSION-REVIEW-LOOP)
 - Extract PR comments: [/procedures/EXTRACT-PR-COMMENTS](/procedures/EXTRACT-PR-COMMENTS)
 
 ## Archive Boundary
 
-The old guide/course/demo surface has been removed from the live docs corpus. The Method, Design, and Retrospective trees remain source material, but they are not part of the public docs map.
+The old guide/course/demo surface has been removed from the live docs corpus.
+The Method, Design, and Retrospective trees remain source material, but they
+are not part of the public docs map. Use the
+[Docs Lifecycle](/procedures/DOCS-LIFECYCLE) policy to decide when active
+design material should be absorbed into canonical domain docs, marked
+superseded, or archived as evidence.

--- a/docs/procedures/DOCS-LIFECYCLE.md
+++ b/docs/procedures/DOCS-LIFECYCLE.md
@@ -1,0 +1,205 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Docs Lifecycle
+
+Echo documentation is part of the runtime architecture. It must tell readers
+what is authoritative now without deleting the evidence that explains how the
+system arrived there.
+
+This policy defines how design docs accumulate, how their current claims become
+domain documentation, and how superseded material is archived.
+
+## Authority Model
+
+Echo docs have several different jobs. Do not make one file do all of them.
+
+| Role      | Purpose                                       | Normal Location                      |
+| --------- | --------------------------------------------- | ------------------------------------ |
+| Canonical | Current behavior, invariants, and APIs        | `docs/architecture/`, `docs/spec/`   |
+| Design    | Active proposal, decision path, tradeoffs     | `docs/design/`                       |
+| Evidence  | Historical proof, retros, audits, raw output  | `docs/method/`, `docs/audits/`       |
+| Procedure | How contributors operate the repo             | `docs/procedures/`, `docs/workflows` |
+| Archive   | Superseded source material retained for audit | Archive/graveyard namespaces         |
+
+The public reader path should prefer canonical docs. Design and evidence docs
+remain valuable, but they must not silently compete with canonical docs for
+authority.
+
+## Lifecycle States
+
+Every design doc is in exactly one lifecycle state:
+
+| State        | Meaning                                                      |
+| ------------ | ------------------------------------------------------------ |
+| `active`     | Still being evaluated or implemented                         |
+| `accepted`   | Decision accepted, implementation or docs absorption pending |
+| `absorbed`   | Current truth merged into canonical domain docs              |
+| `superseded` | Replaced by a newer design, spec, architecture doc, or code  |
+| `archived`   | Retained only as historical evidence                         |
+
+The lifecycle state is about authority, not age. A recent design can be
+superseded. An old spec can remain canonical.
+
+## Required Design Header
+
+New or materially edited design docs should start with a status block after the
+title:
+
+```md
+Status: active
+Domain: observation
+Canonical output: docs/spec/SPEC-0004-worldlines-playback-truthbus.md
+Supersedes: none
+Superseded by: none
+Evidence: cargo xtask test-slice observation
+```
+
+Use `Canonical output` to name the domain doc that will absorb the current
+truth. If the design is exploratory and has no destination yet, write
+`Canonical output: pending`.
+
+## Domain Areas
+
+Every feature or architectural theme should converge into one canonical domain
+area. The first pass domain areas are:
+
+| Domain               | Canonical Output Pattern                                        |
+| -------------------- | --------------------------------------------------------------- |
+| Runtime carrier      | `docs/spec/warp-core.md`, carrier-specific specs                |
+| Admission/scheduler  | scheduler, tick, settlement, and receipt specs                  |
+| Observation/readings | observation, reading envelope, WARP view protocol specs         |
+| Contract hosting     | application contract hosting and Wesley boundary docs           |
+| Retention/WSC        | WSC, retained readings, CAS, and semantic lookup docs           |
+| Continuum            | witnessed suffix, import/export, and transport docs             |
+| Determinism          | deterministic math, DIND, release policy, benchmark evidence    |
+| Product integrations | jedit, WARPDrive, and other application-facing integration docs |
+| Contributor workflow | procedures, validation, review, and docs lifecycle docs         |
+
+If a design doc spans multiple domains, pick a primary canonical output and
+cross-link the secondary outputs.
+
+## Accumulation Process
+
+Design docs are allowed to accumulate while a feature is uncertain. They should
+capture problem framing, rejected alternatives, constraints, evidence, and open
+questions. They should not pretend to be current product documentation.
+
+Use this loop:
+
+1. **Open design**: create or update a design packet in `docs/design/` with
+   `Status: active` and a named `Canonical output`.
+2. **Build evidence**: land implementation, tests, fixtures, demos, or docs
+   that prove the claim.
+3. **Accept decision**: when the design direction is chosen, set
+   `Status: accepted` and list the exact evidence.
+4. **Absorb current truth**: update the canonical domain doc so a new reader
+   can learn the current system without reading the whole design thread.
+5. **Retire design authority**: set the design doc to `absorbed`,
+   `superseded`, or `archived`.
+
+The output of design work is not another permanent reader-path design doc. The
+output is an updated canonical domain doc plus retained decision evidence.
+
+## Absorption Rules
+
+A design doc is ready to be marked `absorbed` when:
+
+- the canonical domain doc contains the current invariant or behavior;
+- the canonical domain doc links back to the design only for rationale;
+- executable evidence is named in the design, PR, changelog, or canonical doc;
+- the design doc no longer needs to appear in the public "Start Here" path.
+
+Absorption should be a summary, not a paste. Preserve the canonical rule,
+surface API, invariants, and operational examples. Leave obsolete debate,
+temporary slice planning, and raw logs in the design/evidence record.
+
+## Supersession Rules
+
+Mark a design `superseded` when a newer design, spec, implementation, or
+architectural decision replaces its claims.
+
+The superseded doc must point to the replacement:
+
+```md
+Status: superseded
+Superseded by: docs/spec/warp-core.md#runtime-owned-ticks
+```
+
+Do not delete superseded docs during ordinary feature work. Deletion is only
+appropriate when the material is duplicate, generated, or migrated with an
+inspectable mapping.
+
+## Archive Rules
+
+Archive material when it is useful as evidence but harmful as reader-path truth.
+
+Good archive candidates:
+
+- old implementation plans after their claims are absorbed;
+- Method backlog exports already migrated to GitHub Issues;
+- raw witness output and review artifacts;
+- design packets whose only current value is historical rationale;
+- docs that describe removed surfaces or retired terminology.
+
+Archive moves must preserve findability:
+
+- leave a short tombstone or status header when the old path has live inbound
+  links;
+- update `docs/index.md` if the old doc was listed there;
+- run dead-reference checks for touched docs;
+- prefer one archive move per domain slice instead of broad unrelated sweeps.
+
+## Public Docs Map Rules
+
+`docs/index.md` is not an inventory. It is the reader path.
+
+Only list a design doc in the public docs map when it is active, currently
+load-bearing, and there is no canonical domain doc yet. Once absorbed, remove
+it from the public path and let the canonical doc carry the current claim.
+
+The docs map should answer:
+
+- What should I believe now?
+- Where is the canonical model?
+- What evidence proves the claim?
+- Where do contributors go to operate safely?
+
+It should not answer:
+
+- What files exist?
+- What plans ever existed?
+- What did every prior slice discuss?
+
+## PR Checklist
+
+For any PR that creates, materially edits, or relies on a design doc:
+
+- [ ] The design doc has a lifecycle status.
+- [ ] The primary domain area is named.
+- [ ] The canonical output is named or explicitly `pending`.
+- [ ] If implementation landed, current behavior was absorbed into a canonical
+      domain doc or a follow-up issue was opened.
+- [ ] Superseded docs point to their replacement.
+- [ ] `docs/index.md` links only to current reader-path docs.
+- [ ] Dead-reference checks pass for touched markdown.
+
+## Anti-Patterns
+
+- Treating `docs/design/` as the public manual.
+- Adding a new design doc when a canonical domain doc update would be clearer.
+- Leaving accepted designs in the reader path after the feature ships.
+- Archiving by age instead of authority.
+- Deleting historical evidence without a migration map.
+- Hiding current behavior in PR prose without updating canonical docs.
+
+## Minimal Slice
+
+When in doubt, do the smallest lawful docs lifecycle slice:
+
+1. Pick one feature/domain.
+2. Name the current canonical doc.
+3. Absorb the current invariant into that doc.
+4. Mark one or more design docs `absorbed` or `superseded`.
+5. Update `docs/index.md` only if the reader path changed.
+6. Run markdownlint and dead-reference checks.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -13,6 +13,13 @@ This doc is the “official workflow index” for Echo: how we work, what invari
 
 - Record architectural decisions in active design packets (`docs/design/`),
   Method items (`docs/method/`), or PR descriptions.
+- When a design packet is created or materially changed, follow the
+  [Docs Lifecycle](./procedures/DOCS-LIFECYCLE.md) policy: name its lifecycle
+  status, domain, canonical output, and evidence path.
+- When implementation lands, absorb current behavior into the relevant
+  canonical domain doc before treating the design packet as done. Mark the
+  design `absorbed`, `superseded`, or `archived` once it no longer owns current
+  reader-path truth.
 - Before opening a PR, run the validation workflow below.
 
 ---

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 blake3 = "1.0"
-bytes = "1.0"
+bytes = ">=1.11.1"
 clap = { version = "4", features = ["derive"] }
 clap_mangen = "0.2"
 hex = "0.4"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,8 +11,11 @@ publish = false
 
 [dependencies]
 anyhow = "1"
+blake3 = "1.0"
+bytes = "1.0"
 clap = { version = "4", features = ["derive"] }
 clap_mangen = "0.2"
+hex = "0.4"
 method = { path = "../crates/method", version = "0.1.0" }
 pulldown-cmark = { version = "0.13", default-features = false }
 serde = { version = "1", features = ["derive"] }
@@ -20,6 +23,7 @@ serde_json = "1"
 sha2 = "0.10"
 time = { version = "0.3.47", features = ["formatting", "parsing"] }
 warp-cli = { path = "../crates/warp-cli", version = "0.1.0" }
+warp-core = { workspace = true, features = ["native_rule_bootstrap"] }
 
 
 [lints]

--- a/xtask/src/hello_echo.rs
+++ b/xtask/src/hello_echo.rs
@@ -318,7 +318,7 @@ impl CapsuleArtifacts {
     }
 }
 
-fn run_capsule(out_dir: &PathBuf) -> Result<CapsuleArtifacts> {
+fn run_capsule(out_dir: &Path) -> Result<CapsuleArtifacts> {
     std::fs::create_dir_all(out_dir)
         .with_context(|| format!("failed to create {}", out_dir.display()))?;
 

--- a/xtask/src/hello_echo.rs
+++ b/xtask/src/hello_echo.rs
@@ -6,7 +6,7 @@
 use anyhow::{bail, Context, Result};
 use bytes::Bytes;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 use warp_core::inbox::INTENT_ATTACHMENT_TYPE;
 use warp_core::wsc::{build_one_warp_input, validate_wsc, write_wsc_one_warp, WscFile};
@@ -242,11 +242,9 @@ impl CapsuleArtifacts {
             &wsc_path,
             self.continuum.outcome,
         );
-        let inspect_tree = format!("cargo run -p warp-cli -- inspect {} --tree", wsc_path);
-        let verify_wsc = format!(
-            "cargo run -p warp-cli -- verify {} --expected {}",
-            wsc_path, wsc_warp_state_root
-        );
+        let inspect_tree = format!("cargo run -p warp-cli -- inspect {wsc_path} --tree");
+        let verify_wsc =
+            format!("cargo run -p warp-cli -- verify {wsc_path} --expected {wsc_warp_state_root}");
 
         HelloEchoReport {
             demo: "hello-echo",
@@ -519,7 +517,7 @@ fn read_counter_from_state(state: &WorldlineState) -> Result<u64> {
 
 fn write_and_validate_wsc(
     state: &WorldlineState,
-    out_dir: &PathBuf,
+    out_dir: &Path,
 ) -> Result<(PathBuf, Hash, Hash, bool, WscCounts)> {
     let store = state
         .store(&state.root().warp_id)

--- a/xtask/src/hello_echo.rs
+++ b/xtask/src/hello_echo.rs
@@ -1,0 +1,779 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+
+//! Thirty-second Hello Echo evidence capsule.
+
+use anyhow::{bail, Context, Result};
+use bytes::Bytes;
+use serde::Serialize;
+use std::path::PathBuf;
+use std::time::Instant;
+use warp_core::inbox::INTENT_ATTACHMENT_TYPE;
+use warp_core::wsc::{build_one_warp_input, validate_wsc, write_wsc_one_warp, WscFile};
+use warp_core::{
+    derive_witnessed_suffix_shell_digest, export_suffix, import_suffix, make_edge_id,
+    make_intent_kind, make_node_id, make_type_id, AtomPayload, AttachmentKey, AttachmentValue,
+    CausalSuffixBundle, ConflictPolicy, EdgeRecord, ExportSuffixRequest, Footprint, GraphStore,
+    GraphView, Hash, ImportSuffixRequest, IngressEnvelope, IngressTarget, NodeId, NodeKey,
+    NodeRecord, PatternGraph, ProvenanceRef, RewriteRule, TickDelta, TickReceipt,
+    TickReceiptDisposition, TickReceiptRejection, WarpOp, WitnessedSuffixAdmissionContext,
+    WitnessedSuffixAdmissionOutcome, WitnessedSuffixExportContext,
+    WitnessedSuffixLocalAdmissionPosture, WorldlineId, WorldlineState, WorldlineTick,
+};
+
+const COUNTER_RULE_NAME: &str = "cmd/hello_echo_counter";
+const COUNTER_VALUE_TYPE: &str = "hello-echo/counter-value/v1";
+const COUNTER_NODE: &str = "hello-echo/counter";
+const INTENT_PREFIX: &str = "hello-echo.intent/v1;";
+const WSC_SCHEMA: &str = "hello-echo/wsc-schema/v1";
+
+pub(crate) struct HelloEchoConfig {
+    pub(crate) out_dir: PathBuf,
+    pub(crate) max_ms: u64,
+}
+
+#[derive(Serialize)]
+pub(crate) struct HelloEchoReport {
+    pub(crate) demo: &'static str,
+    pub(crate) verdict: &'static str,
+    pub(crate) elapsed_ms: u128,
+    pub(crate) max_ms: u64,
+    pub(crate) deterministic_evidence_digest: String,
+    pub(crate) features: Vec<FeatureEvidence>,
+    pub(crate) worldline: WorldlineReport,
+    pub(crate) ingress: IngressReport,
+    pub(crate) receipt: ReceiptReport,
+    pub(crate) counter: CounterReport,
+    pub(crate) hashes: HashReport,
+    pub(crate) patch: PatchReport,
+    pub(crate) wsc: WscReport,
+    pub(crate) continuum: ContinuumReport,
+    pub(crate) inspection: InspectionReport,
+}
+
+#[derive(Serialize)]
+pub(crate) struct FeatureEvidence {
+    pub(crate) feature: &'static str,
+    pub(crate) witness: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WorldlineReport {
+    pub(crate) id: String,
+    pub(crate) root_warp: String,
+    pub(crate) root_node: String,
+    pub(crate) current_tick: u64,
+    pub(crate) explicit_basis: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct IngressReport {
+    pub(crate) intent_kind: String,
+    pub(crate) submitted: usize,
+    pub(crate) ingress_ids: Vec<String>,
+    pub(crate) payloads: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ReceiptReport {
+    pub(crate) tx: u64,
+    pub(crate) entries: Vec<ReceiptEntryReport>,
+    pub(crate) applied_count: usize,
+    pub(crate) rejected_count: usize,
+    pub(crate) conflict_count: usize,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ReceiptEntryReport {
+    pub(crate) index: usize,
+    pub(crate) rule_id: String,
+    pub(crate) scope: String,
+    pub(crate) disposition: &'static str,
+    pub(crate) blocked_by: Vec<u32>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct CounterReport {
+    pub(crate) node: String,
+    pub(crate) value: u64,
+    pub(crate) submitted_increment_total: u64,
+    pub(crate) applied_increment_total: u64,
+}
+
+#[derive(Serialize)]
+pub(crate) struct HashReport {
+    pub(crate) commit_hash: String,
+    pub(crate) state_root: String,
+    pub(crate) plan_digest: String,
+    pub(crate) decision_digest: String,
+    pub(crate) receipt_digest: String,
+    pub(crate) decision_matches_receipt: bool,
+    pub(crate) rewrites_digest: String,
+    pub(crate) patch_digest: String,
+    pub(crate) patch_matches_snapshot: bool,
+    pub(crate) wsc_file_digest: String,
+    pub(crate) wsc_warp_state_root: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct PatchReport {
+    pub(crate) ops: usize,
+    pub(crate) in_slots: usize,
+    pub(crate) out_slots: usize,
+    pub(crate) commit_status: &'static str,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WscReport {
+    pub(crate) path: String,
+    pub(crate) verified: bool,
+    pub(crate) tick: u64,
+    pub(crate) warp_count: usize,
+    pub(crate) nodes: usize,
+    pub(crate) edges: usize,
+    pub(crate) node_attachments: usize,
+    pub(crate) edge_attachments: usize,
+    pub(crate) bytes: usize,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ContinuumReport {
+    pub(crate) bundle_digest: String,
+    pub(crate) shell_digest: String,
+    pub(crate) source_entries: usize,
+    pub(crate) outcome: &'static str,
+    pub(crate) admitted_refs: usize,
+}
+
+#[derive(Serialize)]
+pub(crate) struct InspectionReport {
+    pub(crate) inspect_tree: String,
+    pub(crate) verify_wsc: String,
+}
+
+pub(crate) fn run(config: HelloEchoConfig) -> Result<HelloEchoReport> {
+    let start = Instant::now();
+    let mut artifacts = run_capsule(&config.out_dir)?;
+    artifacts.elapsed_ms = start.elapsed().as_millis();
+
+    if artifacts.elapsed_ms > u128::from(config.max_ms) {
+        bail!(
+            "Hello Echo demo exceeded budget: {}ms > {}ms",
+            artifacts.elapsed_ms,
+            config.max_ms
+        );
+    }
+
+    Ok(artifacts.into_report(config.max_ms))
+}
+
+struct CapsuleArtifacts {
+    elapsed_ms: u128,
+    worldline_id: WorldlineId,
+    ingress: Vec<IngressEnvelope>,
+    state: WorldlineState,
+    outcome: warp_core::CommitOutcome,
+    counter_value: u64,
+    wsc_path: PathBuf,
+    wsc_file_digest: Hash,
+    wsc_warp_state_root: Hash,
+    wsc_verified: bool,
+    wsc_counts: WscCounts,
+    continuum: ContinuumArtifacts,
+}
+
+struct WscCounts {
+    tick: u64,
+    warp_count: usize,
+    nodes: usize,
+    edges: usize,
+    node_attachments: usize,
+    edge_attachments: usize,
+    bytes: usize,
+}
+
+struct ContinuumArtifacts {
+    bundle: CausalSuffixBundle,
+    outcome: &'static str,
+    admitted_refs: usize,
+}
+
+impl CapsuleArtifacts {
+    fn into_report(self, max_ms: u64) -> HelloEchoReport {
+        let root = self.state.root();
+        let receipt = self.outcome.receipt;
+        let patch = self.outcome.patch;
+        let snapshot = self.outcome.snapshot;
+        let ingress_ids = self
+            .ingress
+            .iter()
+            .map(|envelope| hash_hex(&envelope.ingress_id()))
+            .collect::<Vec<_>>();
+        let payloads = self
+            .ingress
+            .iter()
+            .map(|envelope| match envelope.payload() {
+                warp_core::IngressPayload::LocalIntent { intent_bytes, .. } => {
+                    String::from_utf8_lossy(intent_bytes).into_owned()
+                }
+            })
+            .collect::<Vec<_>>();
+        let receipt_report = receipt_report(&receipt);
+        let submitted_increment_total = payloads
+            .iter()
+            .filter_map(|payload| parse_amount(payload.as_bytes()))
+            .sum::<u64>();
+        let applied_increment_total = self.counter_value;
+        let deterministic_evidence_digest = deterministic_evidence_digest(
+            &snapshot.hash,
+            &receipt.digest(),
+            &patch.digest(),
+            &self.wsc_file_digest,
+            &self.continuum.bundle.bundle_digest,
+            self.counter_value,
+        );
+        let wsc_path = self.wsc_path.display().to_string();
+        let wsc_warp_state_root = hash_hex(&self.wsc_warp_state_root);
+        let features = feature_matrix(
+            self.ingress.len(),
+            receipt_report.applied_count,
+            receipt_report.conflict_count,
+            patch.ops().len(),
+            &wsc_path,
+            self.continuum.outcome,
+        );
+        let inspect_tree = format!("cargo run -p warp-cli -- inspect {} --tree", wsc_path);
+        let verify_wsc = format!(
+            "cargo run -p warp-cli -- verify {} --expected {}",
+            wsc_path, wsc_warp_state_root
+        );
+
+        HelloEchoReport {
+            demo: "hello-echo",
+            verdict: "pass",
+            elapsed_ms: self.elapsed_ms,
+            max_ms,
+            deterministic_evidence_digest,
+            features,
+            worldline: WorldlineReport {
+                id: hex::encode(self.worldline_id.as_bytes()),
+                root_warp: hash_hex(root.warp_id.as_bytes()),
+                root_node: hash_hex(root.local_id.as_bytes()),
+                current_tick: self.state.current_tick().as_u64(),
+                explicit_basis: "u0 -> tick:1".to_string(),
+            },
+            ingress: IngressReport {
+                intent_kind: hash_hex(make_intent_kind("hello-echo/increment").as_hash()),
+                submitted: self.ingress.len(),
+                ingress_ids,
+                payloads,
+            },
+            receipt: receipt_report,
+            counter: CounterReport {
+                node: hash_hex(counter_node_id().as_bytes()),
+                value: self.counter_value,
+                submitted_increment_total,
+                applied_increment_total,
+            },
+            hashes: HashReport {
+                commit_hash: hash_hex(&snapshot.hash),
+                state_root: hash_hex(&snapshot.state_root),
+                plan_digest: hash_hex(&snapshot.plan_digest),
+                decision_digest: hash_hex(&snapshot.decision_digest),
+                receipt_digest: hash_hex(&receipt.digest()),
+                decision_matches_receipt: snapshot.decision_digest == receipt.digest(),
+                rewrites_digest: hash_hex(&snapshot.rewrites_digest),
+                patch_digest: hash_hex(&patch.digest()),
+                patch_matches_snapshot: snapshot.patch_digest == patch.digest(),
+                wsc_file_digest: hash_hex(&self.wsc_file_digest),
+                wsc_warp_state_root,
+            },
+            patch: PatchReport {
+                ops: patch.ops().len(),
+                in_slots: patch.in_slots().len(),
+                out_slots: patch.out_slots().len(),
+                commit_status: "committed",
+            },
+            wsc: WscReport {
+                path: wsc_path,
+                verified: self.wsc_verified,
+                tick: self.wsc_counts.tick,
+                warp_count: self.wsc_counts.warp_count,
+                nodes: self.wsc_counts.nodes,
+                edges: self.wsc_counts.edges,
+                node_attachments: self.wsc_counts.node_attachments,
+                edge_attachments: self.wsc_counts.edge_attachments,
+                bytes: self.wsc_counts.bytes,
+            },
+            continuum: ContinuumReport {
+                bundle_digest: hash_hex(&self.continuum.bundle.bundle_digest),
+                shell_digest: hash_hex(&self.continuum.bundle.source_suffix.witness_digest),
+                source_entries: self.continuum.bundle.source_suffix.source_entries.len(),
+                outcome: self.continuum.outcome,
+                admitted_refs: self.continuum.admitted_refs,
+            },
+            inspection: InspectionReport {
+                inspect_tree,
+                verify_wsc,
+            },
+        }
+    }
+}
+
+fn run_capsule(out_dir: &PathBuf) -> Result<CapsuleArtifacts> {
+    std::fs::create_dir_all(out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+
+    let root_node = make_node_id("hello-echo/root");
+    let store = initial_store(root_node);
+    let mut engine = warp_core::Engine::new(store.clone(), root_node);
+    engine
+        .register_rule(counter_rule())
+        .context("failed to register Hello Echo counter rule")?;
+
+    let mut state =
+        WorldlineState::from_root_store(store, root_node).context("failed to build worldline")?;
+    let worldline_id = WorldlineId::from_bytes([0xE0; 32]);
+    let intent_kind = make_intent_kind("hello-echo/increment");
+    let ingress = vec![
+        IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            intent_kind,
+            intent_bytes("alice", 1),
+        ),
+        IngressEnvelope::local_intent(
+            IngressTarget::DefaultWriter { worldline_id },
+            intent_kind,
+            intent_bytes("bob", 1),
+        ),
+    ];
+
+    let outcome = engine
+        .commit_with_state(&mut state, &ingress)
+        .context("failed to commit Hello Echo runtime tick")?;
+    let counter_value = read_counter_from_state(&state)?;
+    let (wsc_path, wsc_file_digest, wsc_warp_state_root, wsc_verified, wsc_counts) =
+        write_and_validate_wsc(&state, out_dir)?;
+    let continuum = continuum_shell(worldline_id, &outcome.snapshot)?;
+
+    Ok(CapsuleArtifacts {
+        elapsed_ms: 0,
+        worldline_id,
+        ingress,
+        state,
+        outcome,
+        counter_value,
+        wsc_path,
+        wsc_file_digest,
+        wsc_warp_state_root,
+        wsc_verified,
+        wsc_counts,
+        continuum,
+    })
+}
+
+fn initial_store(root: NodeId) -> GraphStore {
+    let counter = counter_node_id();
+    let mut store = GraphStore::default();
+    store.insert_node(
+        root,
+        NodeRecord {
+            ty: make_type_id("hello-echo/world"),
+        },
+    );
+    store.insert_node(
+        counter,
+        NodeRecord {
+            ty: make_type_id("hello-echo/counter"),
+        },
+    );
+    store.insert_edge(
+        root,
+        EdgeRecord {
+            id: make_edge_id("hello-echo/root/counter"),
+            from: root,
+            to: counter,
+            ty: make_type_id("hello-echo/contains"),
+        },
+    );
+    store.set_node_attachment(counter, Some(counter_attachment(0)));
+    store
+}
+
+fn counter_rule() -> RewriteRule {
+    RewriteRule {
+        id: make_type_id("rule:cmd/hello_echo_counter").0,
+        name: COUNTER_RULE_NAME,
+        left: PatternGraph { nodes: vec![] },
+        matcher: counter_matcher,
+        executor: counter_executor,
+        compute_footprint: counter_footprint,
+        factor_mask: 1,
+        conflict_policy: ConflictPolicy::Abort,
+        join_fn: None,
+    }
+}
+
+fn counter_matcher(view: GraphView<'_>, scope: &NodeId) -> bool {
+    read_intent_amount(&view, scope).is_some()
+}
+
+fn counter_executor(view: GraphView<'_>, scope: &NodeId, delta: &mut TickDelta) {
+    let Some(amount) = read_intent_amount(&view, scope) else {
+        return;
+    };
+    let current = view
+        .node_attachment(&counter_node_id())
+        .and_then(counter_from_attachment)
+        .unwrap_or(0);
+    let Some(next) = current.checked_add(amount) else {
+        return;
+    };
+    let key = AttachmentKey::node_alpha(NodeKey {
+        warp_id: view.warp_id(),
+        local_id: counter_node_id(),
+    });
+    delta.push(WarpOp::SetAttachment {
+        key,
+        value: Some(counter_attachment(next)),
+    });
+}
+
+fn counter_footprint(view: GraphView<'_>, scope: &NodeId) -> Footprint {
+    let warp_id = view.warp_id();
+    let event = NodeKey {
+        warp_id,
+        local_id: *scope,
+    };
+    let counter = NodeKey {
+        warp_id,
+        local_id: counter_node_id(),
+    };
+    let mut footprint = Footprint::default();
+    footprint.n_read.insert(event);
+    footprint.n_read.insert(counter);
+    footprint.a_read.insert(AttachmentKey::node_alpha(event));
+    footprint.a_read.insert(AttachmentKey::node_alpha(counter));
+    footprint.a_write.insert(AttachmentKey::node_alpha(counter));
+    footprint.factor_mask = 1;
+    footprint
+}
+
+fn read_intent_amount(view: &GraphView<'_>, scope: &NodeId) -> Option<u64> {
+    let attachment = view.node_attachment(scope)?;
+    let AttachmentValue::Atom(atom) = attachment else {
+        return None;
+    };
+    if atom.type_id != make_type_id(INTENT_ATTACHMENT_TYPE) {
+        return None;
+    }
+    parse_amount(atom.bytes.as_ref())
+}
+
+fn parse_amount(bytes: &[u8]) -> Option<u64> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    let rest = text.strip_prefix(INTENT_PREFIX)?;
+    rest.split(';').find_map(|part| {
+        part.strip_prefix("amount=")
+            .and_then(|amount| amount.parse::<u64>().ok())
+    })
+}
+
+fn intent_bytes(client: &str, amount: u64) -> Vec<u8> {
+    format!("{INTENT_PREFIX}op=increment;amount={amount};client={client}").into_bytes()
+}
+
+fn counter_node_id() -> NodeId {
+    make_node_id(COUNTER_NODE)
+}
+
+fn counter_attachment(value: u64) -> AttachmentValue {
+    AttachmentValue::Atom(AtomPayload::new(
+        make_type_id(COUNTER_VALUE_TYPE),
+        Bytes::copy_from_slice(&value.to_le_bytes()),
+    ))
+}
+
+fn counter_from_attachment(value: &AttachmentValue) -> Option<u64> {
+    let AttachmentValue::Atom(atom) = value else {
+        return None;
+    };
+    if atom.type_id != make_type_id(COUNTER_VALUE_TYPE) || atom.bytes.len() != 8 {
+        return None;
+    }
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(atom.bytes.as_ref());
+    Some(u64::from_le_bytes(bytes))
+}
+
+fn read_counter_from_state(state: &WorldlineState) -> Result<u64> {
+    let store = state
+        .store(&state.root().warp_id)
+        .context("worldline root store is missing")?;
+    let value = store
+        .node_attachment(&counter_node_id())
+        .and_then(counter_from_attachment)
+        .context("counter attachment is missing or malformed")?;
+    Ok(value)
+}
+
+fn write_and_validate_wsc(
+    state: &WorldlineState,
+    out_dir: &PathBuf,
+) -> Result<(PathBuf, Hash, Hash, bool, WscCounts)> {
+    let store = state
+        .store(&state.root().warp_id)
+        .context("worldline root store is missing")?;
+    let input = build_one_warp_input(store, state.root().local_id);
+    let bytes = write_wsc_one_warp(
+        &input,
+        make_type_id(WSC_SCHEMA).0,
+        state.current_tick().as_u64(),
+    )
+    .context("failed to write WSC bytes")?;
+    let path = out_dir.join("counter.wsc");
+    std::fs::write(&path, &bytes).with_context(|| format!("failed to write {}", path.display()))?;
+
+    let file =
+        WscFile::open(&path).with_context(|| format!("failed to open {}", path.display()))?;
+    validate_wsc(&file).with_context(|| format!("failed to validate {}", path.display()))?;
+    let view = file.warp_view(0).context("failed to read WSC warp 0")?;
+    let node_attachments = view
+        .nodes()
+        .iter()
+        .enumerate()
+        .map(|(index, _)| view.node_attachments(index).len())
+        .sum();
+    let edge_attachments = view
+        .edges()
+        .iter()
+        .enumerate()
+        .map(|(index, _)| view.edge_attachments(index).len())
+        .sum();
+    let counts = WscCounts {
+        tick: file.tick(),
+        warp_count: file.warp_count(),
+        nodes: view.nodes().len(),
+        edges: view.edges().len(),
+        node_attachments,
+        edge_attachments,
+        bytes: bytes.len(),
+    };
+    Ok((
+        path,
+        blake3::hash(&bytes).into(),
+        store.canonical_state_hash(),
+        true,
+        counts,
+    ))
+}
+
+fn continuum_shell(
+    worldline_id: WorldlineId,
+    snapshot: &warp_core::Snapshot,
+) -> Result<ContinuumArtifacts> {
+    let base = ProvenanceRef {
+        worldline_id,
+        worldline_tick: WorldlineTick::ZERO,
+        commit_hash: warp_core::digest_len0_u64(),
+    };
+    let target = ProvenanceRef {
+        worldline_id,
+        worldline_tick: WorldlineTick::from_raw(1),
+        commit_hash: snapshot.hash,
+    };
+    let export_request = ExportSuffixRequest {
+        source_worldline_id: worldline_id,
+        base_frontier: base,
+        target_frontier: Some(target),
+        basis_report: None,
+    };
+    let export_context = DemoSuffixExportContext {
+        source_entry: target,
+        boundary_witness: base,
+    };
+    let bundle = export_suffix(&export_request, &export_context)
+        .map_err(|obstruction| anyhow::anyhow!("suffix export obstructed: {obstruction:?}"))?;
+    let import_request = ImportSuffixRequest {
+        bundle: bundle.clone(),
+        target_worldline_id: worldline_id,
+        target_basis: base,
+        basis_report: None,
+    };
+    let admission_context = DemoSuffixAdmissionContext {
+        target_basis: base,
+        admitted_ref: target,
+    };
+    let import = import_suffix(&import_request, &admission_context);
+    let (outcome, admitted_refs) = match &import.admission.outcome {
+        WitnessedSuffixAdmissionOutcome::Admitted { admitted_refs, .. } => {
+            ("admitted", admitted_refs.len())
+        }
+        WitnessedSuffixAdmissionOutcome::Staged { staged_refs, .. } => {
+            ("staged", staged_refs.len())
+        }
+        WitnessedSuffixAdmissionOutcome::Plural { candidate_refs, .. } => {
+            ("plural", candidate_refs.len())
+        }
+        WitnessedSuffixAdmissionOutcome::Conflict { .. } => ("conflict", 0),
+        WitnessedSuffixAdmissionOutcome::Obstructed { .. } => ("obstructed", 0),
+    };
+    Ok(ContinuumArtifacts {
+        bundle,
+        outcome,
+        admitted_refs,
+    })
+}
+
+struct DemoSuffixExportContext {
+    source_entry: ProvenanceRef,
+    boundary_witness: ProvenanceRef,
+}
+
+impl WitnessedSuffixExportContext for DemoSuffixExportContext {
+    fn source_entries(&self, _request: &ExportSuffixRequest) -> Option<Vec<ProvenanceRef>> {
+        Some(vec![self.source_entry])
+    }
+
+    fn boundary_witness(&self, _request: &ExportSuffixRequest) -> Option<ProvenanceRef> {
+        Some(self.boundary_witness)
+    }
+}
+
+struct DemoSuffixAdmissionContext {
+    target_basis: ProvenanceRef,
+    admitted_ref: ProvenanceRef,
+}
+
+impl WitnessedSuffixAdmissionContext for DemoSuffixAdmissionContext {
+    fn source_shell_digest(&self, shell: &warp_core::WitnessedSuffixShell) -> Option<Hash> {
+        Some(derive_witnessed_suffix_shell_digest(shell))
+    }
+
+    fn resolve_target_basis(&self, target_basis: ProvenanceRef) -> Option<ProvenanceRef> {
+        (target_basis == self.target_basis).then_some(target_basis)
+    }
+
+    fn local_admission_posture(
+        &self,
+        _request: &warp_core::WitnessedSuffixAdmissionRequest,
+    ) -> WitnessedSuffixLocalAdmissionPosture {
+        WitnessedSuffixLocalAdmissionPosture::Admissible {
+            admitted_refs: vec![self.admitted_ref],
+        }
+    }
+}
+
+fn receipt_report(receipt: &TickReceipt) -> ReceiptReport {
+    let mut applied_count = 0usize;
+    let mut rejected_count = 0usize;
+    let mut conflict_count = 0usize;
+    let mut entries = Vec::with_capacity(receipt.entries().len());
+
+    for (index, entry) in receipt.entries().iter().enumerate() {
+        let disposition = match entry.disposition {
+            TickReceiptDisposition::Applied => {
+                applied_count += 1;
+                "applied"
+            }
+            TickReceiptDisposition::Rejected(TickReceiptRejection::FootprintConflict) => {
+                rejected_count += 1;
+                conflict_count += 1;
+                "rejected:footprint-conflict"
+            }
+        };
+        entries.push(ReceiptEntryReport {
+            index,
+            rule_id: hash_hex(&entry.rule_id),
+            scope: hash_hex(entry.scope.local_id.as_bytes()),
+            disposition,
+            blocked_by: receipt.blocked_by(index).to_vec(),
+        });
+    }
+
+    ReceiptReport {
+        tx: receipt.tx().value(),
+        entries,
+        applied_count,
+        rejected_count,
+        conflict_count,
+    }
+}
+
+fn feature_matrix(
+    ingress_count: usize,
+    applied_count: usize,
+    conflict_count: usize,
+    patch_ops: usize,
+    wsc_path: &str,
+    continuum_outcome: &str,
+) -> Vec<FeatureEvidence> {
+    vec![
+        FeatureEvidence {
+            feature: "explicit causal basis",
+            witness: "worldline reports U0 -> tick:1 and root warp/node coordinates".to_string(),
+        },
+        FeatureEvidence {
+            feature: "canonical ingress",
+            witness: format!("{ingress_count} content-addressed local intent envelopes"),
+        },
+        FeatureEvidence {
+            feature: "runtime-owned tick",
+            witness: "Engine::commit_with_state admitted and committed the scheduler tick"
+                .to_string(),
+        },
+        FeatureEvidence {
+            feature: "domain semantics outside Echo core",
+            witness: format!("repo-owned {COUNTER_RULE_NAME} rule hosts toy counter semantics"),
+        },
+        FeatureEvidence {
+            feature: "receipt evidence",
+            witness: format!("{applied_count} applied candidate and {conflict_count} obstruction"),
+        },
+        FeatureEvidence {
+            feature: "footprint conflict detection",
+            witness: "two increment intents target the same counter attachment slot".to_string(),
+        },
+        FeatureEvidence {
+            feature: "canonical hashing",
+            witness:
+                "report includes commit, state, plan, decision, receipt, patch, and WSC digests"
+                    .to_string(),
+        },
+        FeatureEvidence {
+            feature: "replayable patch boundary",
+            witness: format!("{patch_ops} canonical patch operations emitted"),
+        },
+        FeatureEvidence {
+            feature: "WSC materialized reading",
+            witness: format!("validated single-warp WSC artifact at {wsc_path}"),
+        },
+        FeatureEvidence {
+            feature: "witnessed suffix posture",
+            witness: format!("shape-only Continuum shell classified as {continuum_outcome}"),
+        },
+    ]
+}
+
+fn deterministic_evidence_digest(
+    commit_hash: &Hash,
+    receipt_digest: &Hash,
+    patch_digest: &Hash,
+    wsc_file_digest: &Hash,
+    suffix_bundle_digest: &Hash,
+    counter_value: u64,
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"hello-echo/evidence/v1");
+    hasher.update(commit_hash);
+    hasher.update(receipt_digest);
+    hasher.update(patch_digest);
+    hasher.update(wsc_file_digest);
+    hasher.update(suffix_bundle_digest);
+    hasher.update(&counter_value.to_le_bytes());
+    hash_hex(hasher.finalize().as_bytes())
+}
+
+fn hash_hex(hash: &Hash) -> String {
+    hex::encode(hash)
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,6 +22,8 @@ use std::process::Command;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+mod hello_echo;
+
 #[derive(Parser)]
 #[command(
     name = "xtask",
@@ -41,6 +43,8 @@ enum Commands {
     Dags(DagsArgs),
     /// Emit agent-native Doghouse recorder events.
     Doghouse(DoghouseArgs),
+    /// Run the 30-second Hello Echo evidence capsule.
+    HelloEcho(HelloEchoArgs),
     /// Summarize current-head PR status, unresolved threads, and check state.
     PrStatus(PrStatusArgs),
     /// Record a durable PR review-state snapshot under local ignored artifacts.
@@ -75,6 +79,19 @@ struct TestSliceArgs {
     /// Print the exact commands without running them.
     #[arg(long)]
     dry_run: bool,
+}
+
+#[derive(Args)]
+struct HelloEchoArgs {
+    /// Output the evidence capsule as JSON.
+    #[arg(long)]
+    json: bool,
+    /// Directory for generated WSC and report artifacts.
+    #[arg(long, default_value = "target/hello-echo")]
+    out_dir: PathBuf,
+    /// Fail if the demo exceeds this local wall-clock budget in milliseconds.
+    #[arg(long, default_value = "30000")]
+    max_ms: u64,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -504,6 +521,7 @@ fn main() -> Result<()> {
         Commands::Bench(args) => run_bench(args),
         Commands::Dags(args) => run_dags(args),
         Commands::Doghouse(args) => run_doghouse(args),
+        Commands::HelloEcho(args) => run_hello_echo(args),
         Commands::PrStatus(args) => run_pr_status(args),
         Commands::PrSnapshot(args) => run_pr_snapshot(args),
         Commands::PrThreads(args) => run_pr_threads(args),
@@ -517,6 +535,38 @@ fn main() -> Result<()> {
         Commands::Wesley(args) => run_wesley(args),
         Commands::TestSlice(args) => run_test_slice(args),
     }
+}
+
+fn run_hello_echo(args: HelloEchoArgs) -> Result<()> {
+    let report = hello_echo::run(hello_echo::HelloEchoConfig {
+        out_dir: args.out_dir,
+        max_ms: args.max_ms,
+    })?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("Hello Echo: {}", report.verdict);
+        println!(
+            "elapsed={}ms budget={}ms evidence={}",
+            report.elapsed_ms, report.max_ms, report.deterministic_evidence_digest
+        );
+        println!(
+            "tick={} applied={} rejected={} conflict={}",
+            report.worldline.current_tick,
+            report.receipt.applied_count,
+            report.receipt.rejected_count,
+            report.receipt.conflict_count
+        );
+        println!(
+            "counter={} wsc={} suffix={}",
+            report.counter.value, report.wsc.path, report.continuum.outcome
+        );
+        println!("inspect: {}", report.inspection.inspect_tree);
+        println!("verify:  {}", report.inspection.verify_wsc);
+    }
+
+    Ok(())
 }
 
 fn run_test_slice(args: TestSliceArgs) -> Result<()> {


### PR DESCRIPTION
## Summary

- add `cargo xtask hello-echo` as a 30-second evidence capsule for Echo
- update the README with the FAQ/onramp framing for common Echo misconceptions
- add the docs lifecycle policy for design accumulation, canonical domain-doc absorption, supersession, and archive handling

## Verification

- `cargo fmt --check`
- `cargo check -p xtask`
- `cargo xtask hello-echo --json`
- `npx markdownlint-cli2 README.md`
- `cargo xtask lint-dead-refs --file README.md`
- `cargo check`
- `npx prettier --check docs/procedures/DOCS-LIFECYCLE.md docs/index.md docs/workflows.md`
- `npx markdownlint-cli2 docs/procedures/DOCS-LIFECYCLE.md docs/index.md docs/workflows.md`
- `cargo xtask lint-dead-refs --file docs/procedures/DOCS-LIFECYCLE.md --file docs/index.md --file docs/workflows.md`
- `git diff --check`

## Notes

The pre-existing untracked `docs/README.md.md` was left untouched and is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hello-echo` command-line tool for testing and evidence validation.

* **Documentation**
  * Expanded README with problem statement, vocabulary definitions, and comprehensive FAQ.
  * Introduced documentation lifecycle policy with status tracking for design documents.
  * Updated contributor workflows and documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->