### PR TITLE
Cover runtime WAL recovery CLI contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,8 +161,8 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
 - `xtask test-slice` now includes `runtime-wal-ack`, a narrow runtime WAL
   ACK witness. The slice runs WAL-backed app-facing submission acceptance,
   scheduler tick receipt commit-before-publish, recovered runtime indexes,
-  CLI submission-posture JSON, stale-claim guard, and generated man-page
-  checks.
+  CLI submission-posture JSON for filesystem runtime WAL roots, stale-claim
+  guard, and generated man-page checks.
 - The docs now include an executable local contract-host quickstart and a
   v0.1.0 authority-boundary audit. The quickstart points developers at
   `cargo xtask test-slice contract-path-release`, names the app-facing and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,8 @@ dependencies = [
  "bytes",
  "clap",
  "comfy-table",
+ "echo-registry-api",
+ "echo-wasm-abi",
  "hex",
  "predicates",
  "regex",

--- a/crates/warp-cli/Cargo.toml
+++ b/crates/warp-cli/Cargo.toml
@@ -29,8 +29,15 @@ warp-core = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2"
+echo-registry-api = { workspace = true }
+echo-wasm-abi = { workspace = true }
 predicates = "3"
 tempfile = "3"
+warp-core = { workspace = true, features = [
+    "native_rule_bootstrap",
+    "trusted_runtime",
+    "host_test",
+] }
 
 
 [lints]

--- a/crates/warp-cli/tests/cli_integration.rs
+++ b/crates/warp-cli/tests/cli_integration.rs
@@ -477,6 +477,9 @@ fn wal_submission_posture_runtime_ack_root_reports_decided_applied_json() -> Tes
     Ok(())
 }
 
