### PR TITLE
feat(xtask): add durable runtime WAL gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ### Added
 
+- `cargo xtask test-slice durable-runtime-wal` now runs the release-grade
+  filesystem runtime WAL durability gate, joining filesystem ACK recovery,
+  filesystem failure atomicity, CLI submission posture JSON, stale-claim, and
+  generated man-page checks while leaving `runtime-wal-ack` as the fast
+  semantic gate.
 - `warp-core` trusted runtime hosts now configure runtime WAL through
   `TrustedRuntimeWalConfig`, including in-memory and filesystem-backed
   adapters. `TrustedRuntimeWalStoreKind` exposes the configured adapter kind as

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -1056,6 +1056,16 @@ completed slice.
     - Test plan: runtime ACK readiness gate fixture plus stale-claim grep:
       `cargo xtask test-slice runtime-wal-ack`.
 
+- [x] **Slice 96: Durable runtime WAL gate**
+    - User story: As a maintainer, the release bar needs one command that joins
+      the filesystem runtime WAL ACK, filesystem failure, CLI posture,
+      stale-claim, and man-page witnesses without slowing the fast ACK gate.
+    - Acceptance criteria: release readiness names the joined filesystem
+      durability gate through `cargo xtask test-slice durable-runtime-wal`
+      while `runtime-wal-ack` remains the fast semantic gate.
+    - Test plan: joined runtime WAL durability witness:
+      `cargo xtask test-slice durable-runtime-wal`.
+
 ## Recently Completed Slice Batch
 
 1. **Contract-Aware Receipts And Readings**

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -148,7 +148,8 @@ The repo also exposes maintenance commands via `cargo xtask …`:
 - `cargo xtask test-slice neighborhood` runs only `warp-core` neighborhood module unit tests via `--lib`.
 - `cargo xtask test-slice warp-core-smoke` runs the `warp-core` lib tests plus the strand integration target without launching every integration-test binary.
 - `cargo xtask test-slice contract-path-release` runs the v0.1 local contract-host release witness: installed contract pipeline replay, reference trusted host loop, and the serious external consumer fixture.
-- `cargo xtask test-slice runtime-wal-ack` runs the runtime WAL-backed ACK witness: app-facing acceptance rollback, scheduler tick receipt invariant checks, scheduler tick commit-before-publish, recovered indexes, CLI submission posture JSON, stale-claim guard, and generated man-page check.
+- `cargo xtask test-slice runtime-wal-ack` runs the fast runtime WAL-backed ACK witness: app-facing acceptance rollback, scheduler tick receipt invariant checks, scheduler tick commit-before-publish, recovered indexes, CLI submission posture JSON, stale-claim guard, and generated man-page check.
+- `cargo xtask test-slice durable-runtime-wal` runs the release-grade filesystem runtime WAL durability witness: filesystem ACK recovery, filesystem failure atomicity, CLI submission posture JSON, stale-claim guard, and generated man-page check.
 - `cargo xtask pr-preflight` runs the default changed-scope pre-PR gate against `origin/main`.
 - `cargo xtask pr-preflight --full` runs the broader explicit full pre-PR gate.
 - `cargo xtask dind` runs the DIND (Deterministic Ironclad Nightmare Drills) harness locally.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -110,6 +110,8 @@ enum TestSlice {
     ContractPathRelease,
     /// Runtime WAL-backed ACK and recovery posture witness.
     RuntimeWalAck,
+    /// Release-grade filesystem runtime WAL durability witness.
+    DurableRuntimeWal,
 }
 
 #[derive(Args)]
@@ -676,6 +678,38 @@ fn build_test_slice_commands(slice: TestSlice) -> Vec<Command> {
                 "--test",
                 "trusted_runtime_host_loop_tests",
                 "runtime_wal_ack",
+            ]),
+            cargo_command([
+                "test",
+                "-p",
+                "warp-cli",
+                "--test",
+                "cli_integration",
+                "wal_submission_posture",
+            ]),
+            cargo_command(["test", "-p", "xtask", "runtime_wal_ack_stale_claims"]),
+            cargo_command(["xtask", "man-pages", "--check"]),
+        ],
+        TestSlice::DurableRuntimeWal => vec![
+            cargo_command([
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime host_test",
+                "--test",
+                "trusted_runtime_host_loop_tests",
+                "filesystem_runtime_wal_ack",
+            ]),
+            cargo_command([
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime host_test",
+                "--test",
+                "trusted_runtime_host_loop_tests",
+                "filesystem_runtime_wal_failure",
             ]),
             cargo_command([
                 "test",
@@ -6525,6 +6559,69 @@ mod tests {
     }
 
     #[test]
+    fn test_slice_durable_runtime_wal_stays_explicit() {
+        let commands = build_test_slice_commands(TestSlice::DurableRuntimeWal);
+        assert_eq!(commands.len(), 5);
+
+        let (program, args) = command_program_and_args(&commands[0]);
+        assert_eq!(program, "cargo");
+        assert_eq!(
+            args,
+            vec![
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime host_test",
+                "--test",
+                "trusted_runtime_host_loop_tests",
+                "filesystem_runtime_wal_ack",
+            ]
+        );
+
+        let (program, args) = command_program_and_args(&commands[1]);
+        assert_eq!(program, "cargo");
+        assert_eq!(
+            args,
+            vec![
+                "test",
+                "-p",
+                "warp-core",
+                "--features",
+                "native_rule_bootstrap trusted_runtime host_test",
+                "--test",
+                "trusted_runtime_host_loop_tests",
+                "filesystem_runtime_wal_failure",
+            ]
+        );
+
+        let (program, args) = command_program_and_args(&commands[2]);
+        assert_eq!(program, "cargo");
+        assert_eq!(
+            args,
+            vec![
+                "test",
+                "-p",
+                "warp-cli",
+                "--test",
+                "cli_integration",
+                "wal_submission_posture",
+            ]
+        );
+
+        let (program, args) = command_program_and_args(&commands[3]);
+        assert_eq!(program, "cargo");
+        assert_eq!(
+            args,
+            vec!["test", "-p", "xtask", "runtime_wal_ack_stale_claims"]
+        );
+
+        let (program, args) = command_program_and_args(&commands[4]);
+        assert_eq!(program, "cargo");
+        assert_eq!(args, vec!["xtask", "man-pages", "--check"]);
+    }
+
+    #[test]
     fn runtime_wal_ack_stale_claims_stay_current() -> Result<(), Box<dyn std::error::Error>> {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -6564,9 +6661,11 @@ mod tests {
         let bearing = fs::read_to_string(repo_root.join("docs/BEARING.md"))?;
         assert!(bearing.contains("Runtime ACK drift gate"));
         assert!(bearing.contains("cargo xtask test-slice runtime-wal-ack"));
+        assert!(bearing.contains("cargo xtask test-slice durable-runtime-wal"));
 
         let workflows = fs::read_to_string(repo_root.join("docs/workflows.md"))?;
         assert!(workflows.contains("cargo xtask test-slice runtime-wal-ack"));
+        assert!(workflows.contains("cargo xtask test-slice durable-runtime-wal"));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Add `cargo xtask test-slice durable-runtime-wal` as the release-grade filesystem runtime WAL durability gate.
- Keep `runtime-wal-ack` documented as the fast semantic gate.
- Document the slice in the workflow guide, current bearing, and changelog.

Closes #558.

## Validation

- `cargo test -p xtask test_slice_durable_runtime_wal_stays_explicit`
- `cargo test -p xtask runtime_wal_ack_stale_claims`
- `cargo xtask test-slice durable-runtime-wal --dry-run`
- `cargo xtask test-slice durable-runtime-wal`
- `cargo xtask test-slice runtime-wal-ack`
- `cargo fmt --check`
- `cargo clippy -p xtask -- -D warnings`
- `npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/workflows.md`
- `git diff --check`