### PR TITLE
Add braid identity golden vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   use fixture builders and accessors, `ProofEnvelope::validate_shape(...)`
   returns structured `ProofError`, and invalid braid lifecycle transitions
   report typed `BraidTransitionKind` instead of action strings.
+- `warp-core` now locks the second braids/strands roadmap goalpost with golden
+  vectors for replay-trace proof-envelope identity, proofless and
+  proof-bearing braid shell identity, revealed and sealed member identity, and
+  sealed-member salt effects. The vector metadata marks these identities as
+  E1 scaffolding identity, and API docs now state that deterministic member
+  blinding defaults are reproducibility tools, not unlinkability boundaries.
 - `warp-core` now enforces the v1 single-writer-head strand invariant through
   both `Strand::new(...)` and `StrandRegistry::insert(...)`, and runtime strand
   forking constructs the registered relation through the same constructor

--- a/crates/warp-core/src/settlement.rs
+++ b/crates/warp-core/src/settlement.rs
@@ -92,11 +92,18 @@ pub enum PluralSettlementPolicy {
 }
 
 /// Non-public settlement-local salt for sealed braid member commitments.
+///
+/// The deterministic default salt is for reproducibility, not unlinkability.
+/// Privacy-preserving flows MUST provide authority-local, capability-local, or
+/// session-local blinding material.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct MemberBlindingSalt(Hash);
 
 impl MemberBlindingSalt {
     /// Builds a member blinding salt from caller-supplied entropy.
+    ///
+    /// Caller-supplied salts are the privacy boundary for sealed member
+    /// commitments; deterministic defaults are not.
     #[must_use]
     pub const fn from_bytes(bytes: Hash) -> Self {
         Self(bytes)
@@ -121,11 +128,20 @@ pub struct SettlementPolicy {
     /// Plural-settlement law selected for this act.
     pub plural: PluralSettlementPolicy,
     /// Non-public salt mixed into sealed braid member commitments.
+    ///
+    /// The default is derived deterministically from the policy id for local
+    /// reproducibility. It is not an unlinkability boundary across independent
+    /// settlements.
     pub member_blinding_salt: MemberBlindingSalt,
 }
 
 impl SettlementPolicy {
     /// Policy that permits lawful plurality over contended footprint overlap.
+    ///
+    /// The deterministic default salt is for reproducibility, not unlinkability.
+    /// Privacy-preserving flows MUST provide authority-local,
+    /// capability-local, or session-local blinding material through
+    /// [`Self::with_member_blinding_salt`].
     #[must_use]
     pub fn allow_plural_over_footprint_overlap(policy_id: Hash) -> Self {
         Self {
@@ -136,6 +152,9 @@ impl SettlementPolicy {
     }
 
     /// Sets the non-public salt used for sealed braid member commitments.
+    ///
+    /// Use this for privacy-sensitive settlement flows. Reusing one salt across
+    /// unlinkability domains can correlate sealed member commitments.
     #[must_use]
     pub const fn with_member_blinding_salt(mut self, salt: MemberBlindingSalt) -> Self {
         self.member_blinding_salt = salt;

--- a/crates/warp-core/tests/braid_identity_golden_vectors.rs
+++ b/crates/warp-core/tests/braid_identity_golden_vectors.rs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+
+//! Golden vectors for young braid/proof identity surfaces.
+
+use warp_core::{
+    make_strand_id, AuthorityDomainId, AuthorityDomainRef, BraidMemberRef, BraidShell,
+    BraidShellError, BraidShellMember, BraidShellOutcome, CausalPosture, MemberVerdict, OriginId,
+    ProofEnvelope, ProofError, ProofKind, ProvenanceRef, WorldlineId, WorldlineTick,
+    BRAID_SHELL_VERSION,
+};
+
+type Hash = [u8; 32];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CompatibilityClass {
+    PublicStable,
+    E1Scaffold,
+    TestOnlyFixture,
+}
+
+impl CompatibilityClass {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::PublicStable => "public stable identity",
+            Self::E1Scaffold => "E1 scaffolding identity",
+            Self::TestOnlyFixture => "test-only fixture identity",
+        }
+    }
+}
+
+struct VectorCase {
+    name: &'static str,
+    compatibility: CompatibilityClass,
+    actual: Hash,
+    expected_hex: &'static str,
+}
+
+fn assert_vector(case: VectorCase) {
+    assert_eq!(
+        hex::encode(case.actual),
+        case.expected_hex,
+        "{} [{}] drifted",
+        case.name,
+        case.compatibility.label()
+    );
+}
+
+fn wl(byte: u8) -> WorldlineId {
+    WorldlineId::from_bytes([byte; 32])
+}
+
+fn authority(origin: u8, domain: u8) -> AuthorityDomainRef {
+    AuthorityDomainRef::new(
+        OriginId::from_bytes([origin; 32]),
+        AuthorityDomainId::from_bytes([domain; 32]),
+    )
+}
+
+fn basis_ref() -> ProvenanceRef {
+    ProvenanceRef {
+        worldline_id: wl(0x41),
+        worldline_tick: WorldlineTick::from_raw(7),
+        commit_hash: [0x42; 32],
+    }
+}
+
+fn revealed_member(label: &str, verdict: MemberVerdict, claim_byte: u8) -> BraidShellMember {
+    BraidShellMember {
+        member_ref: BraidMemberRef::Revealed(make_strand_id(label)),
+        support_pin_digest: [0x21; 32],
+        basis_digest: [0x22; 32],
+        frontier_digest: [0x23; 32],
+        footprint_digest: [0x24; 32],
+        claim_digest: [claim_byte; 32],
+        verdict,
+        verdict_digest: [0x26; 32],
+        posture: CausalPosture::AuthorOnly,
+    }
+}
+
+fn sealed_member(
+    blinded_commitment: Hash,
+    authority: AuthorityDomainRef,
+    verdict: MemberVerdict,
+    claim_byte: u8,
+) -> BraidShellMember {
+    BraidShellMember {
+        member_ref: BraidMemberRef::Sealed {
+            blinded_commitment,
+            authority,
+        },
+        support_pin_digest: [0x21; 32],
+        basis_digest: [0x22; 32],
+        frontier_digest: [0x23; 32],
+        footprint_digest: [0x24; 32],
+        claim_digest: [claim_byte; 32],
+        verdict,
+        verdict_digest: [0x26; 32],
+        posture: CausalPosture::AuthorOnly,
+    }
+}
+
+fn plural_outcome() -> BraidShellOutcome {
+    BraidShellOutcome::Plural {
+        alternative_ids: vec![[0x31; 32], [0x32; 32]],
+    }
+}
+
+#[test]
+fn compatibility_classes_are_explicit_vector_metadata() {
+    let classes = [
+        CompatibilityClass::PublicStable,
+        CompatibilityClass::E1Scaffold,
+        CompatibilityClass::TestOnlyFixture,
+    ];
+
+    assert_eq!(classes[0].label(), "public stable identity");
+    assert_eq!(classes[1].label(), "E1 scaffolding identity");
+    assert_eq!(classes[2].label(), "test-only fixture identity");
+}
+
+#[test]
+fn replay_trace_proof_envelope_digest_vector_is_locked() {
+    let expected_public_inputs = [0x44; 32];
+    let proof = ProofEnvelope {
+        kind: ProofKind::ReplayTrace,
+        proof_bytes: b"gp2/replay-trace/evidence".to_vec(),
+        public_inputs_hash: expected_public_inputs,
+    };
+
+    assert_eq!(proof.validate_shape(expected_public_inputs), Ok(()));
+    assert_vector(VectorCase {
+        name: "proof-envelope/replay-trace",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: proof.digest(),
+        expected_hex: "c4dc4d862a493cde6d8b62a83079463da56505358261fb3e7e7d190d6370f8c0",
+    });
+
+    for kind in [ProofKind::ZkSnark, ProofKind::VectorOpening] {
+        let unsupported = ProofEnvelope {
+            kind,
+            proof_bytes: b"reserved-proof-kind".to_vec(),
+            public_inputs_hash: expected_public_inputs,
+        };
+
+        assert_eq!(
+            unsupported.validate_shape(expected_public_inputs),
+            Err(ProofError::UnsupportedKind { kind })
+        );
+    }
+}
+
+#[test]
+fn proofless_and_proof_bearing_shell_digest_vectors_are_locked() -> Result<(), BraidShellError> {
+    let members = vec![
+        revealed_member("gp2/member-a", MemberVerdict::Plural, 0x25),
+        revealed_member("gp2/member-b", MemberVerdict::Derived, 0x35),
+    ];
+    let proofless_shell = BraidShell::assemble(
+        wl(0x40),
+        basis_ref(),
+        members.clone(),
+        [0x5E; 32],
+        plural_outcome(),
+        CausalPosture::AuthorOnly,
+    )?;
+    let proof = ProofEnvelope {
+        kind: ProofKind::ReplayTrace,
+        proof_bytes: b"gp2/shell/replay-trace".to_vec(),
+        public_inputs_hash: proofless_shell.witness_digest,
+    };
+    let proof_digest = proof.digest();
+    let proof_bearing_shell = BraidShell::assemble_with_proof(
+        wl(0x40),
+        basis_ref(),
+        members,
+        [0x5E; 32],
+        plural_outcome(),
+        CausalPosture::AuthorOnly,
+        Some(proof),
+    )?;
+
+    assert_eq!(proofless_shell.version, BRAID_SHELL_VERSION);
+    assert_eq!(proof_bearing_shell.version, BRAID_SHELL_VERSION);
+    assert_ne!(proofless_shell.digest, proof_bearing_shell.digest);
+    assert_vector(VectorCase {
+        name: "braid-shell/proofless",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: proofless_shell.digest,
+        expected_hex: "61acd40a01a32ef2771b7a98d11b3d6734e1064ca19393dba7b8dd8e40195d37",
+    });
+    assert_vector(VectorCase {
+        name: "proof-envelope/shell-replay-trace",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: proof_digest,
+        expected_hex: "c1c6e5ef0a01cd29e8230124b42868045b69c474a33cca7f4b6a7fb24ace4c4c",
+    });
+    assert_vector(VectorCase {
+        name: "braid-shell/proof-bearing",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: proof_bearing_shell.digest,
+        expected_hex: "7bd76a3efbcbd944ce3b1b52f09cc7bbb9a5fae633f65ad361a3376d8a9cbbbe",
+    });
+
+    Ok(())
+}
+
+#[test]
+fn revealed_and_sealed_member_reference_vectors_are_locked() {
+    let revealed = revealed_member("gp2/revealed-member", MemberVerdict::Plural, 0x25);
+    let strand_id = make_strand_id("gp2/sealed-member");
+    let child_worldline_id = wl(0x88);
+    let member_authority = authority(0xA1, 0xB1);
+    let first_blinding = [0xA5; 32];
+    let second_blinding = [0xB6; 32];
+    let first_commitment = BraidMemberRef::seal(strand_id, child_worldline_id, first_blinding);
+    let second_commitment = BraidMemberRef::seal(strand_id, child_worldline_id, second_blinding);
+    let sealed = sealed_member(
+        first_commitment,
+        member_authority,
+        MemberVerdict::Plural,
+        0x27,
+    );
+
+    assert_ne!(first_commitment, second_commitment);
+    assert_vector(VectorCase {
+        name: "braid-member/revealed-member-digest",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: revealed.member_digest(),
+        expected_hex: "f11e5fdea68591570c852b2119d3f1e57d63959e0ea3412a0a5e3a223fc4cf07",
+    });
+    assert_vector(VectorCase {
+        name: "braid-member/sealed-commitment/first-blinding",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: first_commitment,
+        expected_hex: "7a34ac5e0f683028d96c75a495f41629124cb5064a29dcc53dc8f8605ab408e4",
+    });
+    assert_vector(VectorCase {
+        name: "braid-member/sealed-commitment/second-blinding",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: second_commitment,
+        expected_hex: "62b203a994819eeac54fed71360728487e4960ce38ea19cf1b0ea0dea8ab3d0d",
+    });
+    assert_vector(VectorCase {
+        name: "braid-member/sealed-member-digest",
+        compatibility: CompatibilityClass::E1Scaffold,
+        actual: sealed.member_digest(),
+        expected_hex: "6af9058f530b0edc611cee34f716f74d2df32c2e4307020a44d0b30c1ae75ee7",
+    });
+}

--- a/docs/design/braids-and-strands-hardening/goalpost-02-stable-identity-and-privacy-posture.md
+++ b/docs/design/braids-and-strands-hardening/goalpost-02-stable-identity-and-privacy-posture.md
@@ -3,7 +3,7 @@
 
 # Goalpost 2: Stable Identity And Privacy Posture
 
-Status: planned.
+Status: implemented.
 
 Roadmap:
 [`../braids-and-strands-roadmap.md`](../braids-and-strands-roadmap.md)
@@ -61,6 +61,41 @@ This goalpost does not include:
 | GP2-S3 | Add revealed/sealed member reference vectors | vector and salt-effect tests            |
 | GP2-S4 | Mark compatibility classes                   | fixture metadata or docs assertion      |
 | GP2-S5 | Document deterministic blinding salt risk    | docs/examples plus salt-path regression |
+
+## Vector Fixtures
+
+The executable vector witness is
+`crates/warp-core/tests/braid_identity_golden_vectors.rs`.
+
+It locks:
+
+- replay-trace `ProofEnvelope::digest`;
+- proofless `BraidShell::digest`;
+- proof-bearing `BraidShell::digest`;
+- proof-envelope digest binding for the shell replay trace;
+- revealed `BraidShellMember::member_digest`;
+- sealed `BraidMemberRef::seal` commitments with two blinding values;
+- sealed `BraidShellMember::member_digest`;
+- unsupported proof-kind rejection shape.
+
+The vector file marks each vector with a compatibility class. Current GP2
+vectors are `E1 scaffolding identity`: accidental drift fails CI, and
+intentional drift requires an explicit compatibility note. Later work may
+promote selected vectors to `public stable identity`; that promotion must name
+the migration path, version bump, or declaration that no prior public stable
+identity was published.
+
+## Privacy Posture
+
+The deterministic default salt is for reproducibility, not unlinkability.
+Privacy-preserving flows MUST provide authority-local, capability-local, or
+session-local blinding material.
+
+The default member blinding salt is derived deterministically from policy
+identity so local tests and reproducible settlement flows stay stable.
+Callers must not treat that default as an unlinkability boundary across
+independent settlements. Privacy-sensitive examples and adapters must use
+caller-supplied blinding material through `with_member_blinding_salt(...)`.
 
 ## Acceptance
 

--- a/docs/design/braids-and-strands-roadmap.md
+++ b/docs/design/braids-and-strands-roadmap.md
@@ -75,12 +75,12 @@ Design:
 Design:
 [`goalpost-02-stable-identity-and-privacy-posture.md`](braids-and-strands-hardening/goalpost-02-stable-identity-and-privacy-posture.md)
 
-- [ ] GP2-S1: Add golden vectors for replay-trace `ProofEnvelope` identity.
-- [ ] GP2-S2: Add proofless and proof-bearing `BraidShell` identity vectors.
-- [ ] GP2-S3: Add revealed and sealed `BraidMemberRef` vectors, including salt
+- [x] GP2-S1: Add golden vectors for replay-trace `ProofEnvelope` identity.
+- [x] GP2-S2: Add proofless and proof-bearing `BraidShell` identity vectors.
+- [x] GP2-S3: Add revealed and sealed `BraidMemberRef` vectors, including salt
       effect.
-- [ ] GP2-S4: Mark vector compatibility classes and migration/versioning rules.
-- [ ] GP2-S5: Document deterministic blinding salt risk in API docs and
+- [x] GP2-S4: Mark vector compatibility classes and migration/versioning rules.
+- [x] GP2-S5: Document deterministic blinding salt risk in API docs and
       privacy-sensitive examples.
 
 ### Goalpost 3: Historical Membership And Replay


### PR DESCRIPTION
## Summary

Implements Goalpost 2 from the braids/strands hardening roadmap: stable identity and privacy posture.

- Adds golden vectors for replay-trace `ProofEnvelope::digest`.
- Adds proofless and proof-bearing `BraidShell::digest` vectors.
- Adds revealed and sealed member identity vectors, including salt-effect commitments.
- Marks vector compatibility classes in the fixture metadata.
- Documents deterministic member blinding salt as reproducibility-only, not an unlinkability boundary.
- Checks off GP2-S1 through GP2-S5 in the roadmap.

## RED Witness

The new vector test was first added with placeholder zero digests and failed only on vector drift assertions:

```text
cargo test -p warp-core --test braid_identity_golden_vectors
```

The failing assertions exposed the current proof, shell, revealed-member, sealed-commitment, and sealed-member digests, which were then pinned as golden vectors.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p warp-core --test braid_identity_golden_vectors`
- `cargo test -p warp-core --test braid_public_api_tests`
- `cargo test -p warp-core --lib braid_shell`
- `cargo test -p warp-core --doc`
- `cargo clippy -p warp-core --test braid_identity_golden_vectors -- -D warnings`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/design/braids-and-strands-roadmap.md docs/design/braids-and-strands-hardening/goalpost-02-stable-identity-and-privacy-posture.md`
- `scripts/check_spdx.sh`
- `git diff --check`
- Pre-push exact slices passed: `settlement::tests`, `braid_identity_golden_vectors`, and Prettier for touched Markdown.
