### PR TITLE
feat(warp-core): add filesystem WAL failure atomicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
   submissions after host reconstruction, reopened filesystem adapters continue
   the committed LSN/digest chain, filesystem commits are marked
   `StrictFilesystem`, read-only filesystem recovery preserves torn/corrupt tail
-  posture, and `TrustedRuntimeApp` remains limited to submit and observe
-  surfaces.
+  posture, host-test-only filesystem fault plans inject append, flush, and
+  manifest failures to prove submission/tick rollback, and `TrustedRuntimeApp`
+  remains limited to submit and observe surfaces.
 - Added an Echo 1.0 release contract that records the four binary release gates,
   compatibility policy, evidence requirements, and GitHub Project boundary
   without carrying live roadmap state in the repository.

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -2635,6 +2635,65 @@ impl WalDoctorReport {
     }
 }
 
+/// Filesystem WAL operation that may be faulted by host-test fixtures.
+#[cfg(any(test, feature = "host_test"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FilesystemWalFaultTarget {
+    /// Fail the next frame append before writing segment bytes.
+    AppendFrame,
+    /// Fail the next commit flush before writing the commit marker.
+    FlushCommit,
+    /// Fail the next manifest publish before writing manifest material.
+    PublishManifest,
+}
+
+/// Host-test-only filesystem WAL fault plan.
+#[cfg(any(test, feature = "host_test"))]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FilesystemWalFaultPlan {
+    append_frame: u32,
+    flush_commit: u32,
+    publish_manifest: u32,
+}
+
+#[cfg(any(test, feature = "host_test"))]
+impl FilesystemWalFaultPlan {
+    /// Builds a plan that fails the next operation for `target`.
+    #[must_use]
+    pub const fn fail_next(target: FilesystemWalFaultTarget) -> Self {
+        match target {
+            FilesystemWalFaultTarget::AppendFrame => Self {
+                append_frame: 1,
+                flush_commit: 0,
+                publish_manifest: 0,
+            },
+            FilesystemWalFaultTarget::FlushCommit => Self {
+                append_frame: 0,
+                flush_commit: 1,
+                publish_manifest: 0,
+            },
+            FilesystemWalFaultTarget::PublishManifest => Self {
+                append_frame: 0,
+                flush_commit: 0,
+                publish_manifest: 1,
+            },
+        }
+    }
+
+    fn should_fail(&mut self, target: FilesystemWalFaultTarget) -> bool {
+        let remaining = match target {
+            FilesystemWalFaultTarget::AppendFrame => &mut self.append_frame,
+            FilesystemWalFaultTarget::FlushCommit => &mut self.flush_commit,
+            FilesystemWalFaultTarget::PublishManifest => &mut self.publish_manifest,
+        };
+        if *remaining == 0 {
+            return false;
+        }
+        *remaining -= 1;
+        true
+    }
+}
+
 /// Local filesystem WAL store backed by segment files.
 #[derive(Clone, Debug)]
 pub struct FilesystemWalStore {
@@ -2645,6 +2704,8 @@ pub struct FilesystemWalStore {
     epoch_closures: BTreeMap<WriterEpochId, WriterEpochClosure>,
     manifests: Vec<WalManifest>,
     sync_evidence: Vec<FilesystemSyncEvidence>,
+    #[cfg(any(test, feature = "host_test"))]
+    fault_plan: FilesystemWalFaultPlan,
 }
 
 impl FilesystemWalStore {
@@ -2687,7 +2748,27 @@ impl FilesystemWalStore {
             epoch_closures: BTreeMap::new(),
             manifests: Vec::new(),
             sync_evidence,
+            #[cfg(any(test, feature = "host_test"))]
+            fault_plan: FilesystemWalFaultPlan::default(),
         })
+    }
+
+    /// Opens a filesystem WAL store with an injected host-test fault plan.
+    #[cfg(any(test, feature = "host_test"))]
+    pub fn open_with_fault_plan_for_test(
+        root: impl AsRef<Path>,
+        segment_id: WalSegmentId,
+        fault_plan: FilesystemWalFaultPlan,
+    ) -> Result<Self, WalStoreError> {
+        let mut store = Self::open(root, segment_id)?;
+        store.fault_plan = fault_plan;
+        Ok(store)
+    }
+
+    /// Replaces the host-test fault plan for this filesystem WAL store.
+    #[cfg(any(test, feature = "host_test"))]
+    pub fn replace_fault_plan_for_test(&mut self, fault_plan: FilesystemWalFaultPlan) {
+        self.fault_plan = fault_plan;
     }
 
     /// Returns the active segment path.
