### PR TITLE
Harden strand construction and typed braid failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   use fixture builders and accessors, `ProofEnvelope::validate_shape(...)`
   returns structured `ProofError`, and invalid braid lifecycle transitions
   report typed `BraidTransitionKind` instead of action strings.
+- `warp-core` now enforces the v1 single-writer-head strand invariant through
+  both `Strand::new(...)` and `StrandRegistry::insert(...)`, and runtime strand
+  forking constructs the registered relation through the same constructor
+  boundary used by external callers.
 - `warp-core` casting a dynamically postured strand to statically shared now returns a semantically precise `PostureObstruction::PostureMismatch` instead of `PostureObstruction::NarrowingRefused`.
 - `warp-core` renamed `ProofEnvelope::verify` to `validate_shape` and updated error variants to `ProofShapeValidationFailed` to accurately reflect shape/input checks rather than full cryptographic proof verification.
 - `warp-core` strand creation now carries explicit `RetentionPosture` through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ### Added
 
+- `warp-core` now hardens the first braids/strands roadmap goalpost: `Strand<P>`
+  fields are no longer publicly constructible, `Strand::new(...)` validates
+  typestate/runtime-posture coherence before construction, public strand tests
+  use fixture builders and accessors, `ProofEnvelope::validate_shape(...)`
+  returns structured `ProofError`, and invalid braid lifecycle transitions
+  report typed `BraidTransitionKind` instead of action strings.
 - `warp-core` casting a dynamically postured strand to statically shared now returns a semantically precise `PostureObstruction::PostureMismatch` instead of `PostureObstruction::NarrowingRefused`.
 - `warp-core` renamed `ProofEnvelope::verify` to `validate_shape` and updated error variants to `ProofShapeValidationFailed` to accurately reflect shape/input checks rather than full cryptographic proof verification.
 - `warp-core` strand creation now carries explicit `RetentionPosture` through

--- a/crates/echo-wesley-gen/tests/generation.rs
+++ b/crates/echo-wesley-gen/tests/generation.rs
@@ -4,7 +4,7 @@
 //! Integration test for the echo-wesley-gen CLI (Wesley IR -> Rust code).
 
 use std::fs;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::OnceLock;
@@ -131,9 +131,11 @@ fn run_wesley_gen_with_args(ir: &str, args: &[&str]) -> Output {
         .expect("failed to spawn echo-wesley-gen");
 
     let mut stdin = child.stdin.take().expect("failed to get stdin");
-    stdin
-        .write_all(ir.as_bytes())
-        .expect("failed to write to stdin");
+    match stdin.write_all(ir.as_bytes()) {
+        Ok(()) => {}
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
+        Err(err) => panic!("failed to write to stdin: {err}"),
+    }
     drop(stdin);
 
     child.wait_with_output().expect("failed to wait on child")

--- a/crates/warp-core/src/braid.rs
+++ b/crates/warp-core/src/braid.rs
@@ -33,6 +33,18 @@ pub enum BraidTransitionKind {
     Collapse,
 }
 
+impl std::fmt::Display for BraidTransitionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Create => "create braid",
+            Self::WeaveMember => "weave member",
+            Self::FinalizeSettlement => "finalize settlement",
+            Self::Collapse => "collapse braid",
+        };
+        f.write_str(label)
+    }
+}
+
 /// Error kinds returned during coordination braid lifecycle updates or folds.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BraidError {
@@ -54,7 +66,7 @@ pub enum BraidError {
         actual: u64,
     },
     /// An invalid transition was attempted for the current braid status.
-    #[error("cannot transition braid state: cannot {transition:?} in status {status:?}")]
+    #[error("cannot transition braid state: cannot {transition} in status {status:?}")]
     InvalidTransition {
         /// Attempted lifecycle transition.
         transition: BraidTransitionKind,

--- a/crates/warp-core/src/braid.rs
+++ b/crates/warp-core/src/braid.rs
@@ -20,6 +20,19 @@ pub enum BraidStatus {
     Collapsed,
 }
 
+/// Typed lifecycle transition attempted against a braid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BraidTransitionKind {
+    /// Create the braid event log.
+    Create,
+    /// Weave a member into the active frontier.
+    WeaveMember,
+    /// Finalize settlement for the current frontier.
+    FinalizeSettlement,
+    /// Collapse a finalized plural braid.
+    Collapse,
+}
+
 /// Error kinds returned during coordination braid lifecycle updates or folds.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BraidError {
@@ -41,10 +54,10 @@ pub enum BraidError {
         actual: u64,
     },
     /// An invalid transition was attempted for the current braid status.
-    #[error("cannot transition braid state: cannot {action} in status {status:?}")]
+    #[error("cannot transition braid state: cannot {transition:?} in status {status:?}")]
     InvalidTransition {
-        /// Attempted action or event kind.
-        action: String,
+        /// Attempted lifecycle transition.
+        transition: BraidTransitionKind,
         /// Current braid status.
         status: BraidStatus,
     },
