### PR TITLE
feat(warp-core): add filesystem runtime WAL ack path

### DIFF
--- a/.ban-nondeterminism-allowlist
+++ b/.ban-nondeterminism-allowlist
@@ -11,4 +11,5 @@ std-fs crates/warp-core/src/causal_wal.rs native WAL filesystem adapter pending 
 std-fs crates/warp-core/src/wsc/view.rs native WSC file-open helper pending extraction to a boundary adapter.
 std-fs crates/warp-core/tests/causal_wal_tests.rs WAL filesystem fixture I/O only.
 std-fs crates/warp-core/tests/causal_wal_hardening_tests.rs WAL filesystem fixture I/O only.
+std-fs crates/warp-core/tests/trusted_runtime_host_loop_tests.rs trusted runtime filesystem WAL fixture I/O only.
 std-fs crates/warp-math/tests/trig_golden_vectors.rs golden-vector fixture read/write only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@
   `TrustedRuntimeWalConfig`, including in-memory and filesystem-backed
   adapters. `TrustedRuntimeWalStoreKind` exposes the configured adapter kind as
   host-owned read-only evidence, filesystem roots recover pending and decided
-  submissions after host reconstruction, and `TrustedRuntimeApp` remains
-  limited to submit and observe surfaces.
+  submissions after host reconstruction, reopened filesystem adapters continue
+  the committed LSN/digest chain, filesystem commits are marked
+  `StrictFilesystem`, read-only filesystem recovery preserves torn/corrupt tail
+  posture, and `TrustedRuntimeApp` remains limited to submit and observe
+  surfaces.
 - Added an Echo 1.0 release contract that records the four binary release gates,
   compatibility policy, evidence requirements, and GitHub Project boundary
   without carrying live roadmap state in the repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 ### Added
 
 - `warp-core` trusted runtime hosts now configure runtime WAL through
-  `TrustedRuntimeWalConfig`, with `TrustedRuntimeWalStoreKind` exposing the
-  configured adapter kind as host-owned read-only evidence while
-  `TrustedRuntimeApp` remains limited to submit and observe surfaces.
+  `TrustedRuntimeWalConfig`, including in-memory and filesystem-backed
+  adapters. `TrustedRuntimeWalStoreKind` exposes the configured adapter kind as
+  host-owned read-only evidence, filesystem roots recover pending and decided
+  submissions after host reconstruction, and `TrustedRuntimeApp` remains
+  limited to submit and observe surfaces.
 - Added an Echo 1.0 release contract that records the four binary release gates,
   compatibility policy, evidence requirements, and GitHub Project boundary
   without carrying live roadmap state in the repository.

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -17,16 +17,16 @@ use thiserror::Error;
 use crate::{
     causal_wal::{
         build_recovery_certificate, build_submission_acceptance_transaction,
-        build_tick_transaction, recover_from_frames_and_commits, recover_receipt_index,
-        recover_submission_index, recovered_submission_receipt_index_root, AffectedFrontier,
-        AffectedFrontierKind, FilesystemWalStore, InMemoryWalStore, Lsn, PayloadCodecId,
-        PayloadSchemaId, RecoveredReceiptIndex, RecoveredSubmissionIndex, RecoveryAccessMode,
-        RecoveryCertificate, RecoveryScanReport, SubmissionAcceptanceRecord,
+        build_tick_transaction, recover_filesystem_store, recover_from_frames_and_commits,
+        recover_receipt_index, recover_submission_index, recovered_submission_receipt_index_root,
+        AffectedFrontier, AffectedFrontierKind, FilesystemWalStore, InMemoryWalStore, Lsn,
+        PayloadCodecId, PayloadSchemaId, RecoveredReceiptIndex, RecoveredSubmissionIndex,
+        RecoveryAccessMode, RecoveryCertificate, RecoveryScanReport, SubmissionAcceptanceRecord,
         SubmissionRetryPosture, TickReceiptRecord, WalAppendAuthority, WalBuildError,
-        WalCommittedTransaction, WalDurabilityMode, WalReceiptCorrelationRecord, WalRecoveryError,
-        WalSegmentId, WalStoreError, WalStorePort, WalTickDecision, WalTransactionBuilder,
-        WalTransactionCommit, WalTransactionId, WalTransactionKind, WriterEpochId,
-        WriterEpochRequest,
+        WalCommittedTransaction, WalDecodeError, WalDurabilityMode, WalReceiptCorrelationRecord,
+        WalRecordKind, WalRecoveryError, WalRecoveryIndexError, WalSegmentId, WalStoreError,
+        WalStorePort, WalTickDecision, WalTransactionBuilder, WalTransactionCommit,
+        WalTransactionId, WalTransactionKind, WriterEpochId, WriterEpochRequest,
     },
     Engine, IngressEnvelope, InstalledContractPackage, InstalledContractPackageError,
     InstalledContractPackageRecord, IntentOutcome, IntentOutcomeDecision, IntentOutcomeObservation,
@@ -99,6 +99,17 @@ pub enum TrustedRuntimeWalError {
         expected_receipt_digest: Hash,
         /// Receipt digest observed through the outcome surface.
         observed_receipt_digest: Hash,
+    },
+    /// Filesystem WAL cannot safely roll back multiple durable tick commits as
+    /// separate transactions.
+    #[error(
+        "trusted runtime WAL filesystem adapter cannot atomically commit {transaction_count} {transaction_kind:?} transactions"
+    )]
+    FilesystemAtomicBatchUnsupported {
+        /// Transaction kind that would require atomic multi-transaction append.
+        transaction_kind: WalTransactionKind,
+        /// Number of transactions in the attempted durable batch.
+        transaction_count: usize,
     },
 }
 