@@ -2806,6 +2887,15 @@ impl WalStorePort for FilesystemWalStore {
             });
         }
         frame.validate_integrity()?;
+        #[cfg(any(test, feature = "host_test"))]
+        if self
+            .fault_plan
+            .should_fail(FilesystemWalFaultTarget::AppendFrame)
+        {
+            return Err(WalStoreError::Io(
+                "injected filesystem WAL append_frame failure".to_owned(),
+            ));
+        }
         append_segment_record(&self.segment_path(), DiskWalRecord::Frame(&frame), false)
     }
 
@@ -2821,6 +2911,17 @@ impl WalStorePort for FilesystemWalStore {
         if active_epoch.epoch_id != epoch_id || commit.writer_epoch != epoch_id {
             return Err(WalStoreError::WriterEpochMismatch);
         }
+        #[cfg(any(test, feature = "host_test"))]
+        if self
+            .fault_plan
+            .should_fail(FilesystemWalFaultTarget::FlushCommit)
+        {
+            return Err(WalStoreError::Io(
+                "injected filesystem WAL flush_commit failure".to_owned(),
+            ));
+        }
+        let transaction_id = commit.transaction_id;
+        append_segment_record(&self.segment_path(), DiskWalRecord::Commit(&commit), true)?;
         self.epoch_closures.insert(
             epoch_id,
             WriterEpochClosure {
@@ -2828,8 +2929,6 @@ impl WalStorePort for FilesystemWalStore {
                 final_commit_digest: Some(commit.commit_digest),
             },
         );
-        let transaction_id = commit.transaction_id;
-        append_segment_record(&self.segment_path(), DiskWalRecord::Commit(&commit), true)?;
         self.sync_evidence.push(FilesystemSyncEvidence::transaction(
             FilesystemSyncBoundary::CommitFileSynced,
             transaction_id,
@@ -2888,6 +2987,15 @@ impl WalStorePort for FilesystemWalStore {
             .ok_or(WalStoreError::NoActiveWriterEpoch)?;
         if active_epoch.epoch_id != epoch_id {
             return Err(WalStoreError::WriterEpochMismatch);
+        }
+        #[cfg(any(test, feature = "host_test"))]
+        if self
+            .fault_plan
+            .should_fail(FilesystemWalFaultTarget::PublishManifest)
+        {
+            return Err(WalStoreError::Io(
+                "injected filesystem WAL publish_manifest failure".to_owned(),
+            ));
         }
         write_manifest_atomic(&self.root, &manifest)?;
         self.sync_evidence.push(FilesystemSyncEvidence::unscoped(

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -37,6 +37,9 @@ use crate::{
 };
 use crate::{Hash, HistoryError};
 
+#[cfg(any(test, feature = "host_test"))]
+use crate::causal_wal::FilesystemWalFaultPlan;
+
 const TRUSTED_RUNTIME_WAL_DOMAIN: &[u8] = b"echo:trusted-runtime-wal:v1\0";
 
 /// Error returned by the reference trusted host loop.
@@ -170,6 +173,26 @@ impl TrustedRuntimeWalConfig {
             store: TrustedRuntimeWalStoreConfig::Filesystem {
                 root: root.as_ref().to_path_buf(),
                 segment_id: WalSegmentId::from_raw(1),
+                #[cfg(any(test, feature = "host_test"))]
+                fault_plan: None,
+            },
+            next_lsn: Lsn::from_raw(0),
+        }
+    }
+
+    /// Builds a filesystem-backed runtime WAL configuration with a host-test
+    /// fault plan.
+    #[cfg(any(test, feature = "host_test"))]
+    #[must_use]
+    pub fn filesystem_with_fault_plan_for_test(
+        root: impl AsRef<Path>,
+        fault_plan: FilesystemWalFaultPlan,
+    ) -> Self {
+        Self {
+            store: TrustedRuntimeWalStoreConfig::Filesystem {
+                root: root.as_ref().to_path_buf(),
+                segment_id: WalSegmentId::from_raw(1),
+                fault_plan: Some(fault_plan),
             },
             next_lsn: Lsn::from_raw(0),
         }
@@ -195,6 +218,8 @@ enum TrustedRuntimeWalStoreConfig {
     Filesystem {
         root: PathBuf,
         segment_id: WalSegmentId,
+        #[cfg(any(test, feature = "host_test"))]
+        fault_plan: Option<FilesystemWalFaultPlan>,
     },
 }
 
@@ -312,6 +337,20 @@ impl TrustedRuntimeHost {
     #[cfg(any(test, feature = "host_test"))]
     pub fn replace_runtime_wal_for_test(&mut self, runtime_wal: TrustedRuntimeWal) {
         self.runtime_wal = Some(runtime_wal);
+    }
+
+    /// Replaces the filesystem WAL fault plan for targeted host tests.
+    #[cfg(any(test, feature = "host_test"))]
+    pub fn inject_runtime_wal_filesystem_fault_for_test(
+        &mut self,
+        fault_plan: FilesystemWalFaultPlan,
+    ) -> Result<(), TrustedRuntimeHostError> {
+        let runtime_wal = self
+            .runtime_wal
+            .as_mut()
+            .ok_or(TrustedRuntimeHostError::RuntimeWalUnavailable)?;
+        runtime_wal.replace_filesystem_fault_plan_for_test(fault_plan)?;
+        Ok(())
     }
 
     /// Returns the app-facing surface. This surface can submit and observe, but
@@ -622,6 +661,16 @@ impl TrustedRuntimeWal {
         self.store.is_filesystem()
     }
 
+    #[cfg(any(test, feature = "host_test"))]
+    fn replace_filesystem_fault_plan_for_test(
+        &mut self,
+        fault_plan: FilesystemWalFaultPlan,
+    ) -> Result<(), TrustedRuntimeWalError> {
+        self.store
+            .replace_filesystem_fault_plan_for_test(fault_plan)?;
+        Ok(())
+    }
+
     fn refresh_cursor_from_store_for_writer(&mut self) -> Result<(), TrustedRuntimeWalError> {
         let report = self.store.recover_for_writer()?;
         let cursor = TrustedRuntimeWalCursor::from_recovery(&report)?;
@@ -812,9 +861,23 @@ impl TrustedRuntimeWalStore {
     fn open(config: TrustedRuntimeWalStoreConfig) -> Result<Self, TrustedRuntimeWalError> {
         match config {
             TrustedRuntimeWalStoreConfig::InMemory => Ok(Self::InMemory(InMemoryWalStore::new())),
-            TrustedRuntimeWalStoreConfig::Filesystem { root, segment_id } => Ok(Self::Filesystem(
-                FilesystemWalStore::open(root, segment_id)?,
-            )),
+            TrustedRuntimeWalStoreConfig::Filesystem {
+                root,
+                segment_id,
+                #[cfg(any(test, feature = "host_test"))]
+                fault_plan,
+            } => {
+                #[cfg(any(test, feature = "host_test"))]
+                let store = match fault_plan {
+                    Some(plan) => {
+                        FilesystemWalStore::open_with_fault_plan_for_test(root, segment_id, plan)?
+                    }
+                    None => FilesystemWalStore::open(root, segment_id)?,
+                };
+                #[cfg(not(any(test, feature = "host_test")))]
+                let store = FilesystemWalStore::open(root, segment_id)?;
+                Ok(Self::Filesystem(store))
+            }
         }
     }
 
@@ -850,6 +913,22 @@ impl TrustedRuntimeWalStore {
             Self::InMemory(store) => recover_runtime_wal_store_read_only(store),
             Self::Filesystem(store) => {
                 recover_filesystem_store(store.root(), RecoveryAccessMode::ReadOnly)
+            }
+        }
+    }
+
+    #[cfg(any(test, feature = "host_test"))]
+    fn replace_filesystem_fault_plan_for_test(
+        &mut self,
+        fault_plan: FilesystemWalFaultPlan,
+    ) -> Result<(), WalStoreError> {
+        match self {
+            Self::InMemory(_) => Err(WalStoreError::Io(
+                "cannot inject filesystem WAL fault plan into in-memory store".to_owned(),
+            )),
+            Self::Filesystem(store) => {
+                store.replace_fault_plan_for_test(fault_plan);
+                Ok(())
             }
         }
     }

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -16,13 +16,15 @@ use echo_registry_api::{
 use warp_core::{
     causal_wal::{
         canonical_segment_path, recover_in_memory_store, recover_receipt_index,
-        recover_submission_index, recovered_submission_receipt_index_root, Lsn,
-        RecoveredSubmissionPosture, RecoveryAccessMode, RecoveryTailPosture, WalBuildError,
-        WalDurabilityMode, WalRecoveryError, WalSegmentId, WalTransactionKind,
+        recover_submission_index, recovered_submission_receipt_index_root, FilesystemWalFaultPlan,
+        FilesystemWalFaultTarget, FilesystemWalStore, Lsn, RecoveredSubmissionPosture,
+        RecoveryAccessMode, RecoveryTailPosture, WalBuildError, WalDurabilityMode, WalManifest,
+        WalRecoveryError, WalSegmentId, WalStoreError, WalStorePort, WalTransactionKind,
+        WriterEpochId, WriterEpochRequest,
     },
     make_head_id, make_intent_kind, make_node_id, make_type_id, AuthoredObserverPlan,
     ContractMutationHandler, ContractOperationKind, ContractPackageIdentity, ContractQueryObserver,
-    ContractQueryObserverResult, EngineBuilder, GraphStore, GraphView, InboxPolicy,
+    ContractQueryObserverResult, EngineBuilder, GraphStore, GraphView, Hash, InboxPolicy,
     IngressEnvelope, IngressTarget, IntentOutcome, NodeId, NodeRecord, ObservationAt,
     ObservationCoordinate, ObservationFrame, ObservationPayload, ObservationProjection,
     ObservationReadBudget, ObservationRequest, ObserverPlanId, OpticAdmissionTicket,
@@ -77,6 +79,27 @@ fn deterministic_test_dir(prefix: &str, label: &str) -> PathBuf {
 
 fn temp_runtime_wal_dir(label: &str) -> PathBuf {
     deterministic_test_dir("echo-trusted-runtime-wal", label)
+}
+
+fn filesystem_wal_failure_digest(label: &str) -> Hash {
+    blake3::hash(format!("trusted-runtime-wal-failure:{label}").as_bytes()).into()
+}
+
+fn filesystem_wal_failure_epoch_id() -> WriterEpochId {
+    WriterEpochId::from_hash(filesystem_wal_failure_digest("epoch"))
+}
+
+fn filesystem_wal_failure_epoch_request() -> WriterEpochRequest {
+    WriterEpochRequest {
+        epoch_id: filesystem_wal_failure_epoch_id(),
+        storage_fencing_token: filesystem_wal_failure_digest("fence"),
+        process_identity: filesystem_wal_failure_digest("process"),
+        host_identity: filesystem_wal_failure_digest("host"),
+        started_at_lsn: Lsn::from_raw(0),
+        previous_epoch_id: None,
+        previous_epoch_final_commit_digest: None,
+        lease_or_lock_evidence: filesystem_wal_failure_digest("lease"),
+    }
 }
 
 static INCREMENT_ARGS: &[ArgDef] = &[ArgDef {
@@ -815,6 +838,245 @@ fn filesystem_runtime_wal_ack_multi_head_tick_rejects_before_partial_filesystem_
             .scheduler_tick_count(),
         0
     );
+}
+
+#[test]
+fn filesystem_runtime_wal_failure_submission_append_rolls_back_pre_ack_visibility() {
+    let wal_root = temp_runtime_wal_dir("failure-submission-append");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(
+        TrustedRuntimeWalConfig::filesystem_with_fault_plan_for_test(
+            &wal_root,
+            FilesystemWalFaultPlan::fail_next(FilesystemWalFaultTarget::AppendFrame),
+        ),
+    )
+    .expect("host should configure faulting filesystem runtime WAL adapter");
+
+    let err = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect_err("injected append failure should reject pre-ACK submission")
+    };
+    assert!(matches!(
+        err,
+        TrustedRuntimeHostError::Wal(TrustedRuntimeWalError::Store(WalStoreError::Io(
+            message
+        ))) if message.contains("injected filesystem WAL append_frame failure")
+    ));
+    assert_eq!(host.runtime().witnessed_submission_count(), 0);
+    let recovery = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured")
+        .recover_read_only()
+        .expect("failed append should leave a clean empty filesystem WAL");
+    assert_eq!(recovery.certificate.committed_transactions_replayed, 0);
+    assert!(recovery.submissions.is_empty());
+}
+
+#[test]
+fn filesystem_runtime_wal_failure_submission_flush_rolls_back_pre_ack_visibility() {
+    let wal_root = temp_runtime_wal_dir("failure-submission-flush");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(
+        TrustedRuntimeWalConfig::filesystem_with_fault_plan_for_test(
+            &wal_root,
+            FilesystemWalFaultPlan::fail_next(FilesystemWalFaultTarget::FlushCommit),
+        ),
+    )
+    .expect("host should configure faulting filesystem runtime WAL adapter");
+
+    let err = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect_err("injected flush failure should reject pre-ACK submission")
+    };
+    assert!(matches!(
+        err,
+        TrustedRuntimeHostError::Wal(TrustedRuntimeWalError::Store(WalStoreError::Io(
+            message
+        ))) if message.contains("injected filesystem WAL flush_commit failure")
+    ));
+    assert_eq!(host.runtime().witnessed_submission_count(), 0);
+    let recovery = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured")
+        .recover_read_only()
+        .expect("failed flush should leave no committed submission after repair");
+    assert_eq!(recovery.certificate.committed_transactions_replayed, 0);
+    assert!(recovery.submissions.is_empty());
+}
+
+#[test]
+fn filesystem_runtime_wal_failure_tick_append_rolls_back_visible_outcome() {
+    let wal_root = temp_runtime_wal_dir("failure-tick-append");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+    host.register_contract_package(package())
+        .expect("host should install package");
+
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect("submission acceptance should commit before ACK")
+    };
+    host.stage_installed_contract_submission(submission.submission_id, &admission_ticket(106))
+        .expect("trusted host should stage package-supported ticketed ingress");
+    host.inject_runtime_wal_filesystem_fault_for_test(FilesystemWalFaultPlan::fail_next(
+        FilesystemWalFaultTarget::AppendFrame,
+    ))
+    .expect("host should inject filesystem append failure");
+
+    let err = host
+        .run_until_idle(4)
+        .expect_err("injected append failure should reject tick publication");
+    assert!(matches!(
+        err,
+        TrustedRuntimeHostError::Wal(TrustedRuntimeWalError::Store(WalStoreError::Io(
+            message
+        ))) if message.contains("injected filesystem WAL append_frame failure")
+    ));
+    assert_eq!(host.runtime().receipt_correlation_count(), 0);
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should stay configured")
+            .scheduler_tick_count(),
+        0
+    );
+    let outcome = {
+        let app = host.app();
+        app.observe_intent_outcome(&submission.submission_id)
+    };
+    assert!(matches!(
+        outcome,
+        IntentOutcome::Pending {
+            submission_id,
+            ticketed_ingress_id: Some(_),
+            ..
+        } if submission_id == submission.submission_id
+    ));
+    let recovery = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured")
+        .recover_read_only()
+        .expect("failed tick append should leave only accepted submission evidence");
+    assert_eq!(recovery.certificate.committed_transactions_replayed, 1);
+    assert_eq!(
+        recovery
+            .submissions
+            .get(&submission.submission_id)
+            .expect("submission should remain accepted pending")
+            .posture,
+        RecoveredSubmissionPosture::AcceptedPending
+    );
+    assert!(recovery.receipts.receipt_by_submission.is_empty());
+}
+
+#[test]
+fn filesystem_runtime_wal_failure_tick_flush_rolls_back_visible_outcome() {
+    let wal_root = temp_runtime_wal_dir("failure-tick-flush");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(&wal_root))
+        .expect("host should configure filesystem runtime WAL adapter");
+    host.register_contract_package(package())
+        .expect("host should install package");
+
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect("submission acceptance should commit before ACK")
+    };
+    host.stage_installed_contract_submission(submission.submission_id, &admission_ticket(107))
+        .expect("trusted host should stage package-supported ticketed ingress");
+    host.inject_runtime_wal_filesystem_fault_for_test(FilesystemWalFaultPlan::fail_next(
+        FilesystemWalFaultTarget::FlushCommit,
+    ))
+    .expect("host should inject filesystem flush failure");
+
+    let err = host
+        .run_until_idle(4)
+        .expect_err("injected flush failure should reject tick publication");
+    assert!(matches!(
+        err,
+        TrustedRuntimeHostError::Wal(TrustedRuntimeWalError::Store(WalStoreError::Io(
+            message
+        ))) if message.contains("injected filesystem WAL flush_commit failure")
+    ));
+    assert_eq!(host.runtime().receipt_correlation_count(), 0);
+    assert_eq!(
+        host.runtime_wal()
+            .expect("runtime WAL should stay configured")
+            .scheduler_tick_count(),
+        0
+    );
+
+    let outcome = {
+        let app = host.app();
+        app.observe_intent_outcome(&submission.submission_id)
+    };
+    assert!(matches!(
+        outcome,
+        IntentOutcome::Pending {
+            submission_id,
+            ticketed_ingress_id: Some(_),
+            ..
+        } if submission_id == submission.submission_id
+    ));
+    let recovery = host
+        .runtime_wal()
+        .expect("runtime WAL should stay configured")
+        .recover_read_only()
+        .expect("failed tick flush should leave only accepted submission evidence");
+    assert_eq!(recovery.certificate.committed_transactions_replayed, 1);
+    assert_eq!(
+        recovery
+            .submissions
+            .get(&submission.submission_id)
+            .expect("submission should remain accepted pending")
+            .posture,
+        RecoveredSubmissionPosture::AcceptedPending
+    );
+    assert!(recovery.receipts.receipt_by_submission.is_empty());
+}
+
+#[test]
+fn filesystem_runtime_wal_failure_manifest_publish_reports_store_error() {
+    let wal_root = temp_runtime_wal_dir("failure-manifest-publish");
+    let mut store = FilesystemWalStore::open_with_fault_plan_for_test(
+        &wal_root,
+        WalSegmentId::from_raw(1),
+        FilesystemWalFaultPlan::fail_next(FilesystemWalFaultTarget::PublishManifest),
+    )
+    .expect("faulting filesystem WAL store should open");
+    store
+        .acquire_writer_epoch(filesystem_wal_failure_epoch_request())
+        .expect("test writer epoch should acquire");
+    let err = store
+        .publish_manifest(
+            filesystem_wal_failure_epoch_id(),
+            WalManifest {
+                manifest_digest: filesystem_wal_failure_digest("manifest"),
+                last_committed_lsn: None,
+                last_commit_digest: None,
+                sealed_segment_count: 1,
+            },
+        )
+        .expect_err("injected manifest failure should be reported");
+
+    assert!(matches!(
+        err,
+        WalStoreError::Io(message)
+            if message.contains("injected filesystem WAL publish_manifest failure")
+    ));
+    assert!(!wal_root.join("manifest.ecwal").exists());
 }
 
 #[test]

--- a/docs/design/causal-wal-hardening-matrix.md
+++ b/docs/design/causal-wal-hardening-matrix.md
@@ -981,12 +981,16 @@ Acceptance criteria:
 - Missing WAL returns an explicit unavailable posture before mutating runtime
   intake state.
 - WAL build failure restores pre-submit runtime state.
+- Filesystem append or flush failure restores pre-submit runtime state and
+  leaves no committed submission evidence after recovery repair.
 - Failed WAL ACK does not create witnessed submission history.
 
 Test plan:
 
 - `runtime_wal_ack_path_requires_configured_runtime_wal`
 - `runtime_wal_ack_failure_rolls_back_intake_mutation`
+- `filesystem_runtime_wal_failure_submission_append_rolls_back_pre_ack_visibility`
+- `filesystem_runtime_wal_failure_submission_flush_rolls_back_pre_ack_visibility`
 
 ## Slice 90: Tick Receipt Transaction Wiring
 
@@ -1017,11 +1021,18 @@ Acceptance criteria:
 - Tick WAL failure either restores runtime/provenance state or blocks receipt
   publication under typed runtime fault posture.
 - The app-facing outcome cannot observe a receipt whose WAL transaction failed.
+- Filesystem append or flush failure during a scheduler tick leaves recovered
+  evidence at accepted-pending submission posture with no receipt index entry.
+- Filesystem manifest publish failure surfaces a typed store error without
+  publishing manifest material.
 
 Test plan:
 
 - Injected tick-WAL failure fixture.
 - App-facing outcome remains pending or runtime-faulted, never half-decided.
+- `filesystem_runtime_wal_failure_tick_append_rolls_back_visible_outcome`
+- `filesystem_runtime_wal_failure_tick_flush_rolls_back_visible_outcome`
+- `filesystem_runtime_wal_failure_manifest_publish_reports_store_error`
 
 ## Slice 92: Runtime Index Rebuild Contract
 

--- a/docs/design/reference-trusted-runtime-host-loop.md
+++ b/docs/design/reference-trusted-runtime-host-loop.md
@@ -79,6 +79,8 @@ Reconstructed filesystem adapters derive their next writer cursor from
 committed WAL history before accepting new appends, and read-only recovery uses
 filesystem recovery so torn or corrupt segment state remains visible in the
 recovery posture.
+Filesystem append, flush, and manifest fault injection is host-test-only
+evidence for this boundary; it is not exposed through `TrustedRuntimeApp`.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

- add host-test-only filesystem WAL fault plans for append, flush, and manifest failure injection
- let trusted runtime host tests inject filesystem WAL faults without exposing WAL authority through `TrustedRuntimeApp`
- prove failed pre-ACK submission append/flush leaves no witnessed submission or committed recovery evidence
- prove failed scheduler tick append/flush leaves no visible receipt/outcome and recovery remains accepted-pending with no receipt index entry
- prove manifest publish failures surface typed store errors without publishing manifest material

Closes #556

## Validation

- `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests filesystem_runtime_wal_failure`
- `cargo test -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests runtime_wal_ack`
- `cargo clippy -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests -- -D warnings`
- `cargo check -p warp-core --features "native_rule_bootstrap trusted_runtime host_test"`
- `cargo fmt --check`
- `pnpm exec prettier --check CHANGELOG.md docs/design/reference-trusted-runtime-host-loop.md docs/design/causal-wal-hardening-matrix.md`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/design/reference-trusted-runtime-host-loop.md docs/design/causal-wal-hardening-matrix.md`
- `scripts/check_spdx.sh CHANGELOG.md docs/design/reference-trusted-runtime-host-loop.md docs/design/causal-wal-hardening-matrix.md crates/warp-core/src/causal_wal.rs crates/warp-core/src/trusted_runtime_host.rs crates/warp-core/tests/trusted_runtime_host_loop_tests.rs`
- `scripts/ban-nondeterminism.sh`
- `git diff --check`
- pre-commit and pre-push hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive filesystem WAL fault injection tests for append, flush, and manifest operations to validate submission and tick rollback scenarios.

* **Documentation**
  * Updated design specifications with explicit filesystem fault-failure requirements and test coverage.
  * Clarified that filesystem WAL fault injection is restricted to host tests only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->