### PR TITLE
docs: retire Echo-only convergence project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -623,6 +623,8 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
 
 ### Changed
 
+- Echo 1.0 planning references now point at the cross-repository Continuum
+  Stack Convergence Project instead of the retired Echo-only Project.
 - `warp-core` renamed the generated contract package host API from
   `install_contract_package(...)` to `register_contract_package(...)` so the
   trusted-runtime boundary reads as explicit runtime-owned registration instead

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -7,10 +7,10 @@ This signpost summarizes current direction. It does not create commitments or
 replace backlog items, design docs, retros, or CLI status. If it disagrees with
 code, the code wins and this file should be corrected.
 
-Live work state belongs in GitHub. The Echo 1.0 Convergence Project is the
-release control surface:
+Live work state belongs in GitHub. The Continuum Stack Convergence Project is
+the release control surface for Echo 1.0 stack work:
 
-<https://github.com/users/flyingrobots/projects/14>
+<https://github.com/users/flyingrobots/projects/15>
 
 The Echo 1.0 release constitution is
 `docs/releases/echo-1.0-contract.md`. Repository docs record stable doctrine;

--- a/docs/WorkItems.md
+++ b/docs/WorkItems.md
@@ -3,10 +3,10 @@
 
 # Work Tracking Boundary
 
-GitHub Issues are the live work tracker. The Echo 1.0 Convergence Project is
-the live release control surface:
+GitHub Issues are the live work tracker. The Continuum Stack Convergence
+Project is the live release control surface for Echo 1.0 stack work:
 
-<https://github.com/users/flyingrobots/projects/14>
+<https://github.com/users/flyingrobots/projects/15>
 
 This file is not an inventory, roadmap, sprint plan, status report, or issue
 ledger. It exists to keep repository readers from treating historical local
@@ -49,7 +49,7 @@ Use GitHub for current state:
 gh issue list --repo flyingrobots/echo --state open --limit 1000
 gh issue list --repo flyingrobots/echo --state open --label release:echo-1.0 --limit 1000
 gh issue list --repo flyingrobots/echo --state open --milestone "Echo 1.0" --limit 1000