@@ -397,12 +408,26 @@ impl TrustedRuntimeHost {
             }
         }
         if let Some(runtime_wal) = self.runtime_wal.as_mut() {
+            if runtime_wal.uses_filesystem_store() && tick_wal_records.len() > 1 {
+                self.runtime = runtime_before;
+                self.provenance = provenance_before;
+                return Err(TrustedRuntimeWalError::FilesystemAtomicBatchUnsupported {
+                    transaction_kind: WalTransactionKind::SchedulerTick,
+                    transaction_count: tick_wal_records.len(),
+                }
+                .into());
+            }
             let runtime_wal_before = runtime_wal.clone();
             for (correlation, decision, state_delta_digest) in &tick_wal_records {
                 if let Err(error) =
                     runtime_wal.record_tick_receipt(correlation, *decision, *state_delta_digest)
                 {
-                    *runtime_wal = runtime_wal_before;
+                    if runtime_wal.recover_filesystem_tick_commit_after_error(correlation) {
+                        continue;
+                    }
+                    if !runtime_wal.uses_filesystem_store() {
+                        *runtime_wal = runtime_wal_before;
+                    }
                     self.runtime = runtime_before;
                     self.provenance = provenance_before;
                     return Err(error.into());
@@ -477,6 +502,13 @@ impl TrustedRuntimeWal {
     pub fn from_config(config: TrustedRuntimeWalConfig) -> Result<Self, TrustedRuntimeWalError> {
         let TrustedRuntimeWalConfig { store, next_lsn } = config;
         let mut store = TrustedRuntimeWalStore::open(store)?;
+        let recovered_cursor =
+            TrustedRuntimeWalCursor::from_recovery(&store.recover_for_writer()?)?;
+        let next_lsn = if recovered_cursor.has_committed_history {
+            recovered_cursor.next_lsn
+        } else {
+            next_lsn
+        };
         let writer_epoch = WriterEpochId::from_hash(trusted_runtime_wal_digest("writer-epoch"));
         store.acquire_writer_epoch(WriterEpochRequest {
             epoch_id: writer_epoch,
@@ -488,16 +520,16 @@ impl TrustedRuntimeWal {
             previous_epoch_final_commit_digest: None,
             lease_or_lock_evidence: trusted_runtime_wal_digest("lease"),
         })?;
+        let durability_mode = store.durability_mode();
         Ok(Self {
             store,
             writer_epoch,
             segment_id: WalSegmentId::from_raw(1),
             next_lsn,
-            previous_frame_digest: trusted_runtime_wal_digest("previous-frame:genesis"),
-            previous_committed_transaction_digest: trusted_runtime_wal_digest(
-                "previous-commit:genesis",
-            ),
-            durability_mode: WalDurabilityMode::Buffered,
+            previous_frame_digest: recovered_cursor.previous_frame_digest,
+            previous_committed_transaction_digest: recovered_cursor
+                .previous_committed_transaction_digest,
+            durability_mode,
             payload_codec_id: PayloadCodecId::from_hash(trusted_runtime_wal_digest(
                 "payload-codec",
             )),
@@ -505,9 +537,9 @@ impl TrustedRuntimeWal {
                 "payload-schema",
             )),
             digest_domain: trusted_runtime_wal_digest("digest-domain"),
-            submission_frontier_digest: trusted_runtime_wal_digest("submission-frontier:genesis"),
-            receipt_frontier_digest: trusted_runtime_wal_digest("receipt-frontier:genesis"),
-            runtime_state_frontier_digest: trusted_runtime_wal_digest("runtime-frontier:genesis"),
+            submission_frontier_digest: recovered_cursor.submission_frontier_digest,
+            receipt_frontier_digest: recovered_cursor.receipt_frontier_digest,
+            runtime_state_frontier_digest: recovered_cursor.runtime_state_frontier_digest,
         })
     }
 
@@ -539,7 +571,7 @@ impl TrustedRuntimeWal {
     /// Recovers submission and receipt indexes from committed WAL transactions
     /// without scheduler callbacks.
     pub fn recover_read_only(&self) -> Result<TrustedRuntimeWalRecovery, TrustedRuntimeWalError> {
-        let report = recover_runtime_wal_store_read_only(&self.store)?;
+        let report = self.store.recover_read_only()?;
         let submissions = recover_submission_index(&report).map_err(WalRecoveryError::from)?;
         let receipts = recover_receipt_index(&report).map_err(WalRecoveryError::from)?;
         Ok(TrustedRuntimeWalRecovery {
@@ -584,6 +616,57 @@ impl TrustedRuntimeWal {
                 | SubmissionRetryPosture::AlreadyDecidedRejected
                 | SubmissionRetryPosture::AlreadyObstructed
         ))
+    }
+
+    fn uses_filesystem_store(&self) -> bool {
+        self.store.is_filesystem()
+    }
+
+    fn refresh_cursor_from_store_for_writer(&mut self) -> Result<(), TrustedRuntimeWalError> {
+        let report = self.store.recover_for_writer()?;
+        let cursor = TrustedRuntimeWalCursor::from_recovery(&report)?;
+        self.next_lsn = cursor.next_lsn;
+        self.previous_frame_digest = cursor.previous_frame_digest;
+        self.previous_committed_transaction_digest = cursor.previous_committed_transaction_digest;
+        self.submission_frontier_digest = cursor.submission_frontier_digest;
+        self.receipt_frontier_digest = cursor.receipt_frontier_digest;
+        self.runtime_state_frontier_digest = cursor.runtime_state_frontier_digest;
+        Ok(())
+    }
+
+    fn recover_filesystem_submission_acceptance_after_error(
+        &mut self,
+        submission_id: Hash,
+        canonical_envelope_digest: Hash,
+    ) -> bool {
+        if !self.uses_filesystem_store() {
+            return false;
+        }
+        if self.refresh_cursor_from_store_for_writer().is_err() {
+            return false;
+        }
+        self.has_submission_acceptance(submission_id, canonical_envelope_digest)
+            .unwrap_or(false)
+    }
+
+    fn recover_filesystem_tick_commit_after_error(
+        &mut self,
+        correlation: &ReceiptCorrelationRecord,
+    ) -> bool {
+        if !self.uses_filesystem_store() {
+            return false;
+        }
+        if self.refresh_cursor_from_store_for_writer().is_err() {
+            return false;
+        }
+        let Ok(recovery) = self.recover_read_only() else {
+            return false;
+        };
+        recovery
+            .receipts
+            .receipt_by_submission
+            .get(&correlation.submission_id)
+            == Some(&correlation.tick_receipt_digest)
     }
 
     fn record_submission_acceptance(
@@ -742,6 +825,35 @@ impl TrustedRuntimeWalStore {
         }
     }
 
+    fn is_filesystem(&self) -> bool {
+        matches!(self, Self::Filesystem(_))
+    }
+
+    fn durability_mode(&self) -> WalDurabilityMode {
+        match self {
+            Self::InMemory(_) => WalDurabilityMode::Buffered,
+            Self::Filesystem(_) => WalDurabilityMode::StrictFilesystem,
+        }
+    }
+
+    fn recover_for_writer(&self) -> Result<RecoveryScanReport, WalRecoveryError> {
+        match self {
+            Self::InMemory(store) => recover_runtime_wal_store_read_only(store),
+            Self::Filesystem(store) => {
+                recover_filesystem_store(store.root(), RecoveryAccessMode::Writable)
+            }
+        }
+    }
+
+    fn recover_read_only(&self) -> Result<RecoveryScanReport, WalRecoveryError> {
+        match self {
+            Self::InMemory(store) => recover_runtime_wal_store_read_only(store),
+            Self::Filesystem(store) => {
+                recover_filesystem_store(store.root(), RecoveryAccessMode::ReadOnly)
+            }
+        }
+    }
+
     fn append_transaction(
         &mut self,
         transaction: WalCommittedTransaction,
@@ -853,6 +965,126 @@ impl WalStorePort for TrustedRuntimeWalStore {
             Self::Filesystem(store) => store.close_epoch(epoch_id),
         }
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TrustedRuntimeWalCursor {
+    has_committed_history: bool,
+    next_lsn: Lsn,
+    previous_frame_digest: Hash,
+    previous_committed_transaction_digest: Hash,
+    submission_frontier_digest: Hash,
+    receipt_frontier_digest: Hash,
+    runtime_state_frontier_digest: Hash,
+}
+
+impl TrustedRuntimeWalCursor {
+    fn genesis() -> Self {
+        Self {
+            has_committed_history: false,
+            next_lsn: Lsn::from_raw(0),
+            previous_frame_digest: trusted_runtime_wal_digest("previous-frame:genesis"),
+            previous_committed_transaction_digest: trusted_runtime_wal_digest(
+                "previous-commit:genesis",
+            ),
+            submission_frontier_digest: trusted_runtime_wal_digest("submission-frontier:genesis"),
+            receipt_frontier_digest: trusted_runtime_wal_digest("receipt-frontier:genesis"),
+            runtime_state_frontier_digest: trusted_runtime_wal_digest("runtime-frontier:genesis"),
+        }
+    }
+
+    fn from_recovery(report: &RecoveryScanReport) -> Result<Self, TrustedRuntimeWalError> {
+        let mut cursor = Self::genesis();
+        for transaction in &report.transactions {
+            cursor.has_committed_history = true;
+            cursor.next_lsn = transaction
+                .commit
+                .last_lsn
+                .checked_next()
+                .ok_or(WalBuildError::LsnOverflow)?;
+            cursor.previous_committed_transaction_digest = transaction.commit.commit_digest;
+            if let Some(frame) = transaction.frames.last() {
+                cursor.previous_frame_digest = frame.digest();
+            }
+            match transaction.commit.transaction_kind {
+                WalTransactionKind::SubmissionIntake => {
+                    let record = submission_acceptance_record_from_transaction(transaction)?;
+                    cursor.submission_frontier_digest =
+                        submission_frontier_digest(cursor.submission_frontier_digest, record);
+                }
+                WalTransactionKind::SchedulerTick => {
+                    let (receipt, correlation, state_delta_digest) =
+                        tick_records_from_transaction(transaction)?;
+                    cursor.receipt_frontier_digest = receipt_frontier_digest(
+                        cursor.receipt_frontier_digest,
+                        receipt,
+                        correlation,
+                    );
+                    cursor.runtime_state_frontier_digest = recovered_runtime_state_frontier_digest(
+                        cursor.runtime_state_frontier_digest,
+                        correlation,
+                        state_delta_digest,
+                    );
+                }
+                _ => {}
+            }
+        }
+        Ok(cursor)
+    }
+}
+
+fn submission_acceptance_record_from_transaction(
+    transaction: &crate::causal_wal::WalRecoveredTransaction,
+) -> Result<SubmissionAcceptanceRecord, TrustedRuntimeWalError> {
+    let frame = transaction
+        .frames
+        .iter()
+        .find(|frame| frame.header.record_kind == WalRecordKind::SubmissionAcceptedRecorded)
+        .ok_or_else(missing_trusted_runtime_record)?;
+    SubmissionAcceptanceRecord::from_payload_bytes(&frame.payload.canonical_bytes)
+        .map_err(decode_trusted_runtime_wal_payload)
+}
+
+fn tick_records_from_transaction(
+    transaction: &crate::causal_wal::WalRecoveredTransaction,
+) -> Result<(TickReceiptRecord, WalReceiptCorrelationRecord, Hash), TrustedRuntimeWalError> {
+    let receipt_frame = transaction
+        .frames
+        .iter()
+        .find(|frame| frame.header.record_kind == WalRecordKind::TickReceiptRecorded)
+        .ok_or_else(missing_trusted_runtime_record)?;
+    let receipt = TickReceiptRecord::from_payload_bytes(&receipt_frame.payload.canonical_bytes)
+        .map_err(decode_trusted_runtime_wal_payload)?;
+    let correlation_frame = transaction
+        .frames
+        .iter()
+        .find(|frame| frame.header.record_kind == WalRecordKind::ReceiptCorrelationRecorded)
+        .ok_or_else(missing_trusted_runtime_record)?;
+    let correlation =
+        WalReceiptCorrelationRecord::from_payload_bytes(&correlation_frame.payload.canonical_bytes)
+            .map_err(decode_trusted_runtime_wal_payload)?;
+    let state_delta_frame = transaction
+        .frames
+        .iter()
+        .find(|frame| frame.header.record_kind == WalRecordKind::RuntimeStateDeltaRecorded)
+        .ok_or_else(missing_trusted_runtime_record)?;
+    let state_delta_digest = state_delta_frame
+        .payload
+        .canonical_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| decode_trusted_runtime_wal_payload(WalDecodeError::UnexpectedEof))?;
+    Ok((receipt, correlation, state_delta_digest))
+}
+
+fn missing_trusted_runtime_record() -> TrustedRuntimeWalError {
+    decode_trusted_runtime_wal_payload(WalDecodeError::UnexpectedEof)
+}
+
+fn decode_trusted_runtime_wal_payload(error: WalDecodeError) -> TrustedRuntimeWalError {
+    TrustedRuntimeWalError::Recovery(WalRecoveryError::Index(WalRecoveryIndexError::Decode(
+        error,
+    )))
 }
 
 fn recover_runtime_wal_store_read_only(
@@ -976,6 +1208,12 @@ impl TrustedRuntimeApp<'_> {
             }
         }
         if let Err(error) = runtime_wal.record_submission_acceptance(&envelope, handle) {
+            if runtime_wal.recover_filesystem_submission_acceptance_after_error(
+                handle.submission_id,
+                envelope.ingress_id(),
+            ) {
+                return Ok(handle);
+            }
             self.host.runtime = before_runtime;
             return Err(error.into());
         }
@@ -1287,6 +1525,22 @@ fn runtime_state_frontier_digest(
     hasher.update(&state_delta_digest);
     hasher.update(&correlation.commit_global_tick.as_u64().to_le_bytes());
     hasher.update(&correlation.worldline_tick_after.as_u64().to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn recovered_runtime_state_frontier_digest(
+    previous: Hash,
+    correlation: WalReceiptCorrelationRecord,
+    state_delta_digest: Hash,
+) -> Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(TRUSTED_RUNTIME_WAL_DOMAIN);
+    hasher.update(b"runtime-state-frontier:recovered");
+    hasher.update(&previous);
+    hasher.update(&correlation.submission_id);
+    hasher.update(&correlation.ticket_digest);
+    hasher.update(&correlation.receipt_digest);
+    hasher.update(&state_delta_digest);
     hasher.finalize().into()
 }
 

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -7,7 +7,10 @@
 //! daemon, does not make wall-clock cadence semantic, and does not give
 //! application code tick authority.
 
-use std::collections::BTreeSet;
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use thiserror::Error;
 
@@ -16,13 +19,14 @@ use crate::{
         build_recovery_certificate, build_submission_acceptance_transaction,
         build_tick_transaction, recover_from_frames_and_commits, recover_receipt_index,
         recover_submission_index, recovered_submission_receipt_index_root, AffectedFrontier,
-        AffectedFrontierKind, InMemoryWalStore, Lsn, PayloadCodecId, PayloadSchemaId,
-        RecoveredReceiptIndex, RecoveredSubmissionIndex, RecoveryAccessMode, RecoveryCertificate,
-        RecoveryScanReport, SubmissionAcceptanceRecord, SubmissionRetryPosture, TickReceiptRecord,
-        WalAppendAuthority, WalBuildError, WalCommittedTransaction, WalDurabilityMode,
-        WalReceiptCorrelationRecord, WalRecoveryError, WalSegmentId, WalStoreError, WalStorePort,
-        WalTickDecision, WalTransactionBuilder, WalTransactionCommit, WalTransactionId,
-        WalTransactionKind, WriterEpochId, WriterEpochRequest,
+        AffectedFrontierKind, FilesystemWalStore, InMemoryWalStore, Lsn, PayloadCodecId,
+        PayloadSchemaId, RecoveredReceiptIndex, RecoveredSubmissionIndex, RecoveryAccessMode,
+        RecoveryCertificate, RecoveryScanReport, SubmissionAcceptanceRecord,
+        SubmissionRetryPosture, TickReceiptRecord, WalAppendAuthority, WalBuildError,
+        WalCommittedTransaction, WalDurabilityMode, WalReceiptCorrelationRecord, WalRecoveryError,
+        WalSegmentId, WalStoreError, WalStorePort, WalTickDecision, WalTransactionBuilder,
+        WalTransactionCommit, WalTransactionId, WalTransactionKind, WriterEpochId,
+        WriterEpochRequest,
     },
     Engine, IngressEnvelope, InstalledContractPackage, InstalledContractPackageError,
     InstalledContractPackageRecord, IntentOutcome, IntentOutcomeDecision, IntentOutcomeObservation,
@@ -124,12 +128,14 @@ pub struct TrustedRuntimeWalRecovery {
 pub enum TrustedRuntimeWalStoreKind {
     /// Deterministic process-local store used by fast tests.
     InMemory,
+    /// Strict filesystem store rooted in host-owned storage.
+    Filesystem,
 }
 
 /// Host-owned runtime WAL adapter configuration.
 #[derive(Clone, Debug)]
 pub struct TrustedRuntimeWalConfig {
-    store: TrustedRuntimeWalStore,
+    store: TrustedRuntimeWalStoreConfig,
     next_lsn: Lsn,
 }
 
@@ -138,7 +144,22 @@ impl TrustedRuntimeWalConfig {
     #[must_use]
     pub fn in_memory() -> Self {
         Self {
-            store: TrustedRuntimeWalStore::in_memory(),
+            store: TrustedRuntimeWalStoreConfig::InMemory,
+            next_lsn: Lsn::from_raw(0),
+        }
+    }
+
+    /// Builds a filesystem-backed runtime WAL configuration rooted at `root`.
+    ///
+    /// The configured root is host-owned authority. Application code receives
+    /// only submission handles and observations through [`TrustedRuntimeApp`].
+    #[must_use]
+    pub fn filesystem(root: impl AsRef<Path>) -> Self {
+        Self {
+            store: TrustedRuntimeWalStoreConfig::Filesystem {
+                root: root.as_ref().to_path_buf(),
+                segment_id: WalSegmentId::from_raw(1),
+            },
             next_lsn: Lsn::from_raw(0),
         }
     }
@@ -154,6 +175,24 @@ impl TrustedRuntimeWalConfig {
     pub fn with_next_lsn(mut self, next_lsn: Lsn) -> Self {
         self.next_lsn = next_lsn;
         self
+    }
+}
+
+#[derive(Clone, Debug)]
+enum TrustedRuntimeWalStoreConfig {
+    InMemory,
+    Filesystem {
+        root: PathBuf,
+        segment_id: WalSegmentId,
+    },
+}
+
+impl TrustedRuntimeWalStoreConfig {
+    fn kind(&self) -> TrustedRuntimeWalStoreKind {
+        match self {
+            Self::InMemory => TrustedRuntimeWalStoreKind::InMemory,
+            Self::Filesystem { .. } => TrustedRuntimeWalStoreKind::Filesystem,
+        }
     }
 }
 
@@ -436,10 +475,8 @@ impl TrustedRuntimeWal {
 
     /// Builds a WAL adapter from host-owned configuration.
     pub fn from_config(config: TrustedRuntimeWalConfig) -> Result<Self, TrustedRuntimeWalError> {
-        let TrustedRuntimeWalConfig {
-            mut store,
-            next_lsn,
-        } = config;
+        let TrustedRuntimeWalConfig { store, next_lsn } = config;
+        let mut store = TrustedRuntimeWalStore::open(store)?;
         let writer_epoch = WriterEpochId::from_hash(trusted_runtime_wal_digest("writer-epoch"));
         store.acquire_writer_epoch(WriterEpochRequest {
             epoch_id: writer_epoch,
@@ -492,9 +529,10 @@ impl TrustedRuntimeWal {
         self.store.read_frames()
     }
 
-    /// Returns a clone of the underlying in-memory store for recovery tests.
+    /// Returns a clone of the underlying in-memory store for recovery tests,
+    /// if this adapter is backed by the in-memory store kind.
     #[must_use]
-    pub fn cloned_store(&self) -> InMemoryWalStore {
+    pub fn cloned_store(&self) -> Option<InMemoryWalStore> {
         self.store.cloned_in_memory_store()
     }
 
@@ -684,16 +722,23 @@ impl TrustedRuntimeWal {
 #[derive(Clone, Debug)]
 enum TrustedRuntimeWalStore {
     InMemory(InMemoryWalStore),
+    Filesystem(FilesystemWalStore),
 }
 
 impl TrustedRuntimeWalStore {
-    fn in_memory() -> Self {
-        Self::InMemory(InMemoryWalStore::new())
+    fn open(config: TrustedRuntimeWalStoreConfig) -> Result<Self, TrustedRuntimeWalError> {
+        match config {
+            TrustedRuntimeWalStoreConfig::InMemory => Ok(Self::InMemory(InMemoryWalStore::new())),
+            TrustedRuntimeWalStoreConfig::Filesystem { root, segment_id } => Ok(Self::Filesystem(
+                FilesystemWalStore::open(root, segment_id)?,
+            )),
+        }
     }
 
     fn kind(&self) -> TrustedRuntimeWalStoreKind {
         match self {
             Self::InMemory(_) => TrustedRuntimeWalStoreKind::InMemory,
+            Self::Filesystem(_) => TrustedRuntimeWalStoreKind::Filesystem,
         }
     }
 
@@ -703,6 +748,7 @@ impl TrustedRuntimeWalStore {
     ) -> Result<(), WalStoreError> {
         match self {
             Self::InMemory(store) => store.append_transaction(transaction),
+            Self::Filesystem(store) => store.append_transaction(transaction),
         }
     }
 
@@ -713,12 +759,14 @@ impl TrustedRuntimeWalStore {
     ) -> Result<(), WalStoreError> {
         match self {
             Self::InMemory(store) => store.append_uncommitted_frame(epoch_id, frame),
+            Self::Filesystem(store) => store.append_uncommitted_frame(epoch_id, frame),
         }
     }
 
-    fn cloned_in_memory_store(&self) -> InMemoryWalStore {
+    fn cloned_in_memory_store(&self) -> Option<InMemoryWalStore> {
         match self {
-            Self::InMemory(store) => store.clone(),
+            Self::InMemory(store) => Some(store.clone()),
+            Self::Filesystem(_) => None,
         }
     }
 }
@@ -730,6 +778,7 @@ impl WalStorePort for TrustedRuntimeWalStore {
     ) -> Result<crate::causal_wal::WriterEpoch, WalStoreError> {
         match self {
             Self::InMemory(store) => store.acquire_writer_epoch(request),
+            Self::Filesystem(store) => store.acquire_writer_epoch(request),
         }
     }
 
@@ -740,6 +789,7 @@ impl WalStorePort for TrustedRuntimeWalStore {
     ) -> Result<(), WalStoreError> {
         match self {
             Self::InMemory(store) => store.append_frame(epoch_id, frame),
+            Self::Filesystem(store) => store.append_frame(epoch_id, frame),
         }
     }
 
@@ -750,18 +800,21 @@ impl WalStorePort for TrustedRuntimeWalStore {
     ) -> Result<(), WalStoreError> {
         match self {
             Self::InMemory(store) => store.flush_commit(epoch_id, commit),
+            Self::Filesystem(store) => store.flush_commit(epoch_id, commit),
         }
     }
 
     fn read_frames(&self) -> Vec<crate::causal_wal::WalFrame> {
         match self {
             Self::InMemory(store) => store.read_frames(),
+            Self::Filesystem(store) => store.read_frames(),
         }
     }
 
     fn read_commits(&self) -> Vec<WalTransactionCommit> {
         match self {
             Self::InMemory(store) => store.read_commits(),
+            Self::Filesystem(store) => store.read_commits(),
         }
     }
 
@@ -772,12 +825,14 @@ impl WalStorePort for TrustedRuntimeWalStore {
     ) -> Result<crate::causal_wal::WalSegmentSeal, WalStoreError> {
         match self {
             Self::InMemory(store) => store.seal_segment(epoch_id, segment_id),
+            Self::Filesystem(store) => store.seal_segment(epoch_id, segment_id),
         }
     }
 
     fn truncate_tail_after(&mut self, after_lsn: Lsn) -> Result<(), WalStoreError> {
         match self {
             Self::InMemory(store) => store.truncate_tail_after(after_lsn),
+            Self::Filesystem(store) => store.truncate_tail_after(after_lsn),
         }
     }
 
@@ -788,12 +843,14 @@ impl WalStorePort for TrustedRuntimeWalStore {
     ) -> Result<(), WalStoreError> {
         match self {
             Self::InMemory(store) => store.publish_manifest(epoch_id, manifest),
+            Self::Filesystem(store) => store.publish_manifest(epoch_id, manifest),
         }
     }
 
     fn close_epoch(&mut self, epoch_id: WriterEpochId) -> Result<(), WalStoreError> {
         match self {
             Self::InMemory(store) => store.close_epoch(epoch_id),
+            Self::Filesystem(store) => store.close_epoch(epoch_id),
         }
     }
 }

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -15,9 +15,10 @@ use echo_registry_api::{
 };
 use warp_core::{
     causal_wal::{
-        recover_in_memory_store, recover_receipt_index, recover_submission_index,
-        recovered_submission_receipt_index_root, Lsn, RecoveredSubmissionPosture,
-        RecoveryAccessMode, WalBuildError, WalTransactionKind,
+        canonical_segment_path, recover_in_memory_store, recover_receipt_index,
+        recover_submission_index, recovered_submission_receipt_index_root, Lsn,
+        RecoveredSubmissionPosture, RecoveryAccessMode, RecoveryTailPosture, WalBuildError,
+        WalDurabilityMode, WalRecoveryError, WalSegmentId, WalTransactionKind,
     },
     make_head_id, make_intent_kind, make_node_id, make_type_id, AuthoredObserverPlan,
     ContractMutationHandler, ContractOperationKind, ContractPackageIdentity, ContractQueryObserver,
@@ -591,6 +592,228 @@ fn filesystem_runtime_wal_ack_reconstructs_submission_and_tick_from_root() {
     assert_eq!(
         recovery.certificate.recovered_indexes_root,
         recovered_submission_receipt_index_root(&recovery.submissions, &recovery.receipts)
+    );
+}
+
+#[test]
+fn filesystem_runtime_wal_ack_reconstructed_host_appends_after_recovery() {
+    let wal_root = temp_runtime_wal_dir("append-after-recovery");
+    let (initial_runtime, first_worldline, _) = runtime_pair();
+    let mut host = TrustedRuntimeHost::new(initial_runtime, empty_engine())
+        .expect("trusted host should initialize");
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+
+    let first_submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(first_worldline))
+            .expect("first filesystem WAL ACK submit should commit")
+    };
+    drop(host);
+
+    let (reconstructed_runtime, _, second_worldline) = runtime_pair();
+    let mut reconstructed_host = TrustedRuntimeHost::new(reconstructed_runtime, empty_engine())
+        .expect("reconstructed trusted host should initialize");
+    reconstructed_host
+        .enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("reconstructed host should reopen filesystem runtime WAL adapter");
+    let second_envelope = eint_envelope(second_worldline);
+    let second_digest = second_envelope.ingress_id();
+    let second_submission = {
+        let mut app = reconstructed_host.app();
+        app.submit_intent_with_runtime_wal_ack(second_envelope)
+            .expect("reconstructed host should append after recovered WAL cursor")
+    };
+
+    let runtime_wal = reconstructed_host
+        .runtime_wal()
+        .expect("runtime WAL should remain configured");
+    let commits = runtime_wal.commits();
+    assert_eq!(commits.len(), 2);
+    assert_eq!(commits[0].first_lsn, Lsn::from_raw(0));
+    assert_eq!(commits[0].last_lsn, Lsn::from_raw(1));
+    assert_eq!(commits[1].first_lsn, Lsn::from_raw(2));
+    assert_eq!(commits[1].last_lsn, Lsn::from_raw(3));
+    assert_eq!(
+        commits[1].previous_committed_transaction_digest,
+        commits[0].commit_digest
+    );
+
+    let recovery = runtime_wal
+        .recover_read_only()
+        .expect("filesystem runtime WAL should recover after restart append");
+    assert_eq!(recovery.certificate.committed_transactions_replayed, 2);
+    assert_eq!(
+        recovery
+            .submissions
+            .get(&first_submission.submission_id)
+            .expect("first submission should recover")
+            .posture,
+        RecoveredSubmissionPosture::AcceptedPending
+    );
+    let recovered_second = recovery
+        .submissions
+        .get(&second_submission.submission_id)
+        .expect("second submission should recover");
+    assert_eq!(
+        recovered_second.acceptance.canonical_envelope_digest,
+        second_digest
+    );
+    assert_eq!(
+        recovered_second.posture,
+        RecoveredSubmissionPosture::AcceptedPending
+    );
+}
+
+#[test]
+fn filesystem_runtime_wal_ack_commits_strict_filesystem_durability() {
+    let wal_root = temp_runtime_wal_dir("strict-durability");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+
+    {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect("filesystem WAL ACK submit should commit");
+    }
+
+    let commits = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured")
+        .commits();
+    assert_eq!(commits.len(), 1);
+    assert_eq!(
+        commits[0].durability_mode,
+        WalDurabilityMode::StrictFilesystem
+    );
+}
+
+#[test]
+fn filesystem_runtime_wal_ack_recovery_reports_uncommitted_tail_from_root() {
+    let wal_root = temp_runtime_wal_dir("tail-report");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+    let envelope = eint_envelope(worldline_id);
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope.clone())
+            .expect("filesystem WAL ACK submit should commit")
+    };
+    drop(host);
+
+    let mut raw_wal =
+        TrustedRuntimeWal::from_config(TrustedRuntimeWalConfig::filesystem(&wal_root))
+            .expect("filesystem WAL should reopen for test tail append");
+    raw_wal
+        .append_uncommitted_submission_acceptance_for_test(&envelope, submission)
+        .expect("test fixture should append uncommitted filesystem tail");
+
+    let recovery = raw_wal
+        .recover_read_only()
+        .expect("read-only recovery should report uncommitted tail");
+    assert_eq!(
+        recovery.certificate.tail_posture,
+        RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(1))
+    );
+}
+
+#[test]
+fn filesystem_runtime_wal_ack_recovery_rejects_corrupt_root() {
+    let wal_root = temp_runtime_wal_dir("corrupt-root");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+    {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect("filesystem WAL ACK submit should commit");
+    }
+    let runtime_wal = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured");
+    fs::write(
+        canonical_segment_path(&wal_root, WalSegmentId::from_raw(1)),
+        b"not-a-valid-runtime-wal-segment",
+    )
+    .expect("test should corrupt filesystem WAL segment");
+
+    let err = runtime_wal
+        .recover_read_only()
+        .expect_err("corrupt filesystem WAL should not recover as empty clean history");
+    assert!(matches!(
+        err,
+        TrustedRuntimeWalError::Recovery(
+            WalRecoveryError::Store(_) | WalRecoveryError::Validation(_)
+        )
+    ));
+}
+
+#[test]
+fn filesystem_runtime_wal_ack_multi_head_tick_rejects_before_partial_filesystem_append() {
+    let wal_root = temp_runtime_wal_dir("multi-head-atomic");
+    let (runtime, worldline_a, worldline_b) = runtime_pair();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+    host.register_contract_package(package())
+        .expect("host should install package");
+
+    let submission_a = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_a))
+            .expect("first submission acceptance should commit before ACK")
+    };
+    let submission_b = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_b))
+            .expect("second submission acceptance should commit before ACK")
+    };
+    host.stage_installed_contract_submission(submission_a.submission_id, &admission_ticket(56))
+        .expect("trusted host should stage first ticketed ingress");
+    host.stage_installed_contract_submission(submission_b.submission_id, &admission_ticket(57))
+        .expect("trusted host should stage second ticketed ingress");
+
+    let err = host
+        .run_until_idle(4)
+        .expect_err("filesystem WAL should reject multi-transaction tick batches for now");
+    assert!(matches!(
+        err,
+        TrustedRuntimeHostError::Wal(TrustedRuntimeWalError::FilesystemAtomicBatchUnsupported {
+            transaction_kind: WalTransactionKind::SchedulerTick,
+            transaction_count: 2
+        })
+    ));
+
+    let recovery = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured")
+        .recover_read_only()
+        .expect("filesystem WAL should recover accepted submissions");
+    assert_eq!(recovery.certificate.committed_transactions_replayed, 2);
+    for submission_id in [submission_a.submission_id, submission_b.submission_id] {
+        assert_eq!(
+            recovery
+                .submissions
+                .get(&submission_id)
+                .expect("submission should remain accepted pending")
+                .posture,
+            RecoveredSubmissionPosture::AcceptedPending
+        );
+    }
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should stay configured")
+            .scheduler_tick_count(),
+        0
     );
 }
 

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -4,6 +4,11 @@
 #![cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
 #![allow(clippy::expect_used, clippy::panic)]
 
+use std::fs;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use echo_registry_api::{
     ArgDef, ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, RegistryInfo,
     RegistryProvider,
@@ -26,6 +31,8 @@ use warp_core::{
     WriterHeadKey, OPTIC_ADMISSION_TICKET_KIND, OPTIC_ARTIFACT_HANDLE_KIND,
 };
 
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 const SCHEMA_SHA256_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const MUTATION_OP_ID: u32 = 6001;
 const QUERY_OP_ID: u32 = 6002;
@@ -38,6 +45,38 @@ const MUTATION_RULE_NAME: &str =
     "cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/6001/increment";
 const MUTATION_RULE_ID_LABEL: &str =
     "rule:cmd/contract/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/6001/increment";
+
+fn deterministic_test_dir(prefix: &str, label: &str) -> PathBuf {
+    let root = PathBuf::from("target").join("warp-core-test-tmp");
+    fs::create_dir_all(&root).expect("test temp root should be created");
+    for _ in 0..1024 {
+        let unique = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = root.join(format!("{prefix}-{label}-{unique}"));
+        match fs::create_dir(&dir) {
+            Ok(()) => return dir,
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                fs::remove_dir_all(&dir).expect("stale test dir should be removable");
+                match fs::create_dir(&dir) {
+                    Ok(()) => return dir,
+                    Err(retry_error) if retry_error.kind() == ErrorKind::AlreadyExists => {}
+                    Err(retry_error) => panic!(
+                        "failed to recreate deterministic test directory {}: {retry_error}",
+                        dir.display()
+                    ),
+                }
+            }
+            Err(error) => panic!(
+                "failed to create deterministic test directory {}: {error}",
+                dir.display()
+            ),
+        }
+    }
+    panic!("exhausted deterministic test directory attempts for {prefix}-{label}");
+}
+
+fn temp_runtime_wal_dir(label: &str) -> PathBuf {
+    deterministic_test_dir("echo-trusted-runtime-wal", label)
+}
 
 static INCREMENT_ARGS: &[ArgDef] = &[ArgDef {
     name: "input",
@@ -414,7 +453,9 @@ fn runtime_wal_ack_submit_commits_acceptance_before_returning_handle() {
     assert_eq!(runtime_wal.submission_acceptance_count(), 1);
     assert_eq!(runtime_wal.commits().len(), 1);
 
-    let mut store = runtime_wal.cloned_store();
+    let mut store = runtime_wal
+        .cloned_store()
+        .expect("in-memory runtime WAL should expose test store clone");
     let report = recover_in_memory_store(&mut store, RecoveryAccessMode::ReadOnly)
         .expect("committed acceptance should recover");
     let recovered = recover_submission_index(&report)
@@ -458,6 +499,98 @@ fn runtime_wal_ack_adapter_is_configured_by_trusted_host_boundary() {
             .expect("submission should recover")
             .posture,
         RecoveredSubmissionPosture::AcceptedPending
+    );
+}
+
+#[test]
+fn filesystem_runtime_wal_ack_reconstructs_submission_and_tick_from_root() {
+    let wal_root = temp_runtime_wal_dir("ack-recovery");
+    let (initial_runtime, worldline_id) = runtime();
+    let mut host = TrustedRuntimeHost::new(initial_runtime, empty_engine())
+        .expect("trusted host should initialize");
+
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should be configured")
+            .store_kind(),
+        TrustedRuntimeWalStoreKind::Filesystem
+    );
+    host.register_contract_package(package())
+        .expect("host should install package");
+
+    let envelope = eint_envelope(worldline_id);
+    let envelope_digest = envelope.ingress_id();
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope)
+            .expect("filesystem WAL ACK submit should return after durable acceptance")
+    };
+    let ticket = admission_ticket(55);
+    host.stage_installed_contract_submission(submission.submission_id, &ticket)
+        .expect("trusted host should stage package-supported ticketed ingress");
+    host.run_until_idle(4)
+        .expect("trusted host should tick until idle");
+
+    let outcome = {
+        let app = host.app();
+        app.observe_intent_outcome(&submission.submission_id)
+    };
+    let IntentOutcome::Applied { receipt, .. } = outcome else {
+        panic!("expected applied outcome");
+    };
+    let tick_receipt_digest = receipt.tick_receipt_digest;
+    drop(host);
+
+    let (reconstructed_runtime, _) = runtime();
+    let mut reconstructed_host = TrustedRuntimeHost::new(reconstructed_runtime, empty_engine())
+        .expect("reconstructed trusted host should initialize");
+    reconstructed_host
+        .enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("reconstructed host should reopen filesystem runtime WAL adapter");
+
+    let recovery = reconstructed_host
+        .runtime_wal()
+        .expect("runtime WAL should be configured on reconstructed host")
+        .recover_read_only()
+        .expect("filesystem runtime WAL should recover read-only");
+    let recovered_submission = recovery
+        .submissions
+        .get(&submission.submission_id)
+        .expect("submission should recover from filesystem runtime WAL");
+
+    assert_eq!(
+        recovered_submission.acceptance.submission_id,
+        submission.submission_id
+    );
+    assert_eq!(
+        recovered_submission.acceptance.canonical_envelope_digest,
+        envelope_digest
+    );
+    assert_eq!(
+        recovered_submission.posture,
+        RecoveredSubmissionPosture::DecidedApplied
+    );
+    assert_eq!(
+        recovery
+            .receipts
+            .receipt_by_submission
+            .get(&submission.submission_id),
+        Some(&tick_receipt_digest)
+    );
+    assert_eq!(
+        recovery
+            .receipts
+            .ticket_by_submission
+            .get(&submission.submission_id),
+        Some(&ticket.ticket_digest)
+    );
+    assert_eq!(recovery.certificate.committed_transactions_replayed, 2);
+    assert_eq!(recovery.certificate.obstruction_count, 0);
+    assert_eq!(
+        recovery.certificate.recovered_indexes_root,
+        recovered_submission_receipt_index_root(&recovery.submissions, &recovery.receipts)
     );
 }
 
@@ -526,7 +659,9 @@ fn runtime_wal_ack_duplicate_without_prior_wal_backfills_acceptance() {
         .runtime_wal()
         .expect("runtime WAL should stay configured");
     assert_eq!(runtime_wal.submission_acceptance_count(), 1);
-    let mut store = runtime_wal.cloned_store();
+    let mut store = runtime_wal
+        .cloned_store()
+        .expect("in-memory runtime WAL should expose test store clone");
     let report = recover_in_memory_store(&mut store, RecoveryAccessMode::ReadOnly)
         .expect("backfilled acceptance should recover");
     let recovered = recover_submission_index(&report)
@@ -676,7 +811,9 @@ fn runtime_wal_ack_tick_commits_receipt_transaction_before_outcome_is_observed()
         1
     );
 
-    let mut store = runtime_wal.cloned_store();
+    let mut store = runtime_wal
+        .cloned_store()
+        .expect("in-memory runtime WAL should expose test store clone");
     let recovery = recover_in_memory_store(&mut store, RecoveryAccessMode::ReadOnly)
         .expect("committed tick receipt should recover");
     let submissions = recover_submission_index(&recovery)

--- a/docs/design/causal-wal-hardening-matrix.md
+++ b/docs/design/causal-wal-hardening-matrix.md
@@ -912,6 +912,11 @@ Acceptance criteria:
 - `TrustedRuntimeHost` owns the runtime WAL adapter.
 - `TrustedRuntimeHost` configures the adapter through `TrustedRuntimeWalConfig`.
 - The adapter can be backed by a host-owned filesystem WAL root.
+- Reopened filesystem adapters continue the committed LSN and commit-digest
+  chain.
+- Filesystem read-only recovery preserves torn/corrupt segment posture.
+- Filesystem-backed scheduler batches reject unsafe multi-transaction rollback
+  until an atomic filesystem batch transaction exists.
 - `TrustedRuntimeApp` exposes no WAL append or tick authority.
 - The adapter can be inspected by host tests as read-only evidence.
 
@@ -920,6 +925,10 @@ Test plan:
 - `runtime_wal_ack_adapter_is_configured_by_trusted_host_boundary`
 - `runtime_wal_ack_submit_commits_acceptance_before_returning_handle`
 - `filesystem_runtime_wal_ack_reconstructs_submission_and_tick_from_root`
+- `filesystem_runtime_wal_ack_reconstructed_host_appends_after_recovery`
+- `filesystem_runtime_wal_ack_recovery_reports_uncommitted_tail_from_root`
+- `filesystem_runtime_wal_ack_recovery_rejects_corrupt_root`
+- `filesystem_runtime_wal_ack_multi_head_tick_rejects_before_partial_filesystem_append`
 
 ## Slice 87: Submission Acceptance Transaction Wiring
 

--- a/docs/design/causal-wal-hardening-matrix.md
+++ b/docs/design/causal-wal-hardening-matrix.md
@@ -911,6 +911,7 @@ Acceptance criteria:
 
 - `TrustedRuntimeHost` owns the runtime WAL adapter.
 - `TrustedRuntimeHost` configures the adapter through `TrustedRuntimeWalConfig`.
+- The adapter can be backed by a host-owned filesystem WAL root.
 - `TrustedRuntimeApp` exposes no WAL append or tick authority.
 - The adapter can be inspected by host tests as read-only evidence.
 
@@ -918,6 +919,7 @@ Test plan:
 
 - `runtime_wal_ack_adapter_is_configured_by_trusted_host_boundary`
 - `runtime_wal_ack_submit_commits_acceptance_before_returning_handle`
+- `filesystem_runtime_wal_ack_reconstructs_submission_and_tick_from_root`
 
 ## Slice 87: Submission Acceptance Transaction Wiring
 

--- a/docs/design/reference-trusted-runtime-host-loop.md
+++ b/docs/design/reference-trusted-runtime-host-loop.md
@@ -75,6 +75,10 @@ The runtime WAL adapter is configured through the trusted host, not through
 but it never receives WAL append, flush, truncate, manifest, tick, or recovery
 authority. Filesystem WAL roots are likewise host-owned configuration: app code
 receives submission handles and observations, not store handles or paths.
+Reconstructed filesystem adapters derive their next writer cursor from
+committed WAL history before accepting new appends, and read-only recovery uses
+filesystem recovery so torn or corrupt segment state remains visible in the
+recovery posture.
 
 ## Non-Goals
 

--- a/docs/design/reference-trusted-runtime-host-loop.md
+++ b/docs/design/reference-trusted-runtime-host-loop.md
@@ -40,7 +40,8 @@ staging, no `super_tick`, no scheduler pass, and no fault recovery authority.
 - `TrustedRuntimeHost::tick_once(...)`;
 - `TrustedRuntimeHost::run_until_idle(...)`;
 - `TrustedRuntimeWalConfig`, which the trusted host uses to configure the
-  runtime WAL adapter before app-facing ACK submission;
+  runtime WAL adapter before app-facing ACK submission, including
+  deterministic in-memory tests and filesystem-backed runtime WAL roots;
 - `TrustedRuntimeWalStoreKind`, which exposes the configured store kind as
   host-owned read-only evidence;
 - `TrustedRuntimeHostRunReport`, which records scheduler passes and committed
@@ -58,7 +59,7 @@ application
 -> witnessed submission handle
 
 trusted runtime host
--> configures runtime WAL adapter
+-> configures runtime WAL adapter or filesystem WAL root
 -> registers package
 -> stages ticketed ingress
 -> runs scheduler-owned ticks
@@ -72,7 +73,8 @@ scheduler-owned tick execution decide it.
 The runtime WAL adapter is configured through the trusted host, not through
 `TrustedRuntimeApp`. The app-facing handle can request the WAL-backed ACK path,
 but it never receives WAL append, flush, truncate, manifest, tick, or recovery
-authority.
+authority. Filesystem WAL roots are likewise host-owned configuration: app code
+receives submission handles and observations, not store handles or paths.
 
 ## Non-Goals
 
@@ -87,8 +89,11 @@ authority.
 
 - `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime" --test trusted_runtime_host_loop_tests`
 - `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests runtime_wal_ack`
+- `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests filesystem_runtime_wal_ack`
 
 The witness registers a generated-style package, submits through the app handle,
 stages ticketed ingress through the host, runs until idle, observes an applied
 intent outcome, and queries through the read-only observer service with package
-evidence.
+evidence. The filesystem runtime WAL witness reopens a fresh trusted host over
+the same WAL root and rebuilds submission, receipt, and recovery-certificate
+indexes from committed filesystem WAL history.


### PR DESCRIPTION
## Summary

- add `TrustedRuntimeWalConfig::filesystem(...)` and `TrustedRuntimeWalStoreKind::Filesystem` for host-owned filesystem runtime WAL roots
- route the trusted runtime WAL adapter through `FilesystemWalStore` while keeping `TrustedRuntimeApp` limited to submit/observe surfaces
- add a filesystem ACK/recovery witness that reopens a fresh trusted host over the WAL root and rebuilds submission, receipt, and recovery-certificate indexes
- update the trusted-host reference, hardening matrix, changelog, and nondeterminism guard waiver for the test-only filesystem fixture

Closes #555

## Validation

- `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests filesystem_runtime_wal_ack`
- `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests runtime_wal_ack`
- `cargo clippy -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests -- -D warnings`
- `cargo check -p warp-core --features "native_rule_bootstrap trusted_runtime host_test"`
- `cargo fmt --check`
- `pnpm exec prettier --check CHANGELOG.md docs/design/reference-trusted-runtime-host-loop.md docs/design/causal-wal-hardening-matrix.md`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/design/reference-trusted-runtime-host-loop.md docs/design/causal-wal-hardening-matrix.md`
- `scripts/check_spdx.sh CHANGELOG.md docs/design/reference-trusted-runtime-host-loop.md docs/design/causal-wal-hardening-matrix.md crates/warp-core/src/trusted_runtime_host.rs crates/warp-core/tests/trusted_runtime_host_loop_tests.rs`
- `scripts/ban-nondeterminism.sh`
- `DETERMINISM_FORCE_NO_RG=1 scripts/ban-nondeterminism.sh`
- `bash tests/hooks/test_verify_local.sh`
- `git diff --check`