+// Runtime-produced filesystem roots cover accepted/applied today. Rejected and
+// obstructed stay as direct WAL taxonomy fixtures until the trusted host can
+// emit those decisions without expanding this CLI contract slice.
 #[test]
 fn wal_submission_posture_json_reports_obstructed_recovered_status() -> TestResult {
     let temp =

--- a/crates/warp-cli/tests/cli_integration.rs
+++ b/crates/warp-cli/tests/cli_integration.rs
@@ -9,6 +9,7 @@
 
 use std::error::Error;
 use std::fs;
+use std::path::Path;
 
 use assert_cmd::cargo::cargo_bin;
 use predicates::prelude::*;
@@ -22,7 +23,15 @@ use warp_core::causal_wal::{
 };
 use warp_core::wsc::{build_one_warp_input, write_wsc_one_warp};
 use warp_core::{
-    make_edge_id, make_node_id, make_type_id, make_warp_id, EdgeRecord, GraphStore, NodeRecord,
+    make_edge_id, make_node_id, make_type_id, make_warp_id, EdgeRecord, GraphStore, Hash,
+    NodeRecord,
+};
+
+#[path = "support/runtime_wal_fixture.rs"]
+mod runtime_wal_fixture;
+use runtime_wal_fixture::{
+    accepted_pending_fixture as runtime_wal_accepted_pending_fixture,
+    decided_applied_fixture as runtime_wal_decided_applied_fixture,
 };
 
 type TestResult<T = ()> = Result<T, Box<dyn Error>>;
@@ -71,6 +80,38 @@ fn write_demo_snapshot() -> TestResult<TempDir> {
     let temp = TempDir::new()?;
     fs::write(temp.path().join("state.wsc"), make_demo_wsc()?)?;
     Ok(temp)
+}
+
+fn wal_doctor_json(root: &Path) -> TestResult<serde_json::Value> {
+    let root = root.to_str().ok_or("WAL root path is not UTF-8")?;
+    let assert = echo_cli()
+        .args(["--format", "json", "wal", "doctor", root])
+        .assert()
+        .success();
+    Ok(serde_json::from_slice(&assert.get_output().stdout)?)
+}
+
+fn wal_submission_posture_json(
+    root: &Path,
+    submission_id: Hash,
+    canonical_envelope_digest: Hash,
+) -> TestResult<serde_json::Value> {
+    let root = root.to_str().ok_or("WAL root path is not UTF-8")?;
+    let assert = echo_cli()
+        .args([
+            "--format",
+            "json",
+            "wal",
+            "submission-posture",
+            root,
+            "--submission-id",
+            &hex::encode(submission_id),
+            "--canonical-envelope-digest",
+            &hex::encode(canonical_envelope_digest),
+        ])
+        .assert()
+        .success();
+    Ok(serde_json::from_slice(&assert.get_output().stdout)?)
 }
 
 fn digest(label: &str) -> warp_core::Hash {
@@ -144,6 +185,13 @@ fn filesystem_wal_with_committed_submission() -> TestResult<TempDir> {
 }
 
 fn filesystem_wal_with_decided_submission() -> TestResult<TempDir> {
+    filesystem_wal_with_decided_submission_decision("decided", WalTickDecision::Applied)
+}
+
+fn filesystem_wal_with_decided_submission_decision(
+    label: &str,
+    decision: WalTickDecision,
+) -> TestResult<TempDir> {
     let temp = TempDir::new()?;
     let epoch = writer_epoch_request();
     let mut store = FilesystemWalStore::open(temp.path(), WalSegmentId::from_raw(1))?;
@@ -152,7 +200,7 @@ fn filesystem_wal_with_decided_submission() -> TestResult<TempDir> {
         WalTransactionBuilder::new(
             epoch.epoch_id,
             WalSegmentId::from_raw(1),
-            WalTransactionId::from_hash(digest("transaction:accepted")),
+            WalTransactionId::from_hash(digest(&format!("transaction:{label}:accepted"))),
             WalTransactionKind::SubmissionIntake,
             WalAppendAuthority::SubmissionIntake,
             Lsn::from_raw(0),
@@ -166,10 +214,10 @@ fn filesystem_wal_with_decided_submission() -> TestResult<TempDir> {
             digest("domain"),
         ),
         SubmissionAcceptanceRecord {
-            submission_id: digest("submission:decided"),
-            canonical_envelope_digest: digest("envelope:decided"),
+            submission_id: digest(&format!("submission:{label}")),
+            canonical_envelope_digest: digest(&format!("envelope:{label}")),
             idempotency_key_digest: None,
-            acceptance_evidence_digest: digest("evidence:decided"),
+            acceptance_evidence_digest: digest(&format!("evidence:{label}")),
         },
         vec![AffectedFrontier {
             kind: AffectedFrontierKind::SubmissionQueue,
@@ -179,10 +227,10 @@ fn filesystem_wal_with_decided_submission() -> TestResult<TempDir> {
     )?;
     store.append_transaction(acceptance)?;
     let receipt = TickReceiptRecord {
-        submission_id: digest("submission:decided"),
-        ticket_digest: digest("ticket:decided"),
-        receipt_digest: digest("receipt:decided"),
-        decision: WalTickDecision::Applied,
+        submission_id: digest(&format!("submission:{label}")),
+        ticket_digest: digest(&format!("ticket:{label}")),
+        receipt_digest: digest(&format!("receipt:{label}")),
+        decision,
     };
     let correlation = WalReceiptCorrelationRecord {
         submission_id: receipt.submission_id,
@@ -193,7 +241,7 @@ fn filesystem_wal_with_decided_submission() -> TestResult<TempDir> {
         WalTransactionBuilder::new(
             epoch.epoch_id,
             WalSegmentId::from_raw(1),
-            WalTransactionId::from_hash(digest("transaction:ticked")),
+            WalTransactionId::from_hash(digest(&format!("transaction:{label}:ticked"))),
             WalTransactionKind::SchedulerTick,
             WalAppendAuthority::TrustedScheduler,
             Lsn::from_raw(2),
@@ -208,7 +256,7 @@ fn filesystem_wal_with_decided_submission() -> TestResult<TempDir> {
         ),
         receipt,
         correlation,
-        digest("state-delta:decided"),
+        digest(&format!("state-delta:{label}")),
         vec![
             AffectedFrontier {
                 kind: AffectedFrontierKind::ReceiptIndex,
@@ -383,6 +431,97 @@ fn wal_submission_posture_json_reports_generic_recovered_status() -> TestResult 
         hex::encode(digest("receipt:decided"))
     );
     assert_eq!(json["ticket_digest"], hex::encode(digest("ticket:decided")));
+    Ok(())
+}
+
+#[test]
+fn wal_submission_posture_runtime_ack_root_reports_accepted_pending_json() -> TestResult {
+    let fixture = runtime_wal_accepted_pending_fixture()?;
+    let doctor = wal_doctor_json(fixture.root.path())?;
+    assert_eq!(doctor["posture"], "Recoverable");
+    assert_eq!(doctor["tail_posture"], "Clean");
+    assert_eq!(doctor["committed_transactions_replayed"], 1);
+    assert_eq!(doctor["obstruction_count"], 0);
+
+    let json = wal_submission_posture_json(
+        fixture.root.path(),
+        fixture.submission_id,
+        fixture.canonical_envelope_digest,
+    )?;
+    assert_eq!(json["retry_posture"], "AlreadyAcceptedPending");
+    assert_eq!(json["recovered_posture"], "AcceptedPending");
+    assert!(json["receipt_digest"].is_null());
+    assert!(json["ticket_digest"].is_null());
+    Ok(())
+}
+
+#[test]
+fn wal_submission_posture_runtime_ack_root_reports_decided_applied_json() -> TestResult {
+    let fixture = runtime_wal_decided_applied_fixture()?;
+    let json = wal_submission_posture_json(
+        fixture.root.path(),
+        fixture.submission_id,
+        fixture.canonical_envelope_digest,
+    )?;
+
+    assert_eq!(json["retry_posture"], "AlreadyDecidedApplied");
+    assert_eq!(json["recovered_posture"], "DecidedApplied");
+    assert_eq!(
+        json["receipt_digest"],
+        hex::encode(fixture.receipt_digest.ok_or("missing applied receipt")?)
+    );
+    assert_eq!(
+        json["ticket_digest"],
+        hex::encode(fixture.ticket_digest.ok_or("missing applied ticket")?)
+    );
+    Ok(())
+}
+
+#[test]
+fn wal_submission_posture_json_reports_obstructed_recovered_status() -> TestResult {
+    let temp =
+        filesystem_wal_with_decided_submission_decision("obstructed", WalTickDecision::Obstructed)?;
+    let json = wal_submission_posture_json(
+        temp.path(),
+        digest("submission:obstructed"),
+        digest("envelope:obstructed"),
+    )?;
+
+    assert_eq!(json["retry_posture"], "AlreadyObstructed");
+    assert_eq!(json["recovered_posture"], "Obstructed");
+    assert_eq!(
+        json["receipt_digest"],
+        hex::encode(digest("receipt:obstructed"))
+    );
+    assert_eq!(
+        json["ticket_digest"],
+        hex::encode(digest("ticket:obstructed"))
+    );
+    Ok(())
+}
+
+#[test]
+fn wal_submission_posture_json_reports_decided_rejected_status() -> TestResult {
+    let temp = filesystem_wal_with_decided_submission_decision(
+        "rejected",
+        WalTickDecision::RejectedFootprintConflict,
+    )?;
+    let json = wal_submission_posture_json(
+        temp.path(),
+        digest("submission:rejected"),
+        digest("envelope:rejected"),
+    )?;
+
+    assert_eq!(json["retry_posture"], "AlreadyDecidedRejected");
+    assert_eq!(json["recovered_posture"], "DecidedRejected");
+    assert_eq!(
+        json["receipt_digest"],
+        hex::encode(digest("receipt:rejected"))
+    );
+    assert_eq!(
+        json["ticket_digest"],
+        hex::encode(digest("ticket:rejected"))
+    );
     Ok(())
 }
 

--- a/crates/warp-cli/tests/support/runtime_wal_fixture.rs
+++ b/crates/warp-cli/tests/support/runtime_wal_fixture.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Runtime-produced filesystem WAL fixtures for CLI integration tests.
+
+use std::error::Error;
+
+use echo_registry_api::{
+    ArgDef, ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, RegistryInfo,
+    RegistryProvider,
+};
+use tempfile::TempDir;
+use warp_core::{
+    make_head_id, make_intent_kind, make_node_id, make_type_id, ContractMutationHandler,
+    ContractPackageIdentity, EngineBuilder, GraphStore, GraphView, Hash, InboxPolicy,
+    IngressEnvelope, IngressTarget, IntentOutcome, NodeId, NodeRecord, OpticAdmissionTicket,
+    OpticArtifactHandle, PatternGraph, PlaybackMode, SchedulerKind, TickDelta, TrustedRuntimeHost,
+    TrustedRuntimeWalConfig, WarpOp, WorldlineId, WorldlineRuntime, WorldlineState, WriterHead,
+    WriterHeadKey, OPTIC_ADMISSION_TICKET_KIND, OPTIC_ARTIFACT_HANDLE_KIND,
+};
+
+type FixtureResult<T> = Result<T, Box<dyn Error>>;
+
+const MUTATION_OP_ID: u32 = 7001;
+const MUTATION_VARS: &[u8] = b"runtime-wal-cli=primary";
+const SCHEMA_SHA256_HEX: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const RULE_NAME: &str =
+    "cmd/contract/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/7001/runtimeWal";
+const RULE_ID_LABEL: &str =
+    "rule:cmd/contract/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/7001/runtimeWal";
+
+static ARGS: &[ArgDef] = &[ArgDef {
+    name: "input",
+    ty: "RuntimeWalInput",
+    required: true,
+    list: false,
+}];
+
+static OPS: &[OpDef] = &[OpDef {
+    kind: OpKind::Mutation,
+    name: "runtimeWal",
+    op_id: MUTATION_OP_ID,
+    args: ARGS,
+    result_ty: "RuntimeWalResult",
+    directives_json: "{}",
+    footprint_certificate: None,
+}];
+
+pub(crate) struct RuntimeWalSubmissionFixture {
+    pub(crate) root: TempDir,
+    pub(crate) submission_id: Hash,
+    pub(crate) canonical_envelope_digest: Hash,
+    pub(crate) receipt_digest: Option<Hash>,
+    pub(crate) ticket_digest: Option<Hash>,
+}
+
+struct Registry;
+
+impl RegistryProvider for Registry {
+    fn info(&self) -> RegistryInfo {
+        RegistryInfo {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
+        }
+    }
+
+    fn op_by_id(&self, op_id: u32) -> Option<&'static OpDef> {
+        OPS.iter().find(|op| op.op_id == op_id)
+    }
+
+    fn all_ops(&self) -> &'static [OpDef] {
+        OPS
+    }
+
+    fn all_enums(&self) -> &'static [echo_registry_api::EnumDef] {
+        &[]
+    }
+
+    fn all_objects(&self) -> &'static [ObjectDef] {
+        &[]
+    }
+}
+
+pub(crate) fn accepted_pending_fixture() -> FixtureResult<RuntimeWalSubmissionFixture> {
+    let root = TempDir::new()?;
+    let (runtime, worldline_id) = runtime()?;
+    let mut host = TrustedRuntimeHost::new(runtime, empty_engine())?;
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(root.path()))?;
+
+    let envelope = eint_envelope(worldline_id)?;
+    let canonical_envelope_digest = envelope.ingress_id();
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope)?
+    };
+    drop(host);
+
+    Ok(RuntimeWalSubmissionFixture {
+        root,
+        submission_id: submission.submission_id,
+        canonical_envelope_digest,
+        receipt_digest: None,
+        ticket_digest: None,
+    })
+}
+
+pub(crate) fn decided_applied_fixture() -> FixtureResult<RuntimeWalSubmissionFixture> {
+    let root = TempDir::new()?;
+    let (runtime, worldline_id) = runtime()?;
+    let mut host = TrustedRuntimeHost::new(runtime, empty_engine())?;
+    host.enable_runtime_wal(TrustedRuntimeWalConfig::filesystem(root.path()))?;
+    host.register_contract_package(package())?;
+
+    let envelope = eint_envelope(worldline_id)?;
+    let canonical_envelope_digest = envelope.ingress_id();
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(envelope)?
+    };
+    let ticket = admission_ticket(31);
+    host.stage_installed_contract_submission(submission.submission_id, &ticket)?;
+    host.run_until_idle(4)?;
+
+    let outcome = {
+        let app = host.app();
+        app.observe_intent_outcome(&submission.submission_id)
+    };
+    let IntentOutcome::Applied { receipt, .. } = outcome else {
+        return Err("runtime WAL fixture did not apply submission".into());
+    };
+    drop(host);
+
+    Ok(RuntimeWalSubmissionFixture {
+        root,
+        submission_id: submission.submission_id,
+        canonical_envelope_digest,
+        receipt_digest: Some(receipt.tick_receipt_digest),
+        ticket_digest: Some(ticket.ticket_digest),
+    })
+}
+
+fn empty_engine() -> warp_core::Engine {
+    let mut store = GraphStore::default();
+    let root = make_node_id("runtime-wal-cli-root");
+    store.insert_node(
+        root,
+        NodeRecord {
+            ty: make_type_id("runtime-wal-cli-world"),
+        },
+    );
+    EngineBuilder::new(store, root)
+        .scheduler(SchedulerKind::Radix)
+        .workers(1)
+        .build()
+}
+
+fn result_node_id() -> NodeId {
+    make_node_id("runtime-wal-cli-result")
+}
+
+fn contract_matches(view: GraphView<'_>, scope: &NodeId) -> bool {
+    warp_core::eint_vars_for_op(view, scope, MUTATION_OP_ID).is_some()
+}
+
+fn contract_execute(view: GraphView<'_>, _scope: &NodeId, delta: &mut TickDelta) {
+    let warp_id = view.warp_id();
+    let result = result_node_id();
+    delta.push(WarpOp::UpsertNode {
+        node: warp_core::NodeKey {
+            warp_id,
+            local_id: result,
+        },
+        record: NodeRecord {
+            ty: make_type_id("runtime-wal-cli-result"),
+        },
+    });
+    delta.push(WarpOp::SetAttachment {
+        key: warp_core::AttachmentKey::node_alpha(warp_core::NodeKey {
+            warp_id,
+            local_id: result,
+        }),
+        value: Some(warp_core::AttachmentValue::Atom(
+            warp_core::AtomPayload::new(
+                make_type_id("runtime-wal-cli-result"),
+                bytes::Bytes::copy_from_slice(b"runtime-wal-cli-result"),
+            ),
+        )),
+    });
+}
+
+fn contract_footprint(view: GraphView<'_>, scope: &NodeId) -> warp_core::Footprint {
+    let mut footprint = warp_core::runtime_ingress_eint_read_footprint(view, scope);
+    let warp_id = view.warp_id();
+    let result = result_node_id();
+    footprint.n_write.insert_with_warp(warp_id, result);
+    footprint
+        .a_write
+        .insert(warp_core::AttachmentKey::node_alpha(warp_core::NodeKey {
+            warp_id,
+            local_id: result,
+        }));
+    footprint
+}
+
+fn contract_rule() -> warp_core::RewriteRule {
+    warp_core::RewriteRule {
+        id: make_type_id(RULE_ID_LABEL).0,
+        name: RULE_NAME,
+        left: PatternGraph { nodes: vec![] },
+        matcher: contract_matches,
+        executor: contract_execute,
+        compute_footprint: contract_footprint,
+        factor_mask: 0,
+        conflict_policy: warp_core::ConflictPolicy::Abort,
+        join_fn: None,
+    }
+}
+
+fn package() -> warp_core::InstalledContractPackage<'static> {
+    static REGISTRY: Registry = Registry;
+    warp_core::InstalledContractPackage {
+        identity: ContractPackageIdentity {
+            package_name: "runtime-wal-cli-fixture",
+            package_version: "0.1.0",
+            artifact_hash_hex: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        },
+        registry: &REGISTRY,
+        verification_policy: ContractArtifactVerificationPolicy {
+            echo_abi_version: 1,
+            codec_id: "cbor-canon-v1",
+            registry_version: 1,
+            schema_sha256_hex: SCHEMA_SHA256_HEX,
+            wesley_generator_version: "echo-wesley-gen/0.1.0",
+            helper_api_version: 1,
+            footprint_certificates: &[],
+            require_mutation_footprint_certificates: false,
+        },
+        mutation_handlers: vec![ContractMutationHandler {
+            op_id: MUTATION_OP_ID,
+            rule: contract_rule(),
+        }],
+        query_observers: vec![],
+    }
+}
+
+fn runtime() -> FixtureResult<(WorldlineRuntime, WorldlineId)> {
+    let mut runtime = WorldlineRuntime::new();
+    let worldline_id = WorldlineId::from_bytes([17; 32]);
+    runtime.register_worldline(worldline_id, WorldlineState::empty())?;
+    runtime.register_writer_head(WriterHead::with_routing(
+        WriterHeadKey {
+            worldline_id,
+            head_id: make_head_id("runtime-wal-cli-default"),
+        },
+        PlaybackMode::Play,
+        InboxPolicy::AcceptAll,
+        None,
+        true,
+    ))?;
+    Ok((runtime, worldline_id))
+}
+
+fn eint_envelope(worldline_id: WorldlineId) -> FixtureResult<IngressEnvelope> {
+    let payload = echo_wasm_abi::pack_intent_v1(MUTATION_OP_ID, MUTATION_VARS)
+        .map_err(|error| format!("failed to pack runtime WAL EINT fixture: {error:?}"))?;
+    Ok(IngressEnvelope::local_intent(
+        IngressTarget::DefaultWriter { worldline_id },
+        make_intent_kind("echo.intent/eint-v1"),
+        payload,
+    ))
+}
+
+fn admission_ticket(seed: u8) -> OpticAdmissionTicket {
+    OpticAdmissionTicket {
+        kind: OPTIC_ADMISSION_TICKET_KIND.to_owned(),
+        artifact_handle: OpticArtifactHandle {
+            kind: OPTIC_ARTIFACT_HANDLE_KIND.to_owned(),
+            id: format!("runtime-wal-cli-{seed}"),
+        },
+        artifact_hash: format!("artifact-hash-{seed}"),
+        operation_id: format!("operation-{seed}"),
+        requirements_digest: format!("requirements-{seed}"),
+        canonical_variables_digest: vec![seed],
+        basis_request_digest: [seed; 32],
+        aperture_request_digest: [seed.wrapping_add(1); 32],
+        budget_request_digest: [seed.wrapping_add(2); 32],
+        law_witness_digest: [seed.wrapping_add(3); 32],
+        ticket_digest: [seed.wrapping_add(4); 32],
+    }
+}

--- a/crates/warp-cli/tests/support/runtime_wal_fixture.rs
+++ b/crates/warp-cli/tests/support/runtime_wal_fixture.rs
@@ -162,7 +162,7 @@ fn result_node_id() -> NodeId {
 }
 
 fn contract_matches(view: GraphView<'_>, scope: &NodeId) -> bool {
-    warp_core::eint_vars_for_op(view, scope, MUTATION_OP_ID).is_some()
+    warp_core::eint_vars_for_op(view, scope, MUTATION_OP_ID) == Some(MUTATION_VARS)
 }
 
 fn contract_execute(view: GraphView<'_>, _scope: &NodeId, delta: &mut TickDelta) {


### PR DESCRIPTION
## Summary

- Adds runtime-produced filesystem WAL fixtures for `warp-cli` integration tests.
- Extends `echo-cli wal submission-posture --format json` coverage for runtime ACK roots reporting `AcceptedPending` and `DecidedApplied` posture, receipt digest, and ticket digest.
- Locks the remaining WAL read-model taxonomy labels, `DecidedRejected` and `Obstructed`, through direct filesystem WAL fixtures until the trusted host can emit those decisions through filesystem runtime roots without expanding this CLI slice.
- Updates the runtime WAL ACK changelog note to specify filesystem runtime WAL root coverage.

Closes #557.

## Self-Code Review

- Lockdown: clean `git status --porcelain`, `git fetch origin` succeeded, GitHub auth valid.
- Reviewed `git diff origin/main...HEAD`; no unresolved self-review findings remain.
- One P5 clarity issue was addressed in commit `92dc74aa` by documenting why rejected/obstructed posture tests are direct WAL taxonomy fixtures rather than runtime-produced filesystem roots today.

## Validation

- `cargo test -p warp-cli --test cli_integration wal_submission_posture`
- `cargo clippy -p warp-cli --test cli_integration -- -D warnings`
- `cargo xtask test-slice runtime-wal-ack`
- `cargo fmt --check`
- `npx prettier --check CHANGELOG.md`
- `npx markdownlint-cli2 CHANGELOG.md`
- `git diff --check origin/main...HEAD`
- pre-commit hook: `cargo clippy -p warp-cli --lib --tests`, `cargo check -p warp-cli`, markdownlint
- pre-push hook: `cargo fmt --all -- --check`, `cargo check -p warp-cli --quiet`, `cargo test -p warp-cli --test cli_integration`, Prettier


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for runtime WAL submission posture validation across multiple recovery scenarios.
  * Added test utilities for runtime WAL fixture generation.

* **Chores**
  * Updated test dependencies and infrastructure.
  * Clarified documentation for runtime WAL test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->