-gh project item-list 14 --owner flyingrobots --limit 1000
+gh project item-list 15 --owner flyingrobots --limit 1000
 ```
 
 Close issues only when their executable exit criteria have passed and the

--- a/docs/design/wal-wsc-durability-roadmap.md
+++ b/docs/design/wal-wsc-durability-roadmap.md
@@ -5,10 +5,10 @@
 
 This document is not the live roadmap. It records the stable WAL/WSC durability
 relationship that Echo 1.0 work must preserve. Live planning, issue hierarchy,
-dependencies, slice status, and proof state belong in the Echo 1.0 Convergence
-Project:
+dependencies, slice status, and proof state belong in the Continuum Stack
+Convergence Project:
 
-<https://github.com/users/flyingrobots/projects/14>
+<https://github.com/users/flyingrobots/projects/15>
 
 The owning release issue is
 [#521 WAL/WSC Storage Relationship](https://github.com/flyingrobots/echo/issues/521),

--- a/docs/design/work-item-sequencing-and-prioritization.md
+++ b/docs/design/work-item-sequencing-and-prioritization.md
@@ -8,9 +8,9 @@ Status: stable operating doctrine.
 Live sequencing belongs in GitHub, not in repository roadmaps. This document
 records how Echo work is ordered without duplicating current Project state.
 
-The live control surface is the Echo 1.0 Convergence Project:
+The live control surface is the Continuum Stack Convergence Project:
 
-<https://github.com/users/flyingrobots/projects/14>
+<https://github.com/users/flyingrobots/projects/15>
 
 The release constitution is
 [`docs/releases/echo-1.0-contract.md`](../releases/echo-1.0-contract.md).
@@ -51,16 +51,18 @@ Keep native fields visible:
 - Linked pull request
 - Reviewers
 
-Use only these custom fields for Echo 1.0 planning:
+Use only these custom fields for Echo 1.0 planning. The Track field is shared
+across the full Continuum stack; Echo-owned work should use the closest
+configured track rather than adding repo-local Project fields.
 
-| Field    | Values                                                              |
-| -------- | ------------------------------------------------------------------- |
-| Track    | Durability, Continuum, Suffix Exchange, Edict, Jedit, Docs, Release |
-| Goalpost | GP0, GP1, GP2, GP3, GP4, GP5, GP6                                   |
-| Target   | 1.0, Deferred, Research                                             |
-| Risk     | Low, Medium, High, Critical                                         |
-| Proof    | Missing, Unit, Integration, Conformance, Network, Release           |
-| Slice    | S, M, Needs decomposition                                           |
+| Field    | Values                                                                                             |
+| -------- | -------------------------------------------------------------------------------------------------- |
+| Track    | Continuum, Echo, Suffix Exchange, Edict, Jedit, Graft, WARP TTD, WARP DRIVE, Wesley, Docs, Release |
+| Goalpost | GP0, GP1, GP2, GP3, GP4, GP5, GP6                                                                  |
+| Target   | 1.0, Deferred, Research                                                                            |
+| Risk     | Low, Medium, High, Critical                                                                        |
+| Proof    | Missing, Unit, Integration, Conformance, Network, Release                                          |
+| Slice    | S, M, Needs decomposition                                                                          |
 
 Repository is native metadata. Do not create a custom Repository field.
 

--- a/docs/releases/echo-1.0-contract.md
+++ b/docs/releases/echo-1.0-contract.md
@@ -10,15 +10,16 @@ work-in-progress status.
 
 Live release state belongs in GitHub:
 
-- Echo 1.0 Convergence Project:
-  <https://github.com/users/flyingrobots/projects/14>
+- Continuum Stack Convergence Project:
+  <https://github.com/users/flyingrobots/projects/15>
 - Echo 1.0 Release Bar:
   [#584](https://github.com/flyingrobots/echo/issues/584)
 - Echo 1.0 milestone:
   <https://github.com/flyingrobots/echo/milestone/31>
 
-The Project is the control surface. Issues and pull requests are the work.
-Executable evidence is the proof. This file records the binary release bar.
+The Project is the cross-repository control surface. Issues and pull requests
+are the work. Executable evidence is the proof. This file records Echo's binary
+release bar inside the larger Continuum stack convergence.
 
 ## Release Gates
 

--- a/scripts/check-wal-wsc-doctrine.sh
+++ b/scripts/check-wal-wsc-doctrine.sh
@@ -62,7 +62,7 @@ require_file "causal WAL design" "$wal_design"
 require_file "WAL/WSC durability doctrine" "$wal_doctrine"
 require_file "Echo 1.0 release contract" "$release_contract"
 
-project_url="https://github.com/users/flyingrobots/projects/14"
+project_url="https://github.com/users/flyingrobots/projects/15"
 issue_521_url="https://github.com/flyingrobots/echo/issues/521"
 issue_584_url="https://github.com/flyingrobots/echo/issues/584"
 issue_585_url="https://github.com/flyingrobots/echo/issues/585"
@@ -73,13 +73,13 @@ release_contract_path="docs/releases/echo-1.0-contract.md"
 wal_design_path="docs/design/causal-wal-end-to-end.md"
 wal_doctrine_path="docs/design/wal-wsc-durability-roadmap.md"
 
-require_literal "BEARING links Echo 1.0 Project" "$bearing" "$project_url"
+require_literal "BEARING links Continuum Stack Convergence Project" "$bearing" "$project_url"
 require_literal "BEARING links release contract" "$bearing" "$release_contract_path"
 require_literal "BEARING links WAL/WSC issue" "$bearing" "$issue_521_url"
 require_literal "BEARING links causal WAL design" "$bearing" "$wal_design_path"
 require_literal "BEARING links WAL/WSC doctrine" "$bearing" "$wal_doctrine_path"
 
-require_literal "Work boundary links Echo 1.0 Project" "$workitems" "$project_url"
+require_literal "Work boundary links Continuum Stack Convergence Project" "$workitems" "$project_url"
 require_literal "Work boundary links Release Bar" "$workitems" "$issue_584_url"
 require_literal "Work boundary links WAL/WSC issue" "$workitems" "$issue_521_url"
 require_literal "Work boundary links release contract" "$workitems" "$release_contract_path"
@@ -108,7 +108,7 @@ reject_literal "Work boundary removes stale inbox backlog links" "$workitems" "]
 reject_literal "Work boundary removes stale bad-code backlog links" "$workitems" "](method/backlog/bad-code/"
 reject_literal "Work boundary removes stale cool-ideas backlog links" "$workitems" "](method/backlog/cool-ideas/"
 
-require_literal "sequencing links Echo 1.0 Project" "$sequencing" "$project_url"
+require_literal "sequencing links Continuum Stack Convergence Project" "$sequencing" "$project_url"
 require_literal "sequencing links release contract" "$sequencing" "../releases/echo-1.0-contract.md"
 require_literal "sequencing links WorkItems boundary" "$sequencing" "../WorkItems.md"
 require_literal "sequencing links WAL/WSC issue" "$sequencing" "$issue_521_url"
@@ -195,7 +195,7 @@ require_literal \
 
 require_literal "release contract has title" "$release_contract" "# Echo 1.0 Release Contract"
 require_literal "release contract rejects live roadmap role" "$release_contract" "not a live roadmap"
-require_literal "release contract links Echo 1.0 Project" "$release_contract" "$project_url"
+require_literal "release contract links Continuum Stack Convergence Project" "$release_contract" "$project_url"
 require_literal "release contract links Release Bar" "$release_contract" "$issue_584_url"
 require_literal "release contract links Gate A" "$release_contract" "$issue_585_url"
 require_literal "release contract links Gate B" "$release_contract" "$issue_591_url"
@@ -225,7 +225,7 @@ reject_literal "release contract removes current status" "$release_contract" "Cu
 
 require_literal "WAL doctrine has title" "$wal_doctrine" "# WAL/WSC Durability Doctrine"
 require_literal "WAL doctrine rejects live roadmap role" "$wal_doctrine" "This document is not the live roadmap."
-require_literal "WAL doctrine links Echo 1.0 Project" "$wal_doctrine" "$project_url"
+require_literal "WAL doctrine links Continuum Stack Convergence Project" "$wal_doctrine" "$project_url"
 require_literal "WAL doctrine links WAL/WSC issue" "$wal_doctrine" "$issue_521_url"
 require_literal "WAL doctrine links suffix exchange gate" "$wal_doctrine" "$issue_591_url"
 require_literal \

--- a/scripts/tests/check_wal_wsc_doctrine_test.sh
+++ b/scripts/tests/check_wal_wsc_doctrine_test.sh
@@ -101,7 +101,7 @@ test_missing_release_project_link_fails() {
   make_fixture tmp
 
   awk '
-    { gsub(/https:\/\/github.com\/users\/flyingrobots\/projects\/14/, "https://example.invalid/project"); print }
+    { gsub(/https:\/\/github.com\/users\/flyingrobots\/projects\/15/, "https://example.invalid/project"); print }
   ' "${tmp}/docs/releases/echo-1.0-contract.md" \
     >"${tmp}/docs/releases/echo-1.0-contract.md.tmp"
   mv \
@@ -109,7 +109,7 @@ test_missing_release_project_link_fails() {
     "${tmp}/docs/releases/echo-1.0-contract.md"
 
   out="$({ ECHO_REPO_ROOT="$tmp" "$checker"; } 2>&1 || true)"
-  echo "$out" | grep -q "release contract links Echo 1.0 Project" || {
+  echo "$out" | grep -q "release contract links Continuum Stack Convergence Project" || {
     echo "$out" >&2
     fail "checker did not report the missing release contract Project link"
   }


### PR DESCRIPTION
## Summary

- replace stale Echo-only Project #14 references with the cross-repository Continuum Stack Convergence Project #15
- update the WAL/WSC doctrine guard and regression fixture to require Project #15
- align the GitHub-native sequencing doc with the configured Project #15 field model
- add PR #582 to Project #15 as a completed GP0 release-control proof item

## Validation

- `scripts/check-wal-wsc-doctrine.sh`
- `scripts/tests/check_wal_wsc_doctrine_test.sh`
- `pnpm exec prettier --check CHANGELOG.md docs/BEARING.md docs/WorkItems.md docs/releases/echo-1.0-contract.md docs/design/wal-wsc-durability-roadmap.md docs/design/work-item-sequencing-and-prioritization.md`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/WorkItems.md docs/releases/echo-1.0-contract.md docs/design/wal-wsc-durability-roadmap.md docs/design/work-item-sequencing-and-prioritization.md`
- `shellcheck scripts/check-wal-wsc-doctrine.sh scripts/tests/check_wal_wsc_doctrine_test.sh`
- `bash -n scripts/check-wal-wsc-doctrine.sh scripts/tests/check_wal_wsc_doctrine_test.sh`
- `scripts/check_spdx.sh CHANGELOG.md docs/BEARING.md docs/WorkItems.md docs/releases/echo-1.0-contract.md docs/design/wal-wsc-durability-roadmap.md docs/design/work-item-sequencing-and-prioritization.md scripts/check-wal-wsc-doctrine.sh scripts/tests/check_wal_wsc_doctrine_test.sh`
- `cargo check`
- `git diff --check`
- pre-commit hook
- pre-push hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project planning and tracking references across documentation to point to the Continuum Stack Convergence Project.
  * Updated work tracking links and planning documentation.

* **Chores**
  * Updated project validation scripts to reflect new tracking references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->