@@ -161,7 +174,7 @@ impl Braid {
             } => {
                 if self.status != BraidStatus::Active {
                     return Err(BraidError::InvalidTransition {
-                        action: "weave member".to_string(),
+                        transition: BraidTransitionKind::WeaveMember,
                         status: self.status,
                     });
                 }
@@ -195,7 +208,7 @@ impl Braid {
             BraidEvent::SettlementFinalized { settlement_digest } => {
                 if self.status != BraidStatus::Active {
                     return Err(BraidError::InvalidTransition {
-                        action: "finalize settlement".to_string(),
+                        transition: BraidTransitionKind::FinalizeSettlement,
                         status: self.status,
                     });
                 }
@@ -211,7 +224,7 @@ impl Braid {
             } => {
                 if self.status != BraidStatus::Finalized {
                     return Err(BraidError::InvalidTransition {
-                        action: "collapse braid".to_string(),
+                        transition: BraidTransitionKind::Collapse,
                         status: self.status,
                     });
                 }
@@ -459,7 +472,7 @@ mod tests {
         assert_eq!(
             Braid::fold(bad_events_weave_after_finalized),
             Err(BraidError::InvalidTransition {
-                action: "weave member".to_string(),
+                transition: BraidTransitionKind::WeaveMember,
                 status: BraidStatus::Finalized
             })
         );
@@ -478,7 +491,7 @@ mod tests {
         assert_eq!(
             Braid::fold(bad_events_collapse_before_finalized),
             Err(BraidError::InvalidTransition {
-                action: "collapse braid".to_string(),
+                transition: BraidTransitionKind::Collapse,
                 status: BraidStatus::Active
             })
         );
@@ -539,7 +552,7 @@ mod tests {
                 sequence_num: 2,
             }),
             Err(BraidError::InvalidTransition {
-                action: "weave member".to_string(),
+                transition: BraidTransitionKind::WeaveMember,
                 status: BraidStatus::Finalized,
             })
         );

--- a/crates/warp-core/src/braid_shell.rs
+++ b/crates/warp-core/src/braid_shell.rs
@@ -338,7 +338,7 @@ pub enum BraidShellError {
     #[error("proof shape validation failed: {reason}")]
     ProofShapeValidationFailed {
         /// Reason for shape validation failure.
-        reason: String,
+        reason: crate::proof::ProofError,
     },
     /// Member entries are not in canonical order.
     #[error("braid shell members are not in canonical order")]
@@ -1891,7 +1891,7 @@ mod tests {
 
     #[test]
     fn assemble_with_proof_validates_envelope() {
-        use crate::proof::{ProofEnvelope, ProofKind};
+        use crate::proof::{ProofEnvelope, ProofError, ProofKind};
 
         let members = vec![member("member-a", MemberVerdict::Plural)];
 
@@ -1966,7 +1966,12 @@ mod tests {
         );
         assert!(matches!(
             result_mismatch,
-            Err(BraidShellError::ProofShapeValidationFailed { .. })
+            Err(BraidShellError::ProofShapeValidationFailed {
+                reason: ProofError::PublicInputsMismatch {
+                    expected,
+                    actual,
+                },
+            }) if expected == expected_witness && actual == [0x99; 32]
         ));
 
         // Invalid proof: empty proof bytes
@@ -1988,13 +1993,15 @@ mod tests {
         );
         assert!(matches!(
             result_empty,
-            Err(BraidShellError::ProofShapeValidationFailed { .. })
+            Err(BraidShellError::ProofShapeValidationFailed {
+                reason: ProofError::EmptyPayload,
+            })
         ));
     }
 
     #[test]
     fn cryptographic_proof_kinds_require_verifier_backend() {
-        use crate::proof::{ProofEnvelope, ProofKind};
+        use crate::proof::{ProofEnvelope, ProofError, ProofKind};
 
         let members = vec![member("member-a", MemberVerdict::Plural)];
         let temp_shell = BraidShell::assemble(
@@ -2027,7 +2034,9 @@ mod tests {
             );
             assert!(matches!(
                 result,
-                Err(BraidShellError::ProofShapeValidationFailed { .. })
+                Err(BraidShellError::ProofShapeValidationFailed {
+                    reason: ProofError::UnsupportedKind { kind: rejected },
+                }) if rejected == kind
             ));
         }
     }

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -1602,20 +1602,20 @@ impl WorldlineRuntime {
                     .map(|head| *head.key())
                     .collect::<Vec<_>>();
                 let retention_posture = request.retention_posture;
+                let strand = Strand::new(
+                    request.strand_id,
+                    fork_basis_ref,
+                    request.child_worldline_id,
+                    writer_heads.clone(),
+                    Vec::new(),
+                    retention_posture,
+                )?;
 
                 self.register_worldline(request.child_worldline_id, child_state)?;
                 for head in request.writer_heads {
                     self.register_writer_head(head)?;
                 }
-                self.register_strand(Strand {
-                    strand_id: request.strand_id,
-                    fork_basis_ref,
-                    child_worldline_id: request.child_worldline_id,
-                    writer_heads: writer_heads.clone(),
-                    support_pins: Vec::new(),
-                    retention_posture,
-                    _marker: std::marker::PhantomData,
-                })?;
+                self.register_strand(strand)?;
 
                 Ok(ForkStrandReceipt {
                     strand_id: request.strand_id,
@@ -4066,6 +4066,61 @@ mod tests {
             historical_state.state_root()
         );
         assert_eq!(provenance.len(child_worldline_id).unwrap(), 1);
+    }
+
+    #[test]
+    fn fork_strand_rejects_empty_writer_heads_and_rolls_back() {
+        let mut runtime = WorldlineRuntime::new();
+        let mut engine = empty_engine();
+        let source_lane_id = wl(1);
+        let child_worldline_id = wl(2);
+        let strand_id = make_strand_id("fork-empty-heads");
+
+        runtime
+            .register_worldline(source_lane_id, WorldlineState::empty())
+            .unwrap();
+        register_head(
+            &mut runtime,
+            source_lane_id,
+            "source-default",
+            None,
+            true,
+            InboxPolicy::AcceptAll,
+        );
+
+        let mut provenance = mirrored_provenance(&runtime);
+        commit_one_tick(
+            &mut runtime,
+            &mut provenance,
+            &mut engine,
+            source_lane_id,
+            "fork-empty-heads-source",
+        );
+
+        let err = runtime
+            .fork_strand(
+                &mut provenance,
+                ForkStrandRequest {
+                    strand_id,
+                    source_lane_id,
+                    fork_tick: wt(0),
+                    child_worldline_id,
+                    writer_heads: Vec::new(),
+                    retention_posture: test_retention_posture(12),
+                },
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RuntimeError::Strand(StrandError::InvariantViolation(
+                "INV-S2: v1 strands must carry exactly one writer head"
+            ))
+        ));
+        assert!(runtime.worldlines().get(&child_worldline_id).is_none());
+        assert!(runtime.strands().get(&strand_id).is_none());
+        assert!(provenance.len(child_worldline_id).is_err());
+        assert_eq!(provenance.len(source_lane_id).unwrap(), 1);
     }
 
     #[test]

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -256,9 +256,11 @@ pub use retained_evidence::{
 // --- Session types ---
 pub use playback::{SessionId, ViewSession};
 // --- Proof types ---
-pub use proof::{ObserverHonestyClaim, ProofEnvelope, ProofKind};
+pub use proof::{
+    ObserverHonestyClaim, ProofEnvelope, ProofError, ProofKind, VerificationFailureCode,
+};
 // --- Braid Log types ---
-pub use braid::{Braid, BraidError, BraidEvent, BraidStatus};
+pub use braid::{Braid, BraidError, BraidEvent, BraidStatus, BraidTransitionKind};
 // --- Retained boundary shell family (θ_tick, θ_braid) ---
 pub use braid_shell::{
     collapse_braid_shell, replay_braid_shell, BraidCoordinate, BraidMemberRef, BraidShell,

--- a/crates/warp-core/src/proof.rs
+++ b/crates/warp-core/src/proof.rs
@@ -3,6 +3,7 @@
 //! Proof envelopes and honesty assertions.
 
 use blake3::Hasher;
+use thiserror::Error;
 
 use crate::braid_shell::BraidCoordinate;
 use crate::ident::Hash;
@@ -41,6 +42,46 @@ impl ProofKind {
     }
 }
 
+/// Future verifier backend rejection code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VerificationFailureCode {
+    /// A verifier backend rejected the proof without a narrower public reason.
+    Rejected,
+}
+
+/// Structured proof envelope validation failure.
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
+pub enum ProofError {
+    /// This proof kind is reserved until a verifier backend is wired.
+    #[error("{kind:?} proof envelopes require a verifier backend before admission")]
+    UnsupportedKind {
+        /// Unsupported proof kind.
+        kind: ProofKind,
+    },
+    /// The envelope carried no proof/evidence bytes.
+    #[error("proof payload is empty")]
+    EmptyPayload,
+    /// The envelope public inputs did not bind to the expected digest.
+    #[error("public inputs mismatch: expected {expected:?}, got {actual:?}")]
+    PublicInputsMismatch {
+        /// Expected public-input hash.
+        expected: Hash,
+        /// Actual public-input hash carried by the envelope.
+        actual: Hash,
+    },
+    /// The envelope shape was malformed before backend verification.
+    #[error("malformed proof envelope")]
+    MalformedEnvelope,
+    /// A verifier backend rejected the proof.
+    #[error("{kind:?} verifier backend rejected proof: {reason:?}")]
+    BackendRejected {
+        /// Proof kind rejected by the backend.
+        kind: ProofKind,
+        /// Backend rejection code.
+        reason: VerificationFailureCode,
+    },
+}
+
 /// A proof-shaped envelope whose current validation admits replay-trace
 /// evidence by checking structure and public-input binding.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -62,22 +103,20 @@ impl ProofEnvelope {
     ///
     /// # Errors
     ///
-    /// Returns a validation error string if proof bytes are empty or public inputs mismatch.
-    pub fn validate_shape(&self, expected_public_inputs_hash: Hash) -> Result<(), String> {
+    /// Returns [`ProofError`] if proof bytes are empty, the proof kind is not
+    /// admitted by shape-only validation, or public inputs mismatch.
+    pub fn validate_shape(&self, expected_public_inputs_hash: Hash) -> Result<(), ProofError> {
         if !self.kind.accepts_shape_only() {
-            return Err(format!(
-                "{:?} proof envelopes require a verifier backend before admission",
-                self.kind
-            ));
+            return Err(ProofError::UnsupportedKind { kind: self.kind });
         }
         if self.proof_bytes.is_empty() {
-            return Err("Proof payload is empty".to_string());
+            return Err(ProofError::EmptyPayload);
         }
         if self.public_inputs_hash != expected_public_inputs_hash {
-            return Err(format!(
-                "Public inputs mismatch: expected {:?}, got {:?}",
-                expected_public_inputs_hash, self.public_inputs_hash
-            ));
+            return Err(ProofError::PublicInputsMismatch {
+                expected: expected_public_inputs_hash,
+                actual: self.public_inputs_hash,
+            });
         }
         Ok(())
     }

--- a/crates/warp-core/src/strand.rs
+++ b/crates/warp-core/src/strand.rs
@@ -134,25 +134,150 @@ pub struct DropReceipt {
 /// A strand either exists in the `StrandRegistry` (live) or does not
 /// (dropped). There is no lifecycle field — operational state is derived
 /// from the writer heads.
+///
+/// External callers must use named constructors. Struct-literal construction
+/// would let callers forge a static posture marker that disagrees with the
+/// runtime retention posture:
+///
+/// ```compile_fail
+/// use warp_core::{Shared, Strand};
+///
+/// let _forged: Strand<Shared> = Strand {
+///     strand_id: todo!(),
+///     fork_basis_ref: todo!(),
+///     child_worldline_id: todo!(),
+///     writer_heads: todo!(),
+///     support_pins: todo!(),
+///     retention_posture: todo!(),
+///     _marker: std::marker::PhantomData,
+/// };
+/// ```
+#[expect(
+    clippy::struct_field_names,
+    reason = "strand_id is the canonical domain field name"
+)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Strand<P: CausalPostureState = DynamicPosture> {
     /// Unique strand identity.
-    pub strand_id: StrandId,
+    pub(crate) strand_id: StrandId,
     /// Immutable fork coordinate.
-    pub fork_basis_ref: ForkBasisRef,
+    pub(crate) fork_basis_ref: ForkBasisRef,
     /// Child worldline created by fork.
-    pub child_worldline_id: WorldlineId,
+    pub(crate) child_worldline_id: WorldlineId,
     /// Writer heads for the child worldline (cardinality 1 in v1).
-    pub writer_heads: Vec<WriterHeadKey>,
+    pub(crate) writer_heads: Vec<WriterHeadKey>,
     /// Read-only support pins for braid geometry.
-    pub support_pins: Vec<SupportPin>,
+    pub(crate) support_pins: Vec<SupportPin>,
     /// Explicit retention, authority, and admission posture for the strand.
-    pub retention_posture: RetentionPosture,
+    pub(crate) retention_posture: RetentionPosture,
     /// Phantom marker for the static causal posture typestate.
-    pub _marker: std::marker::PhantomData<P>,
+    pub(crate) _marker: std::marker::PhantomData<P>,
 }
 
 impl<P: CausalPostureState> Strand<P> {
+    /// Creates a strand through a posture-aware constructor boundary.
+    ///
+    /// This validates the retained posture bundle, checks the static posture
+    /// marker against runtime posture when the marker is concrete, and enforces
+    /// the local strand invariants that do not require live registry context.
+    /// [`StrandRegistry`] remains responsible for registry-relative admission
+    /// checks such as support target liveness.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StrandError`] when the retained posture is incoherent, the
+    /// static posture marker disagrees with runtime posture, the child and
+    /// source worldlines are the same, writer heads target the wrong child
+    /// worldline, or support pins are self-targeted or duplicate one another.
+    pub fn new(
+        strand_id: StrandId,
+        fork_basis_ref: ForkBasisRef,
+        child_worldline_id: WorldlineId,
+        writer_heads: Vec<WriterHeadKey>,
+        support_pins: Vec<SupportPin>,
+        retention_posture: RetentionPosture,
+    ) -> Result<Self, StrandError> {
+        retention_posture.validate().map_err(StrandError::Posture)?;
+        if let Some(expected) = P::causal_posture() {
+            if retention_posture.causal_posture != expected {
+                return Err(StrandError::Posture(PostureObstruction::PostureMismatch {
+                    actual: retention_posture.causal_posture,
+                    expected,
+                }));
+            }
+        }
+        if child_worldline_id == fork_basis_ref.source_lane_id {
+            return Err(StrandError::InvariantViolation(
+                "INV-S7: child_worldline_id must differ from fork_basis_ref.source_lane_id",
+            ));
+        }
+        for head_key in &writer_heads {
+            if head_key.worldline_id != child_worldline_id {
+                return Err(StrandError::InvariantViolation(
+                    "INV-S8: every writer head must belong to child_worldline_id",
+                ));
+            }
+        }
+        let mut seen_support_targets = BTreeSet::new();
+        for support_pin in &support_pins {
+            if support_pin.strand_id == strand_id {
+                return Err(StrandError::SelfSupportPin(strand_id));
+            }
+            if !seen_support_targets.insert(support_pin.strand_id) {
+                return Err(StrandError::DuplicateSupportTarget {
+                    owner: strand_id,
+                    target: support_pin.strand_id,
+                });
+            }
+        }
+
+        Ok(Self {
+            strand_id,
+            fork_basis_ref,
+            child_worldline_id,
+            writer_heads,
+            support_pins,
+            retention_posture,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    /// Returns this strand's stable identity.
+    #[must_use]
+    pub fn strand_id(&self) -> StrandId {
+        self.strand_id
+    }
+
+    /// Returns the immutable fork coordinate.
+    #[must_use]
+    pub fn fork_basis_ref(&self) -> ForkBasisRef {
+        self.fork_basis_ref
+    }
+
+    /// Returns the child worldline created by this strand.
+    #[must_use]
+    pub fn child_worldline_id(&self) -> WorldlineId {
+        self.child_worldline_id
+    }
+
+    /// Returns the writer heads owned by this strand's child worldline.
+    #[must_use]
+    pub fn writer_heads(&self) -> &[WriterHeadKey] {
+        &self.writer_heads
+    }
+
+    /// Returns the read-only support pins held by this strand.
+    #[must_use]
+    pub fn support_pins(&self) -> &[SupportPin] {
+        &self.support_pins
+    }
+
+    /// Returns the explicit retention, authority, and admission posture.
+    #[must_use]
+    pub fn retention_posture(&self) -> RetentionPosture {
+        self.retention_posture
+    }
+
     /// Builds a basis-relative report for this strand against current parent history.
     ///
     /// The report is the first live-strand seam: the strand still records an

--- a/crates/warp-core/src/strand.rs
+++ b/crates/warp-core/src/strand.rs
@@ -240,8 +240,9 @@ impl<P: CausalPostureState> Strand<P> {
     ///
     /// Returns [`StrandError`] when the retained posture is incoherent, the
     /// static posture marker disagrees with runtime posture, the child and
-    /// source worldlines are the same, writer heads target the wrong child
-    /// worldline, or support pins are self-targeted or duplicate one another.
+    /// source worldlines are the same, the v1 writer-head set does not contain
+    /// exactly one head, writer heads target the wrong child worldline, or
+    /// support pins are self-targeted or duplicate one another.
     pub fn new(
         strand_id: StrandId,
         fork_basis_ref: ForkBasisRef,

--- a/crates/warp-core/src/strand.rs
+++ b/crates/warp-core/src/strand.rs
@@ -174,6 +174,59 @@ pub struct Strand<P: CausalPostureState = DynamicPosture> {
     pub(crate) _marker: std::marker::PhantomData<P>,
 }
 
+const V1_WRITER_HEAD_COUNT_INVARIANT: &str =
+    "INV-S2: v1 strands must carry exactly one writer head";
+
+fn validate_local_strand_invariants<P: CausalPostureState>(
+    strand_id: StrandId,
+    fork_basis_ref: &ForkBasisRef,
+    child_worldline_id: WorldlineId,
+    writer_heads: &[WriterHeadKey],
+    support_pins: &[SupportPin],
+    retention_posture: &RetentionPosture,
+) -> Result<(), StrandError> {
+    retention_posture.validate().map_err(StrandError::Posture)?;
+    if let Some(expected) = P::causal_posture() {
+        if retention_posture.causal_posture != expected {
+            return Err(StrandError::Posture(PostureObstruction::PostureMismatch {
+                actual: retention_posture.causal_posture,
+                expected,
+            }));
+        }
+    }
+    if child_worldline_id == fork_basis_ref.source_lane_id {
+        return Err(StrandError::InvariantViolation(
+            "INV-S7: child_worldline_id must differ from fork_basis_ref.source_lane_id",
+        ));
+    }
+    if writer_heads.len() != 1 {
+        return Err(StrandError::InvariantViolation(
+            V1_WRITER_HEAD_COUNT_INVARIANT,
+        ));
+    }
+    for head_key in writer_heads {
+        if head_key.worldline_id != child_worldline_id {
+            return Err(StrandError::InvariantViolation(
+                "INV-S8: every writer head must belong to child_worldline_id",
+            ));
+        }
+    }
+    let mut seen_support_targets = BTreeSet::new();
+    for support_pin in support_pins {
+        if support_pin.strand_id == strand_id {
+            return Err(StrandError::SelfSupportPin(strand_id));
+        }
+        if !seen_support_targets.insert(support_pin.strand_id) {
+            return Err(StrandError::DuplicateSupportTarget {
+                owner: strand_id,
+                target: support_pin.strand_id,
+            });
+        }
+    }
+
+    Ok(())
+}
+
 impl<P: CausalPostureState> Strand<P> {
     /// Creates a strand through a posture-aware constructor boundary.
     ///
@@ -197,39 +250,14 @@ impl<P: CausalPostureState> Strand<P> {
         support_pins: Vec<SupportPin>,
         retention_posture: RetentionPosture,
     ) -> Result<Self, StrandError> {
-        retention_posture.validate().map_err(StrandError::Posture)?;
-        if let Some(expected) = P::causal_posture() {
-            if retention_posture.causal_posture != expected {
-                return Err(StrandError::Posture(PostureObstruction::PostureMismatch {
-                    actual: retention_posture.causal_posture,
-                    expected,
-                }));
-            }
-        }
-        if child_worldline_id == fork_basis_ref.source_lane_id {
-            return Err(StrandError::InvariantViolation(
-                "INV-S7: child_worldline_id must differ from fork_basis_ref.source_lane_id",
-            ));
-        }
-        for head_key in &writer_heads {
-            if head_key.worldline_id != child_worldline_id {
-                return Err(StrandError::InvariantViolation(
-                    "INV-S8: every writer head must belong to child_worldline_id",
-                ));
-            }
-        }
-        let mut seen_support_targets = BTreeSet::new();
-        for support_pin in &support_pins {
-            if support_pin.strand_id == strand_id {
-                return Err(StrandError::SelfSupportPin(strand_id));
-            }
-            if !seen_support_targets.insert(support_pin.strand_id) {
-                return Err(StrandError::DuplicateSupportTarget {
-                    owner: strand_id,
-                    target: support_pin.strand_id,
-                });
-            }
-        }
+        validate_local_strand_invariants::<P>(
+            strand_id,
+            &fork_basis_ref,
+            child_worldline_id,
+            &writer_heads,
+            &support_pins,
+            &retention_posture,
+        )?;
 
         Ok(Self {
             strand_id,
@@ -794,6 +822,7 @@ impl StrandRegistry {
     /// Inserts a fully constructed strand into the registry.
     ///
     /// Validates contract invariants before insertion:
+    /// - INV-S2: v1 strands carry exactly one writer head
     /// - INV-S7: `child_worldline_id != fork_basis_ref.source_lane_id`
     /// - INV-S8: every writer head belongs to `child_worldline_id`
     /// - support pins, when present, reference already-live strands and do not
@@ -808,24 +837,14 @@ impl StrandRegistry {
         if self.strands.contains_key(&strand.strand_id) {
             return Err(StrandError::AlreadyExists(strand.strand_id));
         }
-        strand
-            .retention_posture
-            .validate()
-            .map_err(StrandError::Posture)?;
-        // INV-S7: distinct worldlines.
-        if strand.child_worldline_id == strand.fork_basis_ref.source_lane_id {
-            return Err(StrandError::InvariantViolation(
-                "INV-S7: child_worldline_id must differ from fork_basis_ref.source_lane_id",
-            ));
-        }
-        // INV-S8: head ownership.
-        for head_key in &strand.writer_heads {
-            if head_key.worldline_id != strand.child_worldline_id {
-                return Err(StrandError::InvariantViolation(
-                    "INV-S8: every writer head must belong to child_worldline_id",
-                ));
-            }
-        }
+        validate_local_strand_invariants::<DynamicPosture>(
+            strand.strand_id,
+            &strand.fork_basis_ref,
+            strand.child_worldline_id,
+            &strand.writer_heads,
+            &strand.support_pins,
+            &strand.retention_posture,
+        )?;
         self.validate_support_pins(&strand)?;
         self.strands.insert(strand.strand_id, strand);
         Ok(())

--- a/crates/warp-core/src/strand.rs
+++ b/crates/warp-core/src/strand.rs
@@ -1018,11 +1018,7 @@ impl StrandRegistry {
     }
 
     fn validate_support_pins(&self, strand: &Strand) -> Result<(), StrandError> {
-        let mut seen = BTreeSet::new();
         for support_pin in &strand.support_pins {
-            if support_pin.strand_id == strand.strand_id {
-                return Err(StrandError::SelfSupportPin(strand.strand_id));
-            }
             let target = self
                 .strands
                 .get(&support_pin.strand_id)
@@ -1032,12 +1028,6 @@ impl StrandRegistry {
                     target: support_pin.strand_id,
                     expected: target.child_worldline_id,
                     got: support_pin.worldline_id,
-                });
-            }
-            if !seen.insert(support_pin.strand_id) {
-                return Err(StrandError::DuplicateSupportTarget {
-                    owner: strand.strand_id,
-                    target: support_pin.strand_id,
                 });
             }
         }

--- a/crates/warp-core/tests/braid_public_api_tests.rs
+++ b/crates/warp-core/tests/braid_public_api_tests.rs
@@ -5,7 +5,8 @@
 
 use warp_core::{
     make_strand_id, AuthorityDomainId, AuthorityDomainRef, Braid, BraidError, BraidEvent,
-    BraidMemberRef, BraidStatus, OriginId,
+    BraidMemberRef, BraidStatus, BraidTransitionKind, OriginId, ProofEnvelope, ProofError,
+    ProofKind,
 };
 
 fn authority_ref() -> AuthorityDomainRef {
@@ -35,4 +36,61 @@ fn crate_root_exports_braid_lifecycle_error_and_member_types() -> Result<(), Bra
         Err(BraidError::DuplicateMember { member_ref })
     );
     Ok(())
+}
+
+#[test]
+fn public_braid_transition_failures_are_typed() {
+    let member_ref = BraidMemberRef::Revealed(make_strand_id("typed-transition-member"));
+    let mut braid = Braid::new([0xAC; 32], authority_ref());
+
+    braid
+        .apply(BraidEvent::MemberWoven {
+            member_ref,
+            sequence_num: 0,
+        })
+        .expect("first member weave");
+    braid
+        .apply(BraidEvent::SettlementFinalized {
+            settlement_digest: [0x5E; 32],
+        })
+        .expect("settlement finalization");
+
+    assert_eq!(
+        braid.apply(BraidEvent::MemberWoven {
+            member_ref: BraidMemberRef::Revealed(make_strand_id("late-member")),
+            sequence_num: 1,
+        }),
+        Err(BraidError::InvalidTransition {
+            transition: BraidTransitionKind::WeaveMember,
+            status: BraidStatus::Finalized,
+        })
+    );
+}
+
+#[test]
+fn public_proof_validation_failures_are_typed() {
+    let expected = [0x42; 32];
+    let actual = [0x24; 32];
+    let proof = ProofEnvelope {
+        kind: ProofKind::ReplayTrace,
+        proof_bytes: vec![1, 2, 3],
+        public_inputs_hash: actual,
+    };
+
+    assert_eq!(
+        proof.validate_shape(expected),
+        Err(ProofError::PublicInputsMismatch { expected, actual })
+    );
+
+    let unsupported = ProofEnvelope {
+        kind: ProofKind::ZkSnark,
+        proof_bytes: vec![1, 2, 3],
+        public_inputs_hash: expected,
+    };
+    assert_eq!(
+        unsupported.validate_shape(expected),
+        Err(ProofError::UnsupportedKind {
+            kind: ProofKind::ZkSnark,
+        })
+    );
 }

--- a/crates/warp-core/tests/braid_public_api_tests.rs
+++ b/crates/warp-core/tests/braid_public_api_tests.rs
@@ -68,6 +68,19 @@ fn public_braid_transition_failures_are_typed() {
 }
 
 #[test]
+fn public_braid_transition_display_is_human_facing() {
+    let err = BraidError::InvalidTransition {
+        transition: BraidTransitionKind::WeaveMember,
+        status: BraidStatus::Finalized,
+    };
+
+    assert_eq!(
+        err.to_string(),
+        "cannot transition braid state: cannot weave member in status Finalized"
+    );
+}
+
+#[test]
 fn public_proof_validation_failures_are_typed() {
     let expected = [0x42; 32];
     let actual = [0x24; 32];

--- a/crates/warp-core/tests/strand_contract_tests.rs
+++ b/crates/warp-core/tests/strand_contract_tests.rs
@@ -169,6 +169,46 @@ fn strand_constructor_rejects_static_runtime_posture_mismatch() {
     );
 }
 
+#[test]
+fn strand_constructor_rejects_missing_v1_writer_head() {
+    let err =
+        make_test_strand_with_parts("missing-head", wl(1), wl(2), wt(5), Vec::new(), Vec::new())
+            .expect_err("v1 strand construction must reject missing writer head");
+
+    assert_eq!(
+        err,
+        StrandError::InvariantViolation("INV-S2: v1 strands must carry exactly one writer head")
+    );
+}
+
+#[test]
+fn strand_constructor_rejects_multiple_v1_writer_heads() {
+    let child_worldline = wl(2);
+    let err = make_test_strand_with_parts(
+        "multiple-heads",
+        wl(1),
+        child_worldline,
+        wt(5),
+        vec![
+            WriterHeadKey {
+                worldline_id: child_worldline,
+                head_id: make_head_id("multiple-heads-a"),
+            },
+            WriterHeadKey {
+                worldline_id: child_worldline,
+                head_id: make_head_id("multiple-heads-b"),
+            },
+        ],
+        Vec::new(),
+    )
+    .expect_err("v1 strand construction must reject multiple writer heads");
+
+    assert_eq!(
+        err,
+        StrandError::InvariantViolation("INV-S2: v1 strands must carry exactly one writer head")
+    );
+}
+
 fn append_committed_tick(
     provenance: &mut ProvenanceService,
     worldline_id: WorldlineId,

--- a/crates/warp-core/tests/strand_contract_tests.rs
+++ b/crates/warp-core/tests/strand_contract_tests.rs
@@ -13,12 +13,12 @@ use warp_core::strand::{
 };
 use warp_core::{
     make_head_id, make_node_id, make_type_id, make_warp_id, ActorId, AuthorityBinding,
-    AuthorityDomainId, AuthorityDomainRef, CausalAuthority, CausalPosture, DynamicPosture,
-    GlobalTick, GraphStore, HashTriplet, HeadEligibility, LocalProvenanceStore, NodeRecord,
-    OriginId, PlaybackHeadRegistry, PlaybackMode, PostureDerivation, PostureObstruction,
-    ProvenanceEntry, ProvenanceRef, ProvenanceService, ProvenanceStore, RetentionContractId,
-    RetentionPosture, RunnableWriterSet, SealStrength, SlotId, WarpId, WorldlineId, WorldlineState,
-    WorldlineTick, WorldlineTickHeaderV1, WorldlineTickPatchV1, WriterHead, WriterHeadKey,
+    AuthorityDomainId, AuthorityDomainRef, CausalAuthority, CausalPosture, GlobalTick, GraphStore,
+    HashTriplet, HeadEligibility, LocalProvenanceStore, NodeRecord, OriginId, PlaybackHeadRegistry,
+    PlaybackMode, PostureDerivation, PostureObstruction, ProvenanceEntry, ProvenanceRef,
+    ProvenanceService, ProvenanceStore, RetentionContractId, RetentionPosture, RunnableWriterSet,
+    SealStrength, Shared, SlotId, WarpId, WorldlineId, WorldlineState, WorldlineTick,
+    WorldlineTickHeaderV1, WorldlineTickPatchV1, WriterHead, WriterHeadKey,
 };
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -78,11 +78,6 @@ fn setup_base_worldline() -> (ProvenanceService, WorldlineId, WorldlineState) {
     (provenance, base_id, initial_state)
 }
 
-/// Build a strand with explicit base/child worldlines for invariant violation tests.
-fn make_test_strand_raw(base_worldline: WorldlineId, child_worldline: WorldlineId) -> Strand {
-    make_test_strand("raw", base_worldline, child_worldline, wt(5))
-}
-
 /// Build a strand by hand (without full engine integration) to test the
 /// registry and type invariants.
 fn make_test_strand(
@@ -91,17 +86,35 @@ fn make_test_strand(
     child_worldline: WorldlineId,
     fork_tick: WorldlineTick,
 ) -> Strand {
+    make_test_strand_with_parts(
+        strand_label,
+        base_worldline,
+        child_worldline,
+        fork_tick,
+        vec![WriterHeadKey {
+            worldline_id: child_worldline,
+            head_id: make_head_id(&format!("strand-head-{strand_label}")),
+        }],
+        Vec::new(),
+    )
+    .expect("test strand")
+}
+
+fn make_test_strand_with_parts(
+    strand_label: &str,
+    base_worldline: WorldlineId,
+    child_worldline: WorldlineId,
+    fork_tick: WorldlineTick,
+    writer_heads: Vec<WriterHeadKey>,
+    support_pins: Vec<SupportPin>,
+) -> Result<Strand, StrandError> {
     let strand_id = make_strand_id(strand_label);
-    let head_key = WriterHeadKey {
-        worldline_id: child_worldline,
-        head_id: make_head_id(&format!("strand-head-{strand_label}")),
-    };
     let commit_hash = [0xAA; 32];
     let boundary_hash = [0xBB; 32];
 
-    Strand {
+    Strand::new(
         strand_id,
-        fork_basis_ref: ForkBasisRef {
+        ForkBasisRef {
             source_lane_id: base_worldline,
             fork_tick,
             commit_hash,
@@ -112,12 +125,48 @@ fn make_test_strand(
                 commit_hash,
             },
         },
-        child_worldline_id: child_worldline,
-        writer_heads: vec![head_key],
-        support_pins: Vec::new(),
-        retention_posture: test_retention_posture(),
-        _marker: std::marker::PhantomData,
-    }
+        child_worldline,
+        writer_heads,
+        support_pins,
+        test_retention_posture(),
+    )
+}
+
+#[test]
+fn strand_constructor_rejects_static_runtime_posture_mismatch() {
+    let base_worldline = wl(1);
+    let child_worldline = wl(2);
+    let fork_tick = wt(5);
+    let err = Strand::<Shared>::new(
+        make_strand_id("forged-shared"),
+        ForkBasisRef {
+            source_lane_id: base_worldline,
+            fork_tick,
+            commit_hash: [0xAA; 32],
+            boundary_hash: [0xBB; 32],
+            provenance_ref: ProvenanceRef {
+                worldline_id: base_worldline,
+                worldline_tick: fork_tick,
+                commit_hash: [0xAA; 32],
+            },
+        },
+        child_worldline,
+        vec![WriterHeadKey {
+            worldline_id: child_worldline,
+            head_id: make_head_id("forged-shared-head"),
+        }],
+        Vec::new(),
+        test_retention_posture(),
+    )
+    .expect_err("Shared typestate must reject AuthorOnly retention posture");
+
+    assert_eq!(
+        err,
+        StrandError::Posture(PostureObstruction::PostureMismatch {
+            actual: CausalPosture::AuthorOnly,
+            expected: CausalPosture::Shared,
+        })
+    );
 }
 
 fn append_committed_tick(
@@ -253,7 +302,8 @@ fn register_worldline_with_tick(provenance: &mut ProvenanceService, worldline_id
 fn inv_s7_child_and_base_worldlines_are_distinct() {
     let strand = make_test_strand("s7-test", wl(1), wl(2), wt(5));
     assert_ne!(
-        strand.child_worldline_id, strand.fork_basis_ref.source_lane_id,
+        strand.child_worldline_id(),
+        strand.fork_basis_ref().source_lane_id,
         "INV-S7: child worldline must differ from base"
     );
 }
@@ -266,7 +316,7 @@ fn inv_s2_s8_strand_heads_belong_to_child_worldline() {
     let child = wl(2);
     let strand = make_test_strand("s2-test", base, child, wt(5));
 
-    for head_key in &strand.writer_heads {
+    for head_key in strand.writer_heads() {
         assert_eq!(
             head_key.worldline_id, child,
             "INV-S8: every writer head must belong to child_worldline_id"
@@ -369,7 +419,7 @@ fn inv_s4_s10_strand_heads_follow_ordinary_runnable_set_rules() {
 fn inv_s9_support_pins_default_empty_until_pinned() {
     let strand = make_test_strand("s9-test", wl(1), wl(2), wt(5));
     assert!(
-        strand.support_pins.is_empty(),
+        strand.support_pins().is_empty(),
         "new strands start without support pins until runtime validation adds them"
     );
 }
@@ -410,9 +460,9 @@ fn live_basis_report_allows_parent_advance_outside_owned_footprint() {
         vec![parent_other],
     );
 
-    let strand = Strand {
-        strand_id: make_strand_id("live-basis-disjoint"),
-        fork_basis_ref: ForkBasisRef {
+    let strand: Strand = Strand::new(
+        make_strand_id("live-basis-disjoint"),
+        ForkBasisRef {
             source_lane_id: base_worldline,
             fork_tick: wt(0),
             commit_hash: base_ref.commit_hash,
@@ -423,15 +473,15 @@ fn live_basis_report_allows_parent_advance_outside_owned_footprint() {
                 .state_root,
             provenance_ref: base_ref,
         },
-        child_worldline_id: child_worldline,
-        writer_heads: vec![WriterHeadKey {
+        child_worldline,
+        vec![WriterHeadKey {
             worldline_id: child_worldline,
             head_id: make_head_id("live-basis-disjoint-head"),
         }],
-        support_pins: Vec::new(),
-        retention_posture: test_retention_posture(),
-        _marker: std::marker::PhantomData::<DynamicPosture>,
-    };
+        Vec::new(),
+        test_retention_posture(),
+    )
+    .expect("test strand");
 
     let report = strand
         .live_basis_report(&provenance)
@@ -483,9 +533,9 @@ fn live_basis_report_requires_revalidation_when_parent_invades_owned_footprint()
         vec![owned_slot],
     );
 
-    let strand = Strand {
-        strand_id: make_strand_id("live-basis-overlap"),
-        fork_basis_ref: ForkBasisRef {
+    let strand: Strand = Strand::new(
+        make_strand_id("live-basis-overlap"),
+        ForkBasisRef {
             source_lane_id: base_worldline,
             fork_tick: wt(0),
             commit_hash: base_ref.commit_hash,
@@ -496,15 +546,15 @@ fn live_basis_report_requires_revalidation_when_parent_invades_owned_footprint()
                 .state_root,
             provenance_ref: base_ref,
         },
-        child_worldline_id: child_worldline,
-        writer_heads: vec![WriterHeadKey {
+        child_worldline,
+        vec![WriterHeadKey {
             worldline_id: child_worldline,
             head_id: make_head_id("live-basis-overlap-head"),
         }],
-        support_pins: Vec::new(),
-        retention_posture: test_retention_posture(),
-        _marker: std::marker::PhantomData::<DynamicPosture>,
-    };
+        Vec::new(),
+        test_retention_posture(),
+    )
+    .expect("test strand");
 
     let report = strand
         .live_basis_report(&provenance)
@@ -524,7 +574,7 @@ fn live_basis_report_requires_revalidation_when_parent_invades_owned_footprint()
 #[test]
 fn inv_s5_base_ref_fields_consistent() {
     let strand = make_test_strand("s5-test", wl(1), wl(2), wt(5));
-    let br = &strand.fork_basis_ref;
+    let br = strand.fork_basis_ref();
 
     // provenance_ref must agree with fork_basis_ref scalars
     assert_eq!(br.provenance_ref.worldline_id, br.source_lane_id);
@@ -538,7 +588,7 @@ fn inv_s5_base_ref_fields_consistent() {
 fn registry_insert_and_get() {
     let mut registry = StrandRegistry::new();
     let strand = make_test_strand("reg-1", wl(1), wl(2), wt(5));
-    let sid = strand.strand_id;
+    let sid = strand.strand_id();
 
     registry.insert(strand).expect("insert");
     assert!(registry.contains(&sid));
@@ -550,7 +600,7 @@ fn registry_insert_and_get() {
 fn registry_duplicate_insert_fails() {
     let mut registry = StrandRegistry::new();
     let strand = make_test_strand("dup", wl(1), wl(2), wt(5));
-    let sid = strand.strand_id;
+    let sid = strand.strand_id();
 
     registry.insert(strand.clone()).expect("first insert");
     let err = registry.insert(strand).expect_err("duplicate insert");
@@ -561,11 +611,11 @@ fn registry_duplicate_insert_fails() {
 fn registry_remove_returns_strand_and_clears() {
     let mut registry = StrandRegistry::new();
     let strand = make_test_strand("rm-1", wl(1), wl(2), wt(5));
-    let sid = strand.strand_id;
+    let sid = strand.strand_id();
 
     registry.insert(strand).expect("insert");
     let removed = registry.remove(&sid).expect("remove should succeed");
-    assert_eq!(removed.strand_id, sid);
+    assert_eq!(removed.strand_id(), sid);
     assert!(
         !registry.contains(&sid),
         "strand should be gone after remove"
@@ -575,11 +625,19 @@ fn registry_remove_returns_strand_and_clears() {
 }
 
 #[test]
-fn registry_insert_rejects_inv_s7_same_worldline() {
-    let mut registry = StrandRegistry::new();
-    // child == base violates INV-S7
-    let strand = make_test_strand_raw(wl(1), wl(1));
-    let err = registry.insert(strand).expect_err("INV-S7 should reject");
+fn strand_constructor_rejects_inv_s7_same_worldline() {
+    let err = make_test_strand_with_parts(
+        "s7-bad",
+        wl(1),
+        wl(1),
+        wt(5),
+        vec![WriterHeadKey {
+            worldline_id: wl(1),
+            head_id: make_head_id("s7-bad-head"),
+        }],
+        Vec::new(),
+    )
+    .expect_err("INV-S7 should reject");
     assert!(
         matches!(err, StrandError::InvariantViolation(_)),
         "expected InvariantViolation, got {err:?}"
@@ -587,33 +645,19 @@ fn registry_insert_rejects_inv_s7_same_worldline() {
 }
 
 #[test]
-fn registry_insert_rejects_inv_s8_wrong_head_worldline() {
-    let mut registry = StrandRegistry::new();
-    let strand_id = make_strand_id("s8-bad");
-    let strand = Strand {
-        strand_id,
-        fork_basis_ref: ForkBasisRef {
-            source_lane_id: wl(1),
-            fork_tick: wt(5),
-            commit_hash: [0xAA; 32],
-            boundary_hash: [0xBB; 32],
-            provenance_ref: ProvenanceRef {
-                worldline_id: wl(1),
-                worldline_tick: wt(5),
-                commit_hash: [0xAA; 32],
-            },
-        },
-        child_worldline_id: wl(2),
-        // Head belongs to wl(3), not wl(2) — violates INV-S8
-        writer_heads: vec![WriterHeadKey {
+fn strand_constructor_rejects_inv_s8_wrong_head_worldline() {
+    let err = make_test_strand_with_parts(
+        "s8-bad",
+        wl(1),
+        wl(2),
+        wt(5),
+        vec![WriterHeadKey {
             worldline_id: wl(3),
             head_id: make_head_id("wrong-wl-head"),
         }],
-        support_pins: Vec::new(),
-        retention_posture: test_retention_posture(),
-        _marker: std::marker::PhantomData,
-    };
-    let err = registry.insert(strand).expect_err("INV-S8 should reject");
+        Vec::new(),
+    )
+    .expect_err("INV-S8 should reject");
     assert!(
         matches!(err, StrandError::InvariantViolation(_)),
         "expected InvariantViolation, got {err:?}"
@@ -621,19 +665,29 @@ fn registry_insert_rejects_inv_s8_wrong_head_worldline() {
 }
 
 #[test]
-fn registry_insert_rejects_shared_posture_without_admission_scope() {
-    let mut registry = StrandRegistry::new();
-    let mut strand = make_test_strand("shared-without-scope", wl(1), wl(2), wt(5));
-    strand.retention_posture.causal_posture = CausalPosture::Shared;
-    strand.retention_posture.admission_scope = None;
-    let err = registry
-        .insert(strand)
-        .expect_err("Shared strand without admission scope should reject");
+fn retention_posture_rejects_shared_without_admission_scope() {
+    let origin_id = OriginId::from_bytes([0x31; 32]);
+    let authority = AuthorityDomainRef::new(origin_id, AuthorityDomainId::from_bytes([0x32; 32]));
+    let err = RetentionPosture::new(
+        CausalPosture::Shared,
+        PostureDerivation::ExplicitIntent,
+        CausalAuthority::new(
+            origin_id,
+            ActorId::from_bytes([0x33; 32]),
+            authority,
+            AuthorityBinding::LocalUnbound { origin: origin_id },
+            SealStrength::Advisory,
+        )
+        .expect("test authority"),
+        RetentionContractId::from_bytes([0x34; 32]),
+        None,
+    )
+    .expect_err("Shared retention posture without admission scope should reject");
     assert_eq!(
         err,
-        StrandError::Posture(PostureObstruction::MissingAdmissionScope {
+        PostureObstruction::MissingAdmissionScope {
             posture: CausalPosture::Shared,
-        })
+        }
     );
 }
 
@@ -641,17 +695,27 @@ fn registry_insert_rejects_shared_posture_without_admission_scope() {
 fn registry_insert_accepts_valid_nonempty_support_pins() {
     let mut registry = StrandRegistry::new();
     let target = make_test_strand("support-target", wl(1), wl(10), wt(5));
-    let target_id = target.strand_id;
-    let target_worldline = target.child_worldline_id;
+    let target_id = target.strand_id();
+    let target_worldline = target.child_worldline_id();
     registry.insert(target).expect("insert support target");
 
-    let mut owner = make_test_strand("support-owner", wl(1), wl(2), wt(5));
-    owner.support_pins.push(SupportPin {
-        strand_id: target_id,
-        worldline_id: target_worldline,
-        pinned_tick: wt(0),
-        state_hash: [0xCC; 32],
-    });
+    let owner = make_test_strand_with_parts(
+        "support-owner",
+        wl(1),
+        wl(2),
+        wt(5),
+        vec![WriterHeadKey {
+            worldline_id: wl(2),
+            head_id: make_head_id("support-owner-head"),
+        }],
+        vec![SupportPin {
+            strand_id: target_id,
+            worldline_id: target_worldline,
+            pinned_tick: wt(0),
+            state_hash: [0xCC; 32],
+        }],
+    )
+    .expect("owner with support pin");
     registry
         .insert(owner)
         .expect("valid support pin should insert");
@@ -660,14 +724,24 @@ fn registry_insert_accepts_valid_nonempty_support_pins() {
 #[test]
 fn registry_insert_rejects_support_pin_missing_target() {
     let mut registry = StrandRegistry::new();
-    let mut owner = make_test_strand("missing-target", wl(1), wl(2), wt(5));
     let missing = make_strand_id("missing-support");
-    owner.support_pins.push(SupportPin {
-        strand_id: missing,
-        worldline_id: wl(10),
-        pinned_tick: wt(0),
-        state_hash: [0; 32],
-    });
+    let owner = make_test_strand_with_parts(
+        "missing-target",
+        wl(1),
+        wl(2),
+        wt(5),
+        vec![WriterHeadKey {
+            worldline_id: wl(2),
+            head_id: make_head_id("missing-target-head"),
+        }],
+        vec![SupportPin {
+            strand_id: missing,
+            worldline_id: wl(10),
+            pinned_tick: wt(0),
+            state_hash: [0; 32],
+        }],
+    )
+    .expect("owner with missing support pin");
     let err = registry
         .insert(owner)
         .expect_err("missing support target should reject");
@@ -678,16 +752,26 @@ fn registry_insert_rejects_support_pin_missing_target() {
 fn registry_insert_rejects_support_pin_worldline_mismatch() {
     let mut registry = StrandRegistry::new();
     let target = make_test_strand("mismatch-target", wl(1), wl(10), wt(5));
-    let target_id = target.strand_id;
+    let target_id = target.strand_id();
     registry.insert(target).expect("insert support target");
 
-    let mut owner = make_test_strand("mismatch-owner", wl(1), wl(2), wt(5));
-    owner.support_pins.push(SupportPin {
-        strand_id: target_id,
-        worldline_id: wl(11),
-        pinned_tick: wt(0),
-        state_hash: [0; 32],
-    });
+    let owner = make_test_strand_with_parts(
+        "mismatch-owner",
+        wl(1),
+        wl(2),
+        wt(5),
+        vec![WriterHeadKey {
+            worldline_id: wl(2),
+            head_id: make_head_id("mismatch-owner-head"),
+        }],
+        vec![SupportPin {
+            strand_id: target_id,
+            worldline_id: wl(11),
+            pinned_tick: wt(0),
+            state_hash: [0; 32],
+        }],
+    )
+    .expect("owner with mismatched support pin");
     let err = registry
         .insert(owner)
         .expect_err("worldline mismatch should reject");
@@ -702,33 +786,22 @@ fn registry_insert_rejects_support_pin_worldline_mismatch() {
 }
 
 #[test]
-fn registry_insert_rejects_duplicate_support_target() {
-    let mut registry = StrandRegistry::new();
+fn strand_constructor_rejects_duplicate_support_target() {
     let target = make_test_strand("duplicate-target", wl(1), wl(10), wt(5));
-    let target_id = target.strand_id;
-    let target_worldline = target.child_worldline_id;
-    registry.insert(target).expect("insert support target");
+    let target_id = target.strand_id();
+    let target_worldline = target.child_worldline_id();
 
     let owner_id = make_strand_id("duplicate-owner");
-    let owner = Strand {
-        strand_id: owner_id,
-        fork_basis_ref: ForkBasisRef {
-            source_lane_id: wl(1),
-            fork_tick: wt(5),
-            commit_hash: [0xAA; 32],
-            boundary_hash: [0xBB; 32],
-            provenance_ref: ProvenanceRef {
-                worldline_id: wl(1),
-                worldline_tick: wt(5),
-                commit_hash: [0xAA; 32],
-            },
-        },
-        child_worldline_id: wl(2),
-        writer_heads: vec![WriterHeadKey {
+    let err = make_test_strand_with_parts(
+        "duplicate-owner",
+        wl(1),
+        wl(2),
+        wt(5),
+        vec![WriterHeadKey {
             worldline_id: wl(2),
             head_id: make_head_id("duplicate-owner-head"),
         }],
-        support_pins: vec![
+        vec![
             SupportPin {
                 strand_id: target_id,
                 worldline_id: target_worldline,
@@ -742,12 +815,8 @@ fn registry_insert_rejects_duplicate_support_target() {
                 state_hash: [2; 32],
             },
         ],
-        retention_posture: test_retention_posture(),
-        _marker: std::marker::PhantomData,
-    };
-    let err = registry
-        .insert(owner)
-        .expect_err("duplicate support target should reject");
+    )
+    .expect_err("duplicate support target should reject");
     assert_eq!(
         err,
         StrandError::DuplicateSupportTarget {
@@ -764,10 +833,10 @@ fn registry_pin_support_records_state_hash_from_provenance() {
 
     let mut registry = StrandRegistry::new();
     let owner = make_test_strand("pin-owner", wl(1), wl(2), wt(5));
-    let owner_id = owner.strand_id;
+    let owner_id = owner.strand_id();
     let target = make_test_strand("pin-target", wl(1), wl(10), wt(5));
-    let target_id = target.strand_id;
-    let target_worldline = target.child_worldline_id;
+    let target_id = target.strand_id();
+    let target_worldline = target.child_worldline_id();
     registry.insert(owner).expect("insert owner");
     registry.insert(target).expect("insert target");
 
@@ -799,9 +868,9 @@ fn registry_pin_support_rejects_duplicate_and_self_target() {
 
     let mut registry = StrandRegistry::new();
     let owner = make_test_strand("pin-owner-dup", wl(1), wl(2), wt(5));
-    let owner_id = owner.strand_id;
+    let owner_id = owner.strand_id();
     let target = make_test_strand("pin-target-dup", wl(1), wl(10), wt(5));
-    let target_id = target.strand_id;
+    let target_id = target.strand_id();
     registry.insert(owner).expect("insert owner");
     registry.insert(target).expect("insert target");
 
@@ -832,9 +901,9 @@ fn registry_remove_rejects_live_pinned_target_until_unpinned() {
 
     let mut registry = StrandRegistry::new();
     let owner = make_test_strand("pin-owner-rm", wl(1), wl(2), wt(5));
-    let owner_id = owner.strand_id;
+    let owner_id = owner.strand_id();
     let target = make_test_strand("pin-target-rm", wl(1), wl(10), wt(5));
-    let target_id = target.strand_id;
+    let target_id = target.strand_id();
     registry.insert(owner).expect("insert owner");
     registry.insert(target).expect("insert target");
     registry
@@ -858,7 +927,7 @@ fn registry_remove_rejects_live_pinned_target_until_unpinned() {
     assert_eq!(removed_pin.strand_id, target_id);
     assert!(registry.list_support_pins(&owner_id).unwrap().is_empty());
     let removed = registry.remove(&target_id).expect("remove unpinned target");
-    assert_eq!(removed.strand_id, target_id);
+    assert_eq!(removed.strand_id(), target_id);
 }
 
 #[test]
@@ -888,7 +957,7 @@ fn registry_list_by_source_lane_filters_correctly() {
     let from_a = registry.list_by_source_lane(&base_a);
     assert_eq!(from_a.len(), 2, "should find 2 strands from source lane a");
     for s in &from_a {
-        assert_eq!(s.fork_basis_ref.source_lane_id, base_a);
+        assert_eq!(s.fork_basis_ref().source_lane_id, base_a);
     }
 
     let from_b = registry.list_by_source_lane(&base_b);
@@ -908,7 +977,7 @@ fn registry_list_by_source_lane_filters_correctly() {
 fn v1_strand_has_exactly_one_writer_head() {
     let strand = make_test_strand("card-1", wl(1), wl(2), wt(5));
     assert_eq!(
-        strand.writer_heads.len(),
+        strand.writer_heads().len(),
         1,
         "v1 strands must have exactly one writer head"
     );
@@ -1048,12 +1117,12 @@ fn provenance_fork_happy_path_child_has_correct_prefix() {
 fn drop_receipt_carries_correct_fields() {
     let strand = make_test_strand("drop-test", wl(1), wl(2), wt(5));
     let receipt = DropReceipt {
-        strand_id: strand.strand_id,
-        child_worldline_id: strand.child_worldline_id,
+        strand_id: strand.strand_id(),
+        child_worldline_id: strand.child_worldline_id(),
         final_tick: wt(10),
     };
 
-    assert_eq!(receipt.strand_id, strand.strand_id);
+    assert_eq!(receipt.strand_id, strand.strand_id());
     assert_eq!(receipt.child_worldline_id, wl(2));
     assert_eq!(receipt.final_tick, wt(10));
 }
@@ -1062,7 +1131,7 @@ fn drop_receipt_carries_correct_fields() {
 fn test_try_into_shared_posture_mismatch() {
     let strand = make_test_strand("mismatch-test", wl(1), wl(2), wt(5));
     assert_eq!(
-        strand.retention_posture.causal_posture,
+        strand.retention_posture().causal_posture,
         CausalPosture::AuthorOnly
     );
     let result = strand.try_into_shared();

--- a/crates/warp-core/tests/strand_contract_tests.rs
+++ b/crates/warp-core/tests/strand_contract_tests.rs
@@ -678,9 +678,11 @@ fn strand_constructor_rejects_inv_s7_same_worldline() {
         Vec::new(),
     )
     .expect_err("INV-S7 should reject");
-    assert!(
-        matches!(err, StrandError::InvariantViolation(_)),
-        "expected InvariantViolation, got {err:?}"
+    assert_eq!(
+        err,
+        StrandError::InvariantViolation(
+            "INV-S7: child_worldline_id must differ from fork_basis_ref.source_lane_id"
+        )
     );
 }
 
@@ -698,9 +700,11 @@ fn strand_constructor_rejects_inv_s8_wrong_head_worldline() {
         Vec::new(),
     )
     .expect_err("INV-S8 should reject");
-    assert!(
-        matches!(err, StrandError::InvariantViolation(_)),
-        "expected InvariantViolation, got {err:?}"
+    assert_eq!(
+        err,
+        StrandError::InvariantViolation(
+            "INV-S8: every writer head must belong to child_worldline_id"
+        )
     );
 }
 

--- a/docs/design/braids-and-strands-hardening/goalpost-01-lawful-construction-and-typed-failures.md
+++ b/docs/design/braids-and-strands-hardening/goalpost-01-lawful-construction-and-typed-failures.md
@@ -3,7 +3,7 @@
 
 # Goalpost 1: Lawful Construction And Typed Failures
 
-Status: planned.
+Status: implemented.
 
 Roadmap:
 [`../braids-and-strands-roadmap.md`](../braids-and-strands-roadmap.md)

--- a/docs/design/braids-and-strands-roadmap.md
+++ b/docs/design/braids-and-strands-roadmap.md
@@ -61,13 +61,13 @@ this campaign.
 Design:
 [`goalpost-01-lawful-construction-and-typed-failures.md`](braids-and-strands-hardening/goalpost-01-lawful-construction-and-typed-failures.md)
 
-- [ ] GP1-S1: Make `Strand<P>` construction posture-aware and non-forgeable
+- [x] GP1-S1: Make `Strand<P>` construction posture-aware and non-forgeable
       through public API.
-- [ ] GP1-S2: Replace public test construction with fixture builders.
-- [ ] GP1-S3: Replace proof validation strings with structured `ProofError`.
-- [ ] GP1-S4: Replace braid transition action strings with
+- [x] GP1-S2: Replace public test construction with fixture builders.
+- [x] GP1-S3: Replace proof validation strings with structured `ProofError`.
+- [x] GP1-S4: Replace braid transition action strings with
       `BraidTransitionKind`.
-- [ ] GP1-S5: Add negative capability tests for forged strands and display
+- [x] GP1-S5: Add negative capability tests for forged strands and display
       string parsing.
 
 ### Goalpost 2: Stable Identity And Privacy Posture


### PR DESCRIPTION
## Summary

- implement Goalpost 1 of the braids/strands hardening roadmap
- move `Strand<P>` public struct-literal construction behind `Strand::new(...)` plus read-only accessors
- validate retained posture and typestate/runtime posture coherence before constructing typed strands
- replace proof validation strings with structured `ProofError`
- replace braid invalid-transition action strings with `BraidTransitionKind`
- thread typed proof errors through `BraidShellError::ProofShapeValidationFailed`
- update public API tests, strand fixture builders, changelog, and the roadmap checklist

## Why

PR #545 made strands and braids law-bearing surfaces, but `Strand<P>` still looked forgeable through public fields and proof/braid failures still exposed behavioral facts through strings. This PR closes the first hardening goalpost: law-bearing strand values are admitted through named construction, and callers can branch on typed failure variants without parsing display text.

Runtime and registry checks remain authoritative. Typestate is only the guardrail.

## Red / Green witnesses

RED before implementation:

- `cargo test -p warp-core --test braid_public_api_tests`
- `cargo test -p warp-core --test strand_contract_tests strand_constructor_rejects_static_runtime_posture_mismatch`

GREEN after implementation:

- `cargo test -p warp-core --lib` — 560/560
- `cargo test -p warp-core --test braid_public_api_tests` — 3/3
- `cargo test -p warp-core --test strand_contract_tests` — 29/29
- `cargo test -p warp-core --doc` — includes the new public `Strand` compile-fail witness
- `cargo clippy -p warp-core --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/check_spdx.sh`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/design/braids-and-strands-roadmap.md docs/design/braids-and-strands-hardening/goalpost-01-lawful-construction-and-typed-failures.md`
- pre-commit and pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured error reporting for invalid state transitions with specific transition types and current status details.
  * Typed proof validation errors replacing generic error messages with specific failure categories.

* **Improvements**
  * Strengthened data structure construction with enhanced invariant validation and better error reporting for violations.
  * Single-writer-head invariant enforcement across data structure initialization and registration.

* **Documentation**
  * Completed roadmap milestone for lawful construction and typed failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->