### PR TITLE
feat(warp-core): project WAL recovery evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   `RecoveryCertificateRef`; `WalSegmentRef::identity_digest()` binds writer
   epoch, LSN range, commit chain, segment digest, commit anchors, and seal
   posture while excluding storage locators from causal projection identity.
+- `warp-core` can now project recovered WAL history into graph-ready
+  `WalRecoveryProjection` records from explicit manifest, segment seal, segment
+  locator, writer epoch, and recovery certificate evidence; missing manifests or
+  unavailable locators produce typed projection obstructions instead of empty
+  success.
 - `cargo xtask test-slice durable-runtime-wal` now runs the release-grade
   filesystem runtime WAL durability gate, joining filesystem ACK recovery,
   filesystem failure atomicity, CLI submission posture JSON, stale-claim, and

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -3016,6 +3016,11 @@ pub enum WalRecoveryProjectionObstruction {
         /// Segment evidence count supplied for projection.
         actual: u64,
     },
+    /// Duplicate segment evidence was supplied for the same logical segment.
+    DuplicateSegmentEvidence {
+        /// Duplicated segment id.
+        segment_id: WalSegmentId,
+    },
     /// Writer epoch projection evidence was missing for a recovered commit.
     MissingWriterEpochEvidence {
         /// Missing writer epoch id.
@@ -3035,6 +3040,43 @@ pub enum WalRecoveryProjectionObstruction {
     SegmentNotSealed {
         /// Unsealed segment id.
         segment_id: WalSegmentId,
+    },
+    /// Segment seal evidence did not cover the recovered committed range.
+    SegmentSealDoesNotCoverRecoveredCommit {
+        /// Segment id.
+        segment_id: WalSegmentId,
+        /// Sealed LSN from segment evidence.
+        sealed_lsn: Option<Lsn>,
+        /// Last recovered committed LSN for this segment.
+        recovered_last_lsn: Lsn,
+    },
+    /// Segment digest evidence did not match recovered frames.
+    SegmentDigestMismatch {
+        /// Segment id.
+        segment_id: WalSegmentId,
+        /// Digest recomputed from recovered segment frames.
+        expected: Hash,
+        /// Digest supplied as projection evidence.
+        actual: Hash,
+    },
+    /// Recovery certificate scan fields did not match the recovery report.
+    RecoveryCertificateScanMismatch {
+        /// Expected first committed LSN from the recovery report.
+        expected_first_lsn: Option<Lsn>,
+        /// Certificate first committed LSN.
+        actual_first_lsn: Option<Lsn>,
+        /// Expected last committed LSN from the recovery report.
+        expected_last_lsn: Option<Lsn>,
+        /// Certificate last committed LSN.
+        actual_last_lsn: Option<Lsn>,
+        /// Expected committed transaction replay count.
+        expected_committed_transactions_replayed: u64,
+        /// Certificate committed transaction replay count.
+        actual_committed_transactions_replayed: u64,
+        /// Expected recovery tail posture.
+        expected_tail_posture: RecoveryTailPosture,
+        /// Certificate recovery tail posture.
+        actual_tail_posture: RecoveryTailPosture,
     },
     /// Recovered frame evidence did not identify a transaction segment.
     TransactionSegmentEvidenceUnavailable {
@@ -3105,16 +3147,16 @@ pub fn project_wal_recovery(
     segments: &[WalRecoverySegmentEvidence],
     recovery_certificate: Option<&RecoveryCertificate>,
 ) -> WalRecoveryProjection {
+    let mut obstructions = Vec::new();
     if report.transactions.is_empty()
         && manifest.is_none()
         && writer_epochs.is_empty()
         && segments.is_empty()
         && recovery_certificate.is_none()
+        && report.tail_posture == RecoveryTailPosture::Clean
     {
         return WalRecoveryProjection::absent();
     }
-
-    let mut obstructions = Vec::new();
     if report.tail_posture != RecoveryTailPosture::Clean {
         obstructions.push(WalRecoveryProjectionObstruction::TailPostureObstructed {
             posture: report.tail_posture,
@@ -3149,6 +3191,15 @@ pub fn project_wal_recovery(
                 actual: len_u64(segments.len()),
             },
         );
+    }
+
+    let mut seen_segments = BTreeSet::new();
+    for segment in segments {
+        if !seen_segments.insert(segment.segment_id) {
+            obstructions.push(WalRecoveryProjectionObstruction::DuplicateSegmentEvidence {
+                segment_id: segment.segment_id,
+            });
+        }
     }
 
     let writer_epoch_by_id = writer_epochs
@@ -3225,6 +3276,40 @@ pub fn project_wal_recovery(
                 segment_id: *segment_id,
             });
         }
+        if let Some(recovered_last_lsn) = transactions
+            .iter()
+            .map(|transaction| transaction.commit.last_lsn)
+            .max()
+        {
+            if let WalSegmentSealPosture::Sealed { sealed_lsn } = segment.seal_posture {
+                if sealed_lsn.is_none_or(|lsn| lsn < recovered_last_lsn) {
+                    obstructions.push(
+                        WalRecoveryProjectionObstruction::SegmentSealDoesNotCoverRecoveredCommit {
+                            segment_id: *segment_id,
+                            sealed_lsn,
+                            recovered_last_lsn,
+                        },
+                    );
+                }
+            }
+        }
+        let segment_frames = transactions
+            .iter()
+            .flat_map(|transaction| {
+                transaction
+                    .frames
+                    .iter()
+                    .filter(move |frame| frame.header.segment_id == *segment_id)
+            })
+            .collect::<Vec<_>>();
+        let recovered_segment_digest = segment_digest(*segment_id, &segment_frames);
+        if segment.segment_digest != recovered_segment_digest {
+            obstructions.push(WalRecoveryProjectionObstruction::SegmentDigestMismatch {
+                segment_id: *segment_id,
+                expected: recovered_segment_digest,
+                actual: segment.segment_digest,
+            });
+        }
         let segment_writer_epochs = transactions
             .iter()
             .map(|transaction| transaction.commit.writer_epoch)
@@ -3233,6 +3318,29 @@ pub fn project_wal_recovery(
             obstructions.push(WalRecoveryProjectionObstruction::MixedWriterEpochSegment {
                 segment_id: *segment_id,
             });
+        }
+    }
+
+    if let Some(certificate) = recovery_certificate {
+        let committed_transactions_replayed = len_u64(report.transactions.len());
+        if certificate.first_lsn != report.first_committed_lsn()
+            || certificate.last_lsn != report.last_committed_lsn()
+            || certificate.committed_transactions_replayed != committed_transactions_replayed
+            || certificate.tail_posture != report.tail_posture
+        {
+            obstructions.push(
+                WalRecoveryProjectionObstruction::RecoveryCertificateScanMismatch {
+                    expected_first_lsn: report.first_committed_lsn(),
+                    actual_first_lsn: certificate.first_lsn,
+                    expected_last_lsn: report.last_committed_lsn(),
+                    actual_last_lsn: certificate.last_lsn,
+                    expected_committed_transactions_replayed: committed_transactions_replayed,
+                    actual_committed_transactions_replayed: certificate
+                        .committed_transactions_replayed,
+                    expected_tail_posture: report.tail_posture,
+                    actual_tail_posture: certificate.tail_posture,
+                },
+            );
         }
     }
 
@@ -3296,6 +3404,37 @@ pub fn project_filesystem_wal_recovery(
         Ok(report) => report.manifest,
         Err(WalStoreError::MissingManifest) => {
             return project_wal_recovery(report, None, writer_epochs, &[], recovery_certificate);
+        }
+        Err(WalStoreError::ManifestLastCommittedLsnMismatch { expected, actual }) => {
+            return WalRecoveryProjection::obstructed(vec![
+                WalRecoveryProjectionObstruction::ManifestLastCommittedLsnMismatch {
+                    expected,
+                    actual,
+                },
+            ]);
+        }
+        Err(WalStoreError::ManifestLastCommitDigestMismatch { expected, actual }) => {
+            return WalRecoveryProjection::obstructed(vec![
+                WalRecoveryProjectionObstruction::ManifestLastCommitDigestMismatch {
+                    expected,
+                    actual,
+                },
+            ]);
+        }
+        Err(WalStoreError::ManifestSegmentCountMismatch { expected, actual }) => {
+            return WalRecoveryProjection::obstructed(vec![
+                WalRecoveryProjectionObstruction::ManifestSegmentCountMismatch {
+                    expected: actual,
+                    actual: expected,
+                },
+            ]);
+        }
+        Err(WalStoreError::ManifestCannotValidateUncommittedTail) => {
+            return WalRecoveryProjection::obstructed(vec![
+                WalRecoveryProjectionObstruction::TailPostureObstructed {
+                    posture: report.tail_posture,
+                },
+            ]);
         }
         Err(_) => {
             return WalRecoveryProjection::obstructed(vec![

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -44,6 +44,7 @@ const WAL_PROJECTION_SEGMENT_DOMAIN: &[u8] = b"echo:causal_wal:projection:segmen
 const WAL_PROJECTION_COMMIT_ANCHOR_DOMAIN: &[u8] = b"echo:causal_wal:projection:commit_anchor:v1\0";
 const WAL_PROJECTION_RECOVERY_CERTIFICATE_DOMAIN: &[u8] =
     b"echo:causal_wal:projection:recovery_certificate:v1\0";
+const WAL_RECOVERY_CERTIFICATE_DOMAIN: &[u8] = b"echo:causal_wal:recovery_certificate:v1\0";
 const WRITER_HEAD_KEY_PAYLOAD_LEN: usize = 64;
 const CHECKPOINT_FILE_MAGIC: &[u8; 8] = b"ECWALCP1";
 const WAL_SEGMENT_RECORD_MAGIC: &[u8; 8] = b"ECWALR1!";
@@ -2924,6 +2925,20 @@ pub struct RecoveryCertificateRef {
 }
 
 impl RecoveryCertificateRef {
+    /// Builds a projection reference from a recovery certificate.
+    #[must_use]
+    pub fn from_certificate(certificate: &RecoveryCertificate) -> Self {
+        Self {
+            certificate_digest: recovery_certificate_digest(certificate),
+            checkpoint_used: certificate.checkpoint_used,
+            first_lsn: certificate.first_lsn,
+            last_lsn: certificate.last_lsn,
+            tail_posture: certificate.tail_posture,
+            recovered_frontier_root: certificate.recovered_frontier_root,
+            recovered_indexes_root: certificate.recovered_indexes_root,
+        }
+    }
+
     /// Computes a stable identity digest for this recovery-certificate reference.
     #[must_use]
     pub fn identity_digest(&self) -> Hash {
@@ -2938,6 +2953,366 @@ impl RecoveryCertificateRef {
         h.update(&self.recovered_indexes_root);
         h.finalize().into()
     }
+}
+
+/// Segment evidence available when projecting a recovered WAL into graph facts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalRecoverySegmentEvidence {
+    /// Logical WAL segment id.
+    pub segment_id: WalSegmentId,
+    /// Digest of the segment contents.
+    pub segment_digest: Hash,
+    /// Segment sealing posture.
+    pub seal_posture: WalSegmentSealPosture,
+    /// Segment locator metadata. Projection from recovery treats missing locators
+    /// as an obstruction rather than fabricating storage evidence.
+    pub storage_locator: Option<WalSegmentStorageLocator>,
+}
+
+/// WAL recovery projection posture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalRecoveryProjectionPosture {
+    /// No WAL evidence was present to project.
+    Absent,
+    /// A projection root was built from explicit recovery evidence.
+    Present,
+    /// Recovery evidence existed, but was insufficient or obstructed.
+    Obstructed,
+}
+
+/// Typed reason a recovered WAL could not be projected into graph facts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WalRecoveryProjectionObstruction {
+    /// Recovery saw a non-clean tail posture, so the projection cannot claim a
+    /// sealed history root.
+    TailPostureObstructed {
+        /// Observed tail posture.
+        posture: RecoveryTailPosture,
+    },
+    /// A published manifest was required but absent.
+    MissingManifest,
+    /// The manifest could not be validated from filesystem evidence.
+    ManifestValidationUnavailable,
+    /// Segment evidence could not be read from filesystem storage.
+    SegmentEvidenceUnavailable,
+    /// The manifest's last committed LSN did not match recovered commits.
+    ManifestLastCommittedLsnMismatch {
+        /// Last committed LSN from recovery.
+        expected: Option<Lsn>,
+        /// Last committed LSN from the manifest.
+        actual: Option<Lsn>,
+    },
+    /// The manifest's last commit digest did not match recovered commits.
+    ManifestLastCommitDigestMismatch {
+        /// Last commit digest from recovery.
+        expected: Option<Hash>,
+        /// Last commit digest from the manifest.
+        actual: Option<Hash>,
+    },
+    /// The manifest's sealed segment count did not match segment evidence.
+    ManifestSegmentCountMismatch {
+        /// Sealed segment count from the manifest.
+        expected: u64,
+        /// Segment evidence count supplied for projection.
+        actual: u64,
+    },
+    /// Writer epoch projection evidence was missing for a recovered commit.
+    MissingWriterEpochEvidence {
+        /// Missing writer epoch id.
+        writer_epoch: WriterEpochId,
+    },
+    /// Segment evidence was missing for recovered committed frames.
+    MissingSegmentEvidence {
+        /// Missing segment id.
+        segment_id: WalSegmentId,
+    },
+    /// Segment locator metadata was unavailable.
+    SegmentLocatorUnavailable {
+        /// Segment id with no locator.
+        segment_id: WalSegmentId,
+    },
+    /// Segment evidence did not prove the segment sealed.
+    SegmentNotSealed {
+        /// Unsealed segment id.
+        segment_id: WalSegmentId,
+    },
+    /// Recovered frame evidence did not identify a transaction segment.
+    TransactionSegmentEvidenceUnavailable {
+        /// Transaction id.
+        transaction_id: WalTransactionId,
+    },
+    /// A recovered transaction spans multiple segment ids and cannot be projected
+    /// as a single segment anchor.
+    TransactionSpansSegments {
+        /// Transaction id.
+        transaction_id: WalTransactionId,
+    },
+    /// A projected segment contains commits from multiple writer epochs.
+    MixedWriterEpochSegment {
+        /// Segment id.
+        segment_id: WalSegmentId,
+    },
+}
+
+/// Projection result for recovered WAL evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WalRecoveryProjection {
+    /// Projection posture.
+    pub posture: WalRecoveryProjectionPosture,
+    /// Projected WAL root, if evidence was complete.
+    pub root: Option<WalRoot>,
+    /// Typed obstructions that prevented projection.
+    pub obstructions: Vec<WalRecoveryProjectionObstruction>,
+}
+
+impl WalRecoveryProjection {
+    fn absent() -> Self {
+        Self {
+            posture: WalRecoveryProjectionPosture::Absent,
+            root: None,
+            obstructions: Vec::new(),
+        }
+    }
+
+    fn present(root: WalRoot) -> Self {
+        Self {
+            posture: WalRecoveryProjectionPosture::Present,
+            root: Some(root),
+            obstructions: Vec::new(),
+        }
+    }
+
+    fn obstructed(obstructions: Vec<WalRecoveryProjectionObstruction>) -> Self {
+        Self {
+            posture: WalRecoveryProjectionPosture::Obstructed,
+            root: None,
+            obstructions,
+        }
+    }
+}
+
+/// Projects recovered WAL evidence into a graph-ready root record.
+///
+/// This function does not read or write storage. It only combines explicit
+/// recovery, manifest, writer-epoch, segment, locator, seal, and certificate
+/// evidence. Missing evidence produces typed obstructions instead of an empty
+/// successful projection.
+#[must_use]
+pub fn project_wal_recovery(
+    report: &RecoveryScanReport,
+    manifest: Option<&WalManifest>,
+    writer_epochs: &[WalWriterEpoch],
+    segments: &[WalRecoverySegmentEvidence],
+    recovery_certificate: Option<&RecoveryCertificate>,
+) -> WalRecoveryProjection {
+    if report.transactions.is_empty() && manifest.is_none() {
+        return WalRecoveryProjection::absent();
+    }
+
+    let mut obstructions = Vec::new();
+    if report.tail_posture != RecoveryTailPosture::Clean {
+        obstructions.push(WalRecoveryProjectionObstruction::TailPostureObstructed {
+            posture: report.tail_posture,
+        });
+    }
+
+    let Some(manifest) = manifest else {
+        obstructions.push(WalRecoveryProjectionObstruction::MissingManifest);
+        return WalRecoveryProjection::obstructed(obstructions);
+    };
+
+    if manifest.last_committed_lsn != report.last_committed_lsn() {
+        obstructions.push(
+            WalRecoveryProjectionObstruction::ManifestLastCommittedLsnMismatch {
+                expected: report.last_committed_lsn(),
+                actual: manifest.last_committed_lsn,
+            },
+        );
+    }
+    if manifest.last_commit_digest != report.last_commit_digest() {
+        obstructions.push(
+            WalRecoveryProjectionObstruction::ManifestLastCommitDigestMismatch {
+                expected: report.last_commit_digest(),
+                actual: manifest.last_commit_digest,
+            },
+        );
+    }
+    if manifest.sealed_segment_count != len_u64(segments.len()) {
+        obstructions.push(
+            WalRecoveryProjectionObstruction::ManifestSegmentCountMismatch {
+                expected: manifest.sealed_segment_count,
+                actual: len_u64(segments.len()),
+            },
+        );
+    }
+
+    let writer_epoch_by_id = writer_epochs
+        .iter()
+        .map(|epoch| (epoch.epoch_id, epoch))
+        .collect::<BTreeMap<_, _>>();
+    let segment_by_id = segments
+        .iter()
+        .map(|segment| (segment.segment_id, segment))
+        .collect::<BTreeMap<_, _>>();
+    let mut transactions_by_segment: BTreeMap<WalSegmentId, Vec<&WalRecoveredTransaction>> =
+        BTreeMap::new();
+    let mut required_writer_epochs = BTreeSet::new();
+
+    for transaction in &report.transactions {
+        required_writer_epochs.insert(transaction.commit.writer_epoch);
+        let frame_segments = transaction
+            .frames
+            .iter()
+            .map(|frame| frame.header.segment_id)
+            .collect::<BTreeSet<_>>();
+        match frame_segments.len() {
+            0 => obstructions.push(
+                WalRecoveryProjectionObstruction::TransactionSegmentEvidenceUnavailable {
+                    transaction_id: transaction.commit.transaction_id,
+                },
+            ),
+            1 => {
+                if let Some(segment_id) = frame_segments.iter().next().copied() {
+                    transactions_by_segment
+                        .entry(segment_id)
+                        .or_default()
+                        .push(transaction);
+                } else {
+                    obstructions.push(
+                        WalRecoveryProjectionObstruction::TransactionSegmentEvidenceUnavailable {
+                            transaction_id: transaction.commit.transaction_id,
+                        },
+                    );
+                }
+            }
+            _ => obstructions.push(WalRecoveryProjectionObstruction::TransactionSpansSegments {
+                transaction_id: transaction.commit.transaction_id,
+            }),
+        }
+    }
+
+    for writer_epoch in &required_writer_epochs {
+        if !writer_epoch_by_id.contains_key(writer_epoch) {
+            obstructions.push(
+                WalRecoveryProjectionObstruction::MissingWriterEpochEvidence {
+                    writer_epoch: *writer_epoch,
+                },
+            );
+        }
+    }
+
+    for (segment_id, transactions) in &transactions_by_segment {
+        let Some(segment) = segment_by_id.get(segment_id) else {
+            obstructions.push(WalRecoveryProjectionObstruction::MissingSegmentEvidence {
+                segment_id: *segment_id,
+            });
+            continue;
+        };
+        if segment.storage_locator.is_none() {
+            obstructions.push(
+                WalRecoveryProjectionObstruction::SegmentLocatorUnavailable {
+                    segment_id: *segment_id,
+                },
+            );
+        }
+        if segment.seal_posture == WalSegmentSealPosture::Open {
+            obstructions.push(WalRecoveryProjectionObstruction::SegmentNotSealed {
+                segment_id: *segment_id,
+            });
+        }
+        let segment_writer_epochs = transactions
+            .iter()
+            .map(|transaction| transaction.commit.writer_epoch)
+            .collect::<BTreeSet<_>>();
+        if segment_writer_epochs.len() > 1 {
+            obstructions.push(WalRecoveryProjectionObstruction::MixedWriterEpochSegment {
+                segment_id: *segment_id,
+            });
+        }
+    }
+
+    if !obstructions.is_empty() {
+        return WalRecoveryProjection::obstructed(obstructions);
+    }
+
+    let projected_writer_epochs = required_writer_epochs
+        .iter()
+        .filter_map(|epoch_id| writer_epoch_by_id.get(epoch_id).copied())
+        .cloned()
+        .collect::<Vec<_>>();
+    let projected_segments = transactions_by_segment
+        .iter()
+        .filter_map(|(segment_id, transactions)| {
+            let segment = *segment_by_id.get(segment_id)?;
+            let mut transactions = transactions.clone();
+            transactions.sort_by_key(|transaction| transaction.commit.first_lsn);
+            let first = transactions.first()?;
+            let last = transactions.last()?;
+            Some(WalSegmentRef {
+                writer_epoch: first.commit.writer_epoch,
+                segment_id: *segment_id,
+                first_lsn: first.commit.first_lsn,
+                last_lsn: last.commit.last_lsn,
+                previous_commit_digest: first.commit.previous_committed_transaction_digest,
+                final_commit_digest: last.commit.commit_digest,
+                segment_digest: segment.segment_digest,
+                commit_anchors: transactions
+                    .iter()
+                    .map(|transaction| WalCommitAnchor::from_commit(&transaction.commit))
+                    .collect(),
+                seal_posture: segment.seal_posture.clone(),
+                storage_locator: segment.storage_locator.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    let recovery_certificate = recovery_certificate.map(RecoveryCertificateRef::from_certificate);
+
+    WalRecoveryProjection::present(WalRoot {
+        root_digest: manifest.manifest_digest,
+        writer_epochs: projected_writer_epochs,
+        segments: projected_segments,
+        recovery_certificate,
+    })
+}
+
+/// Projects a filesystem WAL recovery scan using read-only filesystem evidence.
+///
+/// The adapter validates the published manifest and scans segment files, but does
+/// not mutate WAL storage or graph storage.
+#[must_use]
+pub fn project_filesystem_wal_recovery(
+    root: impl AsRef<Path>,
+    report: &RecoveryScanReport,
+    writer_epochs: &[WalWriterEpoch],
+    recovery_certificate: Option<&RecoveryCertificate>,
+) -> WalRecoveryProjection {
+    let root = root.as_ref();
+    let manifest = match validate_filesystem_manifest(root) {
+        Ok(report) => report.manifest,
+        Err(WalStoreError::MissingManifest) => {
+            return project_wal_recovery(report, None, writer_epochs, &[], recovery_certificate);
+        }
+        Err(_) => {
+            return WalRecoveryProjection::obstructed(vec![
+                WalRecoveryProjectionObstruction::ManifestValidationUnavailable,
+            ]);
+        }
+    };
+    let segments = match filesystem_wal_recovery_segment_evidence(root) {
+        Ok(segments) => segments,
+        Err(_) => {
+            return WalRecoveryProjection::obstructed(vec![
+                WalRecoveryProjectionObstruction::SegmentEvidenceUnavailable,
+            ]);
+        }
+    };
+    project_wal_recovery(
+        report,
+        Some(&manifest),
+        writer_epochs,
+        &segments,
+        recovery_certificate,
+    )
 }
 
 /// Read-only WAL doctor posture.
@@ -3469,6 +3844,33 @@ pub fn validate_filesystem_manifest(
         last_committed_lsn,
         last_commit_digest,
     })
+}
+
+fn filesystem_wal_recovery_segment_evidence(
+    root: &Path,
+) -> Result<Vec<WalRecoverySegmentEvidence>, WalStoreError> {
+    let mut evidence = Vec::new();
+    for path in segment_paths(root)? {
+        let segment_id = parse_segment_id(&path)?;
+        let (frames, _, torn_tail) = read_segment_file(&path)?;
+        if torn_tail {
+            return Err(WalStoreError::ManifestCannotValidateUncommittedTail);
+        }
+        let frame_refs = frames.iter().collect::<Vec<_>>();
+        let storage_locator = match path.strip_prefix(root) {
+            Ok(relative) => WalSegmentStorageLocator::RelativePath(relative.to_path_buf()),
+            Err(_) => WalSegmentStorageLocator::AbsolutePath(path.clone()),
+        };
+        evidence.push(WalRecoverySegmentEvidence {
+            segment_id,
+            segment_digest: segment_digest(segment_id, &frame_refs),
+            seal_posture: WalSegmentSealPosture::Sealed {
+                sealed_lsn: frames.iter().map(|frame| frame.header.lsn).max(),
+            },
+            storage_locator: Some(storage_locator),
+        });
+    }
+    Ok(evidence)
 }
 
 /// Object-store read-after-write posture required by strict object storage.
@@ -5612,6 +6014,22 @@ pub fn build_recovery_certificate(
         recovered_frontier_root,
         recovered_indexes_root,
     }
+}
+
+/// Computes the stable digest for a recovery certificate.
+#[must_use]
+pub fn recovery_certificate_digest(certificate: &RecoveryCertificate) -> Hash {
+    let mut h = blake3::Hasher::new();
+    h.update(WAL_RECOVERY_CERTIFICATE_DOMAIN);
+    update_optional_projection_digest(&mut h, certificate.checkpoint_used);
+    update_optional_lsn(&mut h, certificate.first_lsn);
+    update_optional_lsn(&mut h, certificate.last_lsn);
+    h.update(&certificate.committed_transactions_replayed.to_le_bytes());
+    update_recovery_tail_posture(&mut h, certificate.tail_posture);
+    h.update(&certificate.obstruction_count.to_le_bytes());
+    h.update(&certificate.recovered_frontier_root);
+    h.update(&certificate.recovered_indexes_root);
+    h.finalize().into()
 }
 
 /// Runs a read-only WAL doctor over an in-memory store.

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -3105,7 +3105,12 @@ pub fn project_wal_recovery(
     segments: &[WalRecoverySegmentEvidence],
     recovery_certificate: Option<&RecoveryCertificate>,
 ) -> WalRecoveryProjection {
-    if report.transactions.is_empty() && manifest.is_none() {
+    if report.transactions.is_empty()
+        && manifest.is_none()
+        && writer_epochs.is_empty()
+        && segments.is_empty()
+        && recovery_certificate.is_none()
+    {
         return WalRecoveryProjection::absent();
     }
 

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -374,6 +374,20 @@ fn wal_projection_from_recovery() {
         .obstructions
         .contains(&WalRecoveryProjectionObstruction::MissingManifest));
 
+    let absent = project_wal_recovery(
+        &RecoveryScanReport {
+            transactions: Vec::new(),
+            tail_posture: RecoveryTailPosture::Clean,
+        },
+        None,
+        &[],
+        &[],
+        None,
+    );
+    assert_eq!(absent.posture, WalRecoveryProjectionPosture::Absent);
+    assert_eq!(absent.root, None);
+    assert!(absent.obstructions.is_empty());
+
     let empty_report_with_segment_evidence = project_wal_recovery(
         &RecoveryScanReport {
             transactions: Vec::new(),
@@ -528,6 +542,30 @@ fn wal_projection_from_recovery() {
         &WalRecoveryProjectionObstruction::ManifestLastCommittedLsnMismatch {
             expected: Some(Lsn::from_raw(4)),
             actual: Some(Lsn::from_raw(3))
+        }
+    ));
+
+    must_ok(store.publish_manifest(
+        epoch_id(),
+        WalManifest {
+            sealed_segment_count: 2,
+            ..manifest
+        },
+    ));
+    let filesystem_segment_count_mismatch = project_filesystem_wal_recovery(
+        &dir,
+        &report,
+        std::slice::from_ref(&writer_epoch),
+        Some(&certificate),
+    );
+    assert_eq!(
+        filesystem_segment_count_mismatch.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert!(filesystem_segment_count_mismatch.obstructions.contains(
+        &WalRecoveryProjectionObstruction::ManifestSegmentCountMismatch {
+            expected: 2,
+            actual: 1,
         }
     ));
 

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -29,10 +29,10 @@ use warp_core::causal_wal::{
     MaterializationObservationRecord, MaterializationReplayPosture, MissingMaterialScope,
     ObjectStoreCapabilityError, ObjectStoreReadAfterWritePosture, ObjectStoreWalCapabilities,
     PayloadCodecId, PayloadSchemaId, ReadingRefRecord, RecoveredState, RecoveredSubmissionPosture,
-    RecoveredTopologyIndex, RecoveryAccessMode, RecoveryCertificateRef, RecoveryTailPosture,
-    RetainedMaterialKind, RetainedMaterialRecord, StrandDropRecord, StrandForkRecord,
-    SubmissionAcceptanceRecord, SubmissionRetryPosture, SuffixImportRecord, TickReceiptRecord,
-    TopologyBraidEventRecord, TopologyImportOutcomeKind, TopologyIntentRecord,
+    RecoveredTopologyIndex, RecoveryAccessMode, RecoveryCertificateRef, RecoveryScanReport,
+    RecoveryTailPosture, RetainedMaterialKind, RetainedMaterialRecord, StrandDropRecord,
+    StrandForkRecord, SubmissionAcceptanceRecord, SubmissionRetryPosture, SuffixImportRecord,
+    TickReceiptRecord, TopologyBraidEventRecord, TopologyImportOutcomeKind, TopologyIntentRecord,
     TransactionLocalIndex, WalAppendAuthority, WalBuildError, WalCommitAnchor,
     WalCommittedTransaction, WalDoctorPosture, WalDurabilityMode, WalManifest,
     WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryIndexError,
@@ -371,6 +371,25 @@ fn wal_projection_from_recovery() {
     );
     assert_eq!(missing_manifest.root, None);
     assert!(missing_manifest
+        .obstructions
+        .contains(&WalRecoveryProjectionObstruction::MissingManifest));
+
+    let empty_report_with_segment_evidence = project_wal_recovery(
+        &RecoveryScanReport {
+            transactions: Vec::new(),
+            tail_posture: RecoveryTailPosture::Clean,
+        },
+        None,
+        &[],
+        std::slice::from_ref(&segment_evidence),
+        None,
+    );
+    assert_eq!(
+        empty_report_with_segment_evidence.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert_eq!(empty_report_with_segment_evidence.root, None);
+    assert!(empty_report_with_segment_evidence
         .obstructions
         .contains(&WalRecoveryProjectionObstruction::MissingManifest));
 

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -393,6 +393,144 @@ fn wal_projection_from_recovery() {
         .obstructions
         .contains(&WalRecoveryProjectionObstruction::MissingManifest));
 
+    let empty_uncommitted_tail = project_wal_recovery(
+        &RecoveryScanReport {
+            transactions: Vec::new(),
+            tail_posture: RecoveryTailPosture::WouldTruncateAll,
+        },
+        None,
+        &[],
+        &[],
+        None,
+    );
+    assert_eq!(
+        empty_uncommitted_tail.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert!(empty_uncommitted_tail.obstructions.contains(
+        &WalRecoveryProjectionObstruction::TailPostureObstructed {
+            posture: RecoveryTailPosture::WouldTruncateAll
+        }
+    ));
+    assert!(empty_uncommitted_tail
+        .obstructions
+        .contains(&WalRecoveryProjectionObstruction::MissingManifest));
+
+    let duplicate_segments = [segment_evidence.clone(), segment_evidence.clone()];
+    let duplicate_segment_evidence = project_wal_recovery(
+        &report,
+        Some(&manifest),
+        std::slice::from_ref(&writer_epoch),
+        &duplicate_segments,
+        Some(&certificate),
+    );
+    assert_eq!(
+        duplicate_segment_evidence.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert!(duplicate_segment_evidence.obstructions.contains(
+        &WalRecoveryProjectionObstruction::DuplicateSegmentEvidence {
+            segment_id: WalSegmentId::from_raw(1)
+        }
+    ));
+
+    let short_seal_evidence = WalRecoverySegmentEvidence {
+        seal_posture: WalSegmentSealPosture::Sealed {
+            sealed_lsn: Some(Lsn::from_raw(3)),
+        },
+        ..segment_evidence.clone()
+    };
+    let short_seal = project_wal_recovery(
+        &report,
+        Some(&manifest),
+        std::slice::from_ref(&writer_epoch),
+        std::slice::from_ref(&short_seal_evidence),
+        Some(&certificate),
+    );
+    assert_eq!(short_seal.posture, WalRecoveryProjectionPosture::Obstructed);
+    assert!(short_seal.obstructions.contains(
+        &WalRecoveryProjectionObstruction::SegmentSealDoesNotCoverRecoveredCommit {
+            segment_id: WalSegmentId::from_raw(1),
+            sealed_lsn: Some(Lsn::from_raw(3)),
+            recovered_last_lsn: Lsn::from_raw(4)
+        }
+    ));
+
+    let bad_digest_evidence = WalRecoverySegmentEvidence {
+        segment_digest: digest("projection-recovery:wrong-segment"),
+        ..segment_evidence.clone()
+    };
+    let bad_segment_digest = project_wal_recovery(
+        &report,
+        Some(&manifest),
+        std::slice::from_ref(&writer_epoch),
+        std::slice::from_ref(&bad_digest_evidence),
+        Some(&certificate),
+    );
+    assert_eq!(
+        bad_segment_digest.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert!(bad_segment_digest.obstructions.contains(
+        &WalRecoveryProjectionObstruction::SegmentDigestMismatch {
+            segment_id: WalSegmentId::from_raw(1),
+            expected: seal.segment_digest,
+            actual: digest("projection-recovery:wrong-segment")
+        }
+    ));
+
+    let mismatched_certificate = warp_core::causal_wal::RecoveryCertificate {
+        committed_transactions_replayed: 99,
+        ..certificate
+    };
+    let certificate_mismatch = project_wal_recovery(
+        &report,
+        Some(&manifest),
+        std::slice::from_ref(&writer_epoch),
+        std::slice::from_ref(&segment_evidence),
+        Some(&mismatched_certificate),
+    );
+    assert_eq!(
+        certificate_mismatch.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert!(certificate_mismatch.obstructions.contains(
+        &WalRecoveryProjectionObstruction::RecoveryCertificateScanMismatch {
+            expected_first_lsn: Some(Lsn::from_raw(0)),
+            actual_first_lsn: Some(Lsn::from_raw(0)),
+            expected_last_lsn: Some(Lsn::from_raw(4)),
+            actual_last_lsn: Some(Lsn::from_raw(4)),
+            expected_committed_transactions_replayed: 2,
+            actual_committed_transactions_replayed: 99,
+            expected_tail_posture: RecoveryTailPosture::Clean,
+            actual_tail_posture: RecoveryTailPosture::Clean
+        }
+    ));
+
+    must_ok(store.publish_manifest(
+        epoch_id(),
+        WalManifest {
+            last_committed_lsn: Some(Lsn::from_raw(3)),
+            ..manifest
+        },
+    ));
+    let filesystem_manifest_mismatch = project_filesystem_wal_recovery(
+        &dir,
+        &report,
+        std::slice::from_ref(&writer_epoch),
+        Some(&certificate),
+    );
+    assert_eq!(
+        filesystem_manifest_mismatch.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert!(filesystem_manifest_mismatch.obstructions.contains(
+        &WalRecoveryProjectionObstruction::ManifestLastCommittedLsnMismatch {
+            expected: Some(Lsn::from_raw(4)),
+            actual: Some(Lsn::from_raw(3))
+        }
+    ));
+
     let unavailable_locator = project_wal_recovery(
         &report,
         Some(&manifest),

--- a/crates/warp-core/tests/causal_wal_tests.rs
+++ b/crates/warp-core/tests/causal_wal_tests.rs
@@ -14,8 +14,9 @@ use warp_core::causal_wal::{
     build_checkpoint_publication_transaction, build_materialization_outbox_transaction,
     build_recovery_certificate, build_retained_reading_transaction,
     build_submission_acceptance_transaction, build_tick_transaction,
-    build_topology_intent_transaction, doctor_in_memory_store, evaluate_checkpoint_publication,
-    lint_wal_schema_terms, missing_material_scope, project_causal_commit_evidence,
+    build_topology_intent_transaction, canonical_segment_relative_path, doctor_in_memory_store,
+    evaluate_checkpoint_publication, lint_wal_schema_terms, missing_material_scope,
+    project_causal_commit_evidence, project_filesystem_wal_recovery, project_wal_recovery,
     read_checkpoint_record, recover_checkpoint_publications, recover_filesystem_store,
     recover_in_memory_store, recover_materialization_outbox, recover_receipt_index,
     recover_retention_index, recover_submission_index, recover_topology_index,
@@ -34,11 +35,12 @@ use warp_core::causal_wal::{
     TopologyBraidEventRecord, TopologyImportOutcomeKind, TopologyIntentRecord,
     TransactionLocalIndex, WalAppendAuthority, WalBuildError, WalCommitAnchor,
     WalCommittedTransaction, WalDoctorPosture, WalDurabilityMode, WalManifest,
-    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryIndexError, WalReleaseReadinessGates,
-    WalRoot, WalSchemaLintError, WalSegmentId, WalSegmentRef, WalSegmentSealPosture,
-    WalSegmentStorageLocator, WalStoreError, WalStorePort, WalTickDecision, WalTransactionBuilder,
-    WalTransactionId, WalTransactionKind, WalWriterEpoch, WriterEpoch, WriterEpochId,
-    WriterEpochRequest,
+    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryIndexError,
+    WalRecoveryProjectionObstruction, WalRecoveryProjectionPosture, WalRecoverySegmentEvidence,
+    WalReleaseReadinessGates, WalRoot, WalSchemaLintError, WalSegmentId, WalSegmentRef,
+    WalSegmentSealPosture, WalSegmentStorageLocator, WalStoreError, WalStorePort, WalTickDecision,
+    WalTransactionBuilder, WalTransactionId, WalTransactionKind, WalWriterEpoch, WriterEpoch,
+    WriterEpochId, WriterEpochRequest,
 };
 use warp_core::{
     make_strand_id, AuthorityDomainId, AuthorityDomainRef, BraidEvent, BraidStatus, Hash, HeadId,
@@ -259,6 +261,139 @@ fn wal_projection_fact_identity_excludes_absolute_storage_locators() {
         segment.identity_digest()
     );
     assert_eq!(root.identity_digest(), reordered_root.identity_digest());
+}
+
+#[test]
+fn wal_projection_from_recovery() {
+    let dir = temp_wal_dir("projection-recovery");
+    let mut store = must_ok(FilesystemWalStore::open(&dir, WalSegmentId::from_raw(1)));
+    let writer_epoch = must_ok(store.acquire_writer_epoch(writer_epoch_request()));
+    must_ok(store.append_transaction(durable_submission_transaction(
+        "projection-recovery",
+        Lsn::from_raw(0),
+    )));
+    must_ok(store.append_transaction(durable_tick_transaction(
+        "projection-recovery",
+        Lsn::from_raw(2),
+        WalTickDecision::Applied,
+    )));
+    let seal = must_ok(store.seal_segment(epoch_id(), WalSegmentId::from_raw(1)));
+    let last_commit_digest = must_some(
+        store
+            .read_commits()
+            .last()
+            .map(|commit| commit.commit_digest),
+    );
+    let manifest = WalManifest {
+        manifest_digest: digest("projection-recovery:manifest"),
+        last_committed_lsn: Some(Lsn::from_raw(4)),
+        last_commit_digest: Some(last_commit_digest),
+        sealed_segment_count: 1,
+    };
+    must_ok(store.publish_manifest(epoch_id(), manifest.clone()));
+    let segment_before = must_ok(fs::read(store.segment_path()));
+    let manifest_before = must_ok(fs::read(dir.join("manifest.ecwal")));
+
+    let report = must_ok(recover_filesystem_store(&dir, RecoveryAccessMode::ReadOnly));
+    let certificate = build_recovery_certificate(
+        &report,
+        None,
+        0,
+        digest("projection-recovery:frontier"),
+        digest("projection-recovery:indexes"),
+    );
+    let writer_epoch = WalWriterEpoch::from_writer_epoch(&writer_epoch);
+    let projection = project_filesystem_wal_recovery(
+        &dir,
+        &report,
+        std::slice::from_ref(&writer_epoch),
+        Some(&certificate),
+    );
+    let repeated = project_filesystem_wal_recovery(
+        &dir,
+        &report,
+        std::slice::from_ref(&writer_epoch),
+        Some(&certificate),
+    );
+
+    assert_eq!(projection, repeated);
+    assert_eq!(projection.posture, WalRecoveryProjectionPosture::Present);
+    assert!(projection.obstructions.is_empty());
+    let root = must_some(projection.root);
+    assert_eq!(root.root_digest, manifest.manifest_digest);
+    assert_eq!(root.writer_epochs, vec![writer_epoch.clone()]);
+    assert_eq!(root.segments.len(), 1);
+    assert_eq!(root.segments[0].writer_epoch, epoch_id());
+    assert_eq!(root.segments[0].segment_id, WalSegmentId::from_raw(1));
+    assert_eq!(root.segments[0].first_lsn, Lsn::from_raw(0));
+    assert_eq!(root.segments[0].last_lsn, Lsn::from_raw(4));
+    assert_eq!(root.segments[0].segment_digest, seal.segment_digest);
+    assert_eq!(root.segments[0].commit_anchors.len(), 2);
+    assert_eq!(
+        root.segments[0].seal_posture,
+        WalSegmentSealPosture::Sealed {
+            sealed_lsn: Some(Lsn::from_raw(4))
+        }
+    );
+    assert_eq!(
+        root.segments[0].storage_locator,
+        Some(WalSegmentStorageLocator::RelativePath(
+            canonical_segment_relative_path(WalSegmentId::from_raw(1))
+        ))
+    );
+    assert!(root.recovery_certificate.is_some());
+    assert_eq!(must_ok(fs::read(store.segment_path())), segment_before);
+    assert_eq!(
+        must_ok(fs::read(dir.join("manifest.ecwal"))),
+        manifest_before
+    );
+
+    let segment_evidence = WalRecoverySegmentEvidence {
+        segment_id: seal.segment_id,
+        segment_digest: seal.segment_digest,
+        seal_posture: WalSegmentSealPosture::Sealed {
+            sealed_lsn: seal.sealed_lsn,
+        },
+        storage_locator: Some(WalSegmentStorageLocator::RelativePath(
+            canonical_segment_relative_path(WalSegmentId::from_raw(1)),
+        )),
+    };
+    let missing_manifest = project_wal_recovery(
+        &report,
+        None,
+        std::slice::from_ref(&writer_epoch),
+        std::slice::from_ref(&segment_evidence),
+        Some(&certificate),
+    );
+    assert_eq!(
+        missing_manifest.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert_eq!(missing_manifest.root, None);
+    assert!(missing_manifest
+        .obstructions
+        .contains(&WalRecoveryProjectionObstruction::MissingManifest));
+
+    let unavailable_locator = project_wal_recovery(
+        &report,
+        Some(&manifest),
+        &[writer_epoch],
+        &[WalRecoverySegmentEvidence {
+            storage_locator: None,
+            ..segment_evidence
+        }],
+        Some(&certificate),
+    );
+    assert_eq!(
+        unavailable_locator.posture,
+        WalRecoveryProjectionPosture::Obstructed
+    );
+    assert_eq!(unavailable_locator.root, None);
+    assert!(unavailable_locator.obstructions.contains(
+        &WalRecoveryProjectionObstruction::SegmentLocatorUnavailable {
+            segment_id: WalSegmentId::from_raw(1)
+        }
+    ));
 }
 
 fn builder(


### PR DESCRIPTION
## Summary
- add `WalRecoveryProjection` posture and typed obstruction records for recovered WAL projection
- project recovered WAL scans from explicit manifest, writer-epoch, segment seal, locator, and recovery certificate evidence
- add `wal_projection_from_recovery` coverage for deterministic projection, missing-manifest obstruction, missing-locator obstruction, and non-mutating filesystem projection

Closes #560

## Validation
- `cargo test -p warp-core wal_projection_from_recovery`
- `cargo test -p warp-core --test causal_wal_tests`
- `cargo clippy -p warp-core --lib --test causal_wal_tests -- -D warnings`
- `cargo check -p warp-core`
- `cargo fmt --check`
- `git diff --check`
- `npx markdownlint-cli2 CHANGELOG.md`
- pre-commit hook: `cargo clippy -p warp-core --lib`, `cargo check -p warp-core`, markdownlint
- pre-push hook: `cargo fmt --all -- --check`, `cargo check -p warp-core --quiet`, `cargo test -p warp-core --test causal_wal_tests`, prettier touched markdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery projection support for WAL history, producing graph-ready recovery records from available evidence.
  * Recovery now captures more details from manifests, segments, writer epochs, and recovery certificates.

* **Bug Fixes**
  * Missing manifests or unavailable segment locators now surface typed obstruction states instead of appearing as successful empty results.
  * Improved validation for recovery consistency, including tail state, segment coverage, digest matching, and certificate details.

* **Tests**
  * Added coverage for deterministic recovery projection and multiple obstruction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->