### PR TITLE
Add WSC causal-history bundle CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@
   envelope material separately from commit markers, hides staged material until
   marker publication, reopens committed envelopes in deterministic order, and
   reports torn envelope or marker files as typed WSC store obstructions.
+- `echo-cli` now exposes read-only `wsc causal-history` commands that export
+  ref-only and self-contained WAL WSC bundles from filesystem WAL roots, inspect
+  bundle envelope metadata, verify self-contained bundles without the original
+  WAL root, and report unavailable ref-only segment bytes as typed material
+  obstructions in JSON output.
 - `cargo xtask test-slice durable-runtime-wal` now runs the release-grade
   filesystem runtime WAL durability gate, joining filesystem ACK recovery,
   filesystem failure atomicity, CLI submission posture JSON, stale-claim, and

--- a/crates/warp-cli/README.md
+++ b/crates/warp-cli/README.md
@@ -70,6 +70,34 @@ echo-cli inspect state.wsc --raw
 echo-cli --format json inspect state.wsc
 ```
 
+### `echo-cli wsc causal-history ...`
+
+Export, inspect, and verify WAL causal-history WSC bundles without importing
+history into Echo. Export commands inspect a filesystem WAL root read-only and
+require explicit writer-epoch projection evidence as JSON.
+
+```sh
+# Export graph facts plus external segment-byte dependencies
+echo-cli wsc causal-history export-ref-only runtime.wal \
+  --writer-epochs writer-epochs.json \
+  --out causal-history.ref-only
+
+# Export graph facts plus embedded WAL segment bytes
+echo-cli wsc causal-history export-self-contained runtime.wal \
+  --writer-epochs writer-epochs.json \
+  --out causal-history.self-contained
+
+# Inspect bundle manifest and envelope metadata
+echo-cli --format json wsc causal-history inspect causal-history.self-contained
+
+# Verify a self-contained bundle without the original WAL root
+echo-cli --format json wsc causal-history verify causal-history.self-contained
+```
+
+Ref-only verification keeps the bundle observable but reports unavailable
+segment bytes as typed JSON material obstructions until external WAL material is
+provided by a future adapter.
+
 ## Global Flags
 
 - `--format text|json` — Output format (default: `text`). Can appear before or after the subcommand.

--- a/crates/warp-cli/src/cli.rs
+++ b/crates/warp-cli/src/cli.rs
@@ -78,6 +78,13 @@ pub enum Commands {
         #[command(subcommand)]
         command: WalCommands,
     },
+
+    /// Export and verify WSC causal-history bundles without importing history.
+    Wsc {
+        /// WSC command family.
+        #[command(subcommand)]
+        command: WscCommands,
+    },
 }
 
 /// WAL inspection subcommands.
@@ -99,6 +106,54 @@ pub enum WalCommands {
         /// 64-character hex canonical envelope digest.
         #[arg(long)]
         canonical_envelope_digest: String,
+    },
+}
+
+/// WSC inspection subcommands.
+#[derive(Subcommand, Debug)]
+pub enum WscCommands {
+    /// Work with WAL causal-history WSC bundles.
+    CausalHistory {
+        /// Causal-history WSC command.
+        #[command(subcommand)]
+        command: WscCausalHistoryCommands,
+    },
+}
+
+/// WAL causal-history WSC bundle subcommands.
+#[derive(Subcommand, Debug)]
+pub enum WscCausalHistoryCommands {
+    /// Export a ref-only WSC causal-history bundle from a filesystem WAL root.
+    ExportRefOnly {
+        /// Filesystem WAL root to inspect.
+        wal_root: PathBuf,
+        /// JSON file containing writer-epoch projection evidence.
+        #[arg(long)]
+        writer_epochs: PathBuf,
+        /// Output bundle directory.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Export a self-contained WSC causal-history bundle from a filesystem WAL root.
+    ExportSelfContained {
+        /// Filesystem WAL root to inspect.
+        wal_root: PathBuf,
+        /// JSON file containing writer-epoch projection evidence.
+        #[arg(long)]
+        writer_epochs: PathBuf,
+        /// Output bundle directory.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Inspect a WSC causal-history bundle manifest and envelopes.
+    Inspect {
+        /// Bundle directory to inspect.
+        bundle: PathBuf,
+    },
+    /// Verify a WSC causal-history bundle without importing Echo history.
+    Verify {
+        /// Bundle directory to verify.
+        bundle: PathBuf,
     },
 }
 
@@ -283,6 +338,55 @@ mod tests {
                 );
             }
             _ => panic!("expected Wal submission-posture command"),
+        }
+    }
+
+    #[test]
+    fn parse_wsc_causal_history_export_ref_only() {
+        let cli = Cli::try_parse_from([
+            "echo-cli",
+            "wsc",
+            "causal-history",
+            "export-ref-only",
+            "runtime.wal",
+            "--writer-epochs",
+            "writer-epochs.json",
+            "--out",
+            "bundle",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Wsc {
+                command:
+                    WscCommands::CausalHistory {
+                        command:
+                            WscCausalHistoryCommands::ExportRefOnly {
+                                ref wal_root,
+                                ref writer_epochs,
+                                ref out,
+                            },
+                    },
+            } => {
+                assert_eq!(wal_root, &PathBuf::from("runtime.wal"));
+                assert_eq!(writer_epochs, &PathBuf::from("writer-epochs.json"));
+                assert_eq!(out, &PathBuf::from("bundle"));
+            }
+            _ => panic!("expected WSC causal-history export-ref-only command"),
+        }
+    }
+
+    #[test]
+    fn parse_wsc_causal_history_verify() {
+        let cli =
+            Cli::try_parse_from(["echo-cli", "wsc", "causal-history", "verify", "bundle"]).unwrap();
+        match cli.command {
+            Commands::Wsc {
+                command:
+                    WscCommands::CausalHistory {
+                        command: WscCausalHistoryCommands::Verify { ref bundle },
+                    },
+            } => assert_eq!(bundle, &PathBuf::from("bundle")),
+            _ => panic!("expected WSC causal-history verify command"),
         }
     }
 

--- a/crates/warp-cli/src/main.rs
+++ b/crates/warp-cli/src/main.rs
@@ -24,9 +24,10 @@ mod inspect;
 mod output;
 mod verify;
 mod wal;
+mod wsc;
 mod wsc_loader;
 
-use cli::{Cli, Commands, WalCommands};
+use cli::{Cli, Commands, WalCommands, WscCausalHistoryCommands, WscCommands};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -56,5 +57,39 @@ fn main() -> Result<()> {
                     ref canonical_envelope_digest,
                 },
         } => wal::submission_posture(root, submission_id, canonical_envelope_digest, &cli.format),
+        Commands::Wsc {
+            command:
+                WscCommands::CausalHistory {
+                    command:
+                        WscCausalHistoryCommands::ExportRefOnly {
+                            ref wal_root,
+                            ref writer_epochs,
+                            ref out,
+                        },
+                },
+        } => wsc::export_ref_only(wal_root, writer_epochs, out, &cli.format),
+        Commands::Wsc {
+            command:
+                WscCommands::CausalHistory {
+                    command:
+                        WscCausalHistoryCommands::ExportSelfContained {
+                            ref wal_root,
+                            ref writer_epochs,
+                            ref out,
+                        },
+                },
+        } => wsc::export_self_contained(wal_root, writer_epochs, out, &cli.format),
+        Commands::Wsc {
+            command:
+                WscCommands::CausalHistory {
+                    command: WscCausalHistoryCommands::Inspect { ref bundle },
+                },
+        } => wsc::inspect(bundle, &cli.format),
+        Commands::Wsc {
+            command:
+                WscCommands::CausalHistory {
+                    command: WscCausalHistoryCommands::Verify { ref bundle },
+                },
+        } => wsc::verify(bundle, &cli.format),
     }
 }

--- a/crates/warp-cli/src/wsc.rs
+++ b/crates/warp-cli/src/wsc.rs
@@ -1,0 +1,1002 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! `echo-cli wsc` — read-only WSC causal-history bundle helpers.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use warp_core::causal_wal::{
+    canonical_segment_path, project_filesystem_wal_recovery, recover_filesystem_store, Lsn,
+    RecoveryAccessMode, RecoveryCertificateRef, RecoveryTailPosture, SubmissionAcceptanceRecord,
+    TickReceiptRecord, WalCommitAnchor, WalProjectionGraphObservationPosture,
+    WalReceiptCorrelationRecord, WalRecordKind, WalRecoveryProjectionPosture, WalRoot,
+    WalSegmentId, WalSegmentSealPosture, WalSegmentStorageLocator, WalTransactionId,
+    WalWriterEpoch, WriterEpochId,
+};
+use warp_core::wsc::{
+    validate_wsc_cas_addressed_wal_export, validate_wsc_ref_only_wal_export,
+    validate_wsc_self_contained_wal_export, wsc_ref_only_wal_export, wsc_self_contained_wal_export,
+    WscCasAddressedWalExport, WscCasBlobStorePort, WscCausalHistoryExportProfileKind,
+    WscRefOnlyWalExport, WscSelfContainedWalExport, WscSelfContainedWalSegmentMaterial,
+    WscStoreEnvelope,
+};
+use warp_core::Hash;
+
+use crate::cli::OutputFormat;
+use crate::output::{emit, hex_hash};
+
+const BUNDLE_MANIFEST: &str = "bundle.json";
+const PROJECTION_ENVELOPE: &str = "projection.ecwsc";
+const ACCEPTED_SUBMISSIONS_ENVELOPE: &str = "accepted-submissions.ecwsc";
+const RECEIPT_CORRELATIONS_ENVELOPE: &str = "receipt-correlations.ecwsc";
+const SEGMENT_MATERIAL_ENVELOPE: &str = "segment-material.ecwsc";
+
+/// Exports a ref-only WAL causal-history WSC bundle.
+pub(crate) fn export_ref_only(
+    wal_root: &Path,
+    writer_epochs: &Path,
+    out: &Path,
+    format: &OutputFormat,
+) -> Result<()> {
+    let projected = project_wal_root(wal_root, writer_epochs)?;
+    let export = wsc_ref_only_wal_export(
+        &projected.root,
+        &projected.accepted_submissions,
+        &projected.receipts,
+        &projected.correlations,
+    )?;
+
+    let manifest = write_ref_only_bundle(out, &projected.root, &export)?;
+    emit_export_report("export-ref-only", out, &manifest, format)
+}
+
+/// Exports a self-contained WAL causal-history WSC bundle.
+pub(crate) fn export_self_contained(
+    wal_root: &Path,
+    writer_epochs: &Path,
+    out: &Path,
+    format: &OutputFormat,
+) -> Result<()> {
+    let projected = project_wal_root(wal_root, writer_epochs)?;
+    let segment_materials = segment_materials(wal_root, &projected.root)?;
+    let export = wsc_self_contained_wal_export(
+        &projected.root,
+        &segment_materials,
+        &projected.accepted_submissions,
+        &projected.receipts,
+        &projected.correlations,
+    )?;
+
+    let manifest = write_self_contained_bundle(out, &projected.root, &export)?;
+    emit_export_report("export-self-contained", out, &manifest, format)
+}
+
+/// Inspects a WSC causal-history bundle without importing history.
+pub(crate) fn inspect(bundle: &Path, format: &OutputFormat) -> Result<()> {
+    let manifest = read_manifest(bundle)?;
+    let mut envelopes = Vec::new();
+    for (role, path) in manifest.envelopes.paths() {
+        envelopes.push(envelope_summary(bundle, role, path)?);
+    }
+    let report = BundleInspectOutput {
+        bundle: bundle.display().to_string(),
+        profile: manifest.profile.clone(),
+        root_identity_digest: hex_hash(&manifest.root.to_wal_root()?.identity_digest()),
+        envelope_count: envelopes.len(),
+        envelopes,
+    };
+    let text = format!(
+        "echo-cli wsc causal-history inspect\nBundle: {}\nProfile: {}\nRoot identity: {}\nEnvelopes: {}\n",
+        report.bundle, report.profile, report.root_identity_digest, report.envelope_count
+    );
+    let json = serde_json::to_value(&report)?;
+    emit(format, &text, &json)
+}
+
+/// Verifies a WSC causal-history bundle without importing history.
+pub(crate) fn verify(bundle: &Path, format: &OutputFormat) -> Result<()> {
+    let manifest = read_manifest(bundle)?;
+    let root = manifest.root.to_wal_root()?;
+    let report = match manifest.profile.as_str() {
+        "ref-only" => verify_ref_only(bundle, &manifest, &root)?,
+        "self-contained" => verify_self_contained(bundle, &manifest, &root)?,
+        "cas-addressed" => verify_cas_addressed(bundle, &manifest, &root)?,
+        profile => bail!("unsupported WSC causal-history profile: {profile}"),
+    };
+    let text = format!(
+        "echo-cli wsc causal-history verify\nBundle: {}\nProfile: {}\nResult: {}\nRoot identity: {}\nObstructions: {}\n",
+        report.bundle,
+        report.profile,
+        report.result,
+        report.root_identity_digest,
+        report.obstructions.len()
+    );
+    let json = serde_json::to_value(&report)?;
+    emit(format, &text, &json)
+}
+
+struct ProjectedWal {
+    root: WalRoot,
+    accepted_submissions: Vec<SubmissionAcceptanceRecord>,
+    receipts: Vec<TickReceiptRecord>,
+    correlations: Vec<WalReceiptCorrelationRecord>,
+}
+
+fn project_wal_root(wal_root: &Path, writer_epochs: &Path) -> Result<ProjectedWal> {
+    let writer_epochs = read_writer_epochs(writer_epochs)?;
+    let report =
+        recover_filesystem_store(wal_root, RecoveryAccessMode::ReadOnly).with_context(|| {
+            format!(
+                "failed to recover filesystem WAL root {}",
+                wal_root.display()
+            )
+        })?;
+    let projection = project_filesystem_wal_recovery(wal_root, &report, &writer_epochs, None);
+    if projection.posture != WalRecoveryProjectionPosture::Present {
+        bail!(
+            "WAL recovery projection obstructed: {:?}",
+            projection.obstructions
+        );
+    }
+    let root = projection
+        .root
+        .ok_or_else(|| anyhow::anyhow!("WAL recovery projection did not produce a root"))?;
+    let (accepted_submissions, receipts, correlations) =
+        causal_history_records_from_report(&report)?;
+    Ok(ProjectedWal {
+        root,
+        accepted_submissions,
+        receipts,
+        correlations,
+    })
+}
+
+fn causal_history_records_from_report(
+    report: &warp_core::causal_wal::RecoveryScanReport,
+) -> Result<(
+    Vec<SubmissionAcceptanceRecord>,
+    Vec<TickReceiptRecord>,
+    Vec<WalReceiptCorrelationRecord>,
+)> {
+    let mut accepted_submissions = Vec::new();
+    let mut receipts = Vec::new();
+    let mut correlations = Vec::new();
+    for transaction in &report.transactions {
+        for frame in &transaction.frames {
+            match frame.header.record_kind {
+                WalRecordKind::SubmissionAcceptedRecorded => {
+                    accepted_submissions.push(
+                        SubmissionAcceptanceRecord::from_payload_bytes(
+                            &frame.payload.canonical_bytes,
+                        )
+                        .context("failed to decode WAL submission acceptance record")?,
+                    );
+                }
+                WalRecordKind::TickReceiptRecorded => {
+                    receipts.push(
+                        TickReceiptRecord::from_payload_bytes(&frame.payload.canonical_bytes)
+                            .context("failed to decode WAL tick receipt record")?,
+                    );
+                }
+                WalRecordKind::ReceiptCorrelationRecorded => {
+                    correlations.push(
+                        WalReceiptCorrelationRecord::from_payload_bytes(
+                            &frame.payload.canonical_bytes,
+                        )
+                        .context("failed to decode WAL receipt correlation record")?,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok((accepted_submissions, receipts, correlations))
+}
+
+fn segment_materials(
+    wal_root: &Path,
+    root: &WalRoot,
+) -> Result<Vec<WscSelfContainedWalSegmentMaterial>> {
+    root.segments
+        .iter()
+        .map(|segment| {
+            let path = canonical_segment_path(wal_root, segment.segment_id);
+            let segment_bytes = fs::read(&path)
+                .with_context(|| format!("failed to read WAL segment {}", path.display()))?;
+            Ok(WscSelfContainedWalSegmentMaterial {
+                segment_id: segment.segment_id,
+                segment_bytes,
+            })
+        })
+        .collect()
+}
+
+fn write_ref_only_bundle(
+    out: &Path,
+    root: &WalRoot,
+    export: &WscRefOnlyWalExport,
+) -> Result<BundleManifest> {
+    fs::create_dir_all(out)
+        .with_context(|| format!("failed to create bundle directory {}", out.display()))?;
+    write_envelope(out, PROJECTION_ENVELOPE, &export.projection_envelope)?;
+    write_envelope(
+        out,
+        ACCEPTED_SUBMISSIONS_ENVELOPE,
+        &export.accepted_submission_envelope,
+    )?;
+    write_envelope(
+        out,
+        RECEIPT_CORRELATIONS_ENVELOPE,
+        &export.receipt_correlation_envelope,
+    )?;
+    let manifest = BundleManifest {
+        schema_version: 1,
+        profile: "ref-only".to_owned(),
+        root: WalRootJson::from_wal_root(root),
+        envelopes: BundleEnvelopePaths {
+            projection: PROJECTION_ENVELOPE.to_owned(),
+            accepted_submissions: ACCEPTED_SUBMISSIONS_ENVELOPE.to_owned(),
+            receipt_correlations: RECEIPT_CORRELATIONS_ENVELOPE.to_owned(),
+            segment_material: None,
+            cas_references: None,
+        },
+    };
+    write_manifest(out, &manifest)?;
+    Ok(manifest)
+}
+
+fn write_self_contained_bundle(
+    out: &Path,
+    root: &WalRoot,
+    export: &WscSelfContainedWalExport,
+) -> Result<BundleManifest> {
+    fs::create_dir_all(out)
+        .with_context(|| format!("failed to create bundle directory {}", out.display()))?;
+    write_envelope(out, PROJECTION_ENVELOPE, &export.projection_envelope)?;
+    write_envelope(
+        out,
+        SEGMENT_MATERIAL_ENVELOPE,
+        &export.segment_material_envelope,
+    )?;
+    write_envelope(
+        out,
+        ACCEPTED_SUBMISSIONS_ENVELOPE,
+        &export.accepted_submission_envelope,
+    )?;
+    write_envelope(
+        out,
+        RECEIPT_CORRELATIONS_ENVELOPE,
+        &export.receipt_correlation_envelope,
+    )?;
+    let manifest = BundleManifest {
+        schema_version: 1,
+        profile: "self-contained".to_owned(),
+        root: WalRootJson::from_wal_root(root),
+        envelopes: BundleEnvelopePaths {
+            projection: PROJECTION_ENVELOPE.to_owned(),
+            accepted_submissions: ACCEPTED_SUBMISSIONS_ENVELOPE.to_owned(),
+            receipt_correlations: RECEIPT_CORRELATIONS_ENVELOPE.to_owned(),
+            segment_material: Some(SEGMENT_MATERIAL_ENVELOPE.to_owned()),
+            cas_references: None,
+        },
+    };
+    write_manifest(out, &manifest)?;
+    Ok(manifest)
+}
+
+fn verify_ref_only(
+    bundle: &Path,
+    manifest: &BundleManifest,
+    root: &WalRoot,
+) -> Result<BundleVerifyOutput> {
+    let expected_dependencies = wsc_ref_only_wal_export(root, &[], &[], &[])?.segment_dependencies;
+    let export = WscRefOnlyWalExport {
+        profile: WscCausalHistoryExportProfileKind::RefOnly,
+        projection_envelope: read_envelope(bundle, &manifest.envelopes.projection)?,
+        accepted_submission_envelope: read_envelope(
+            bundle,
+            &manifest.envelopes.accepted_submissions,
+        )?,
+        receipt_correlation_envelope: read_envelope(
+            bundle,
+            &manifest.envelopes.receipt_correlations,
+        )?,
+        segment_dependencies: expected_dependencies,
+    };
+    let imported = validate_wsc_ref_only_wal_export(&export, root)?;
+    let obstructions = imported
+        .segment_dependencies
+        .iter()
+        .map(|dependency| MaterialObstruction {
+            kind: "ExternalSegmentBytesUnavailable".to_owned(),
+            segment_id: Some(dependency.segment_id.as_u64()),
+            content_hash: None,
+            semantic_coordinate_digest: None,
+        })
+        .collect::<Vec<_>>();
+    Ok(verify_output(
+        bundle,
+        "ref-only",
+        root,
+        VerificationSummary {
+            result: "obstructed",
+            accepted_submission_count: imported.accepted_submissions.len(),
+            receipt_count: imported.receipts.len(),
+            correlation_count: imported.correlations.len(),
+            projection_node_count: imported.projection.node_count,
+            obstructions,
+        },
+    ))
+}
+
+fn verify_self_contained(
+    bundle: &Path,
+    manifest: &BundleManifest,
+    root: &WalRoot,
+) -> Result<BundleVerifyOutput> {
+    let segment_material = manifest
+        .envelopes
+        .segment_material
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("self-contained bundle is missing segment material"))?;
+    let export = WscSelfContainedWalExport {
+        profile: WscCausalHistoryExportProfileKind::SelfContained,
+        projection_envelope: read_envelope(bundle, &manifest.envelopes.projection)?,
+        segment_material_envelope: read_envelope(bundle, segment_material)?,
+        accepted_submission_envelope: read_envelope(
+            bundle,
+            &manifest.envelopes.accepted_submissions,
+        )?,
+        receipt_correlation_envelope: read_envelope(
+            bundle,
+            &manifest.envelopes.receipt_correlations,
+        )?,
+    };
+    let imported = validate_wsc_self_contained_wal_export(&export, root)?;
+    Ok(verify_output(
+        bundle,
+        "self-contained",
+        root,
+        VerificationSummary {
+            result: "pass",
+            accepted_submission_count: imported.accepted_submissions.len(),
+            receipt_count: imported.receipts.len(),
+            correlation_count: imported.correlations.len(),
+            projection_node_count: imported.projection.node_count,
+            obstructions: Vec::new(),
+        },
+    ))
+}
+
+fn verify_cas_addressed(
+    bundle: &Path,
+    manifest: &BundleManifest,
+    root: &WalRoot,
+) -> Result<BundleVerifyOutput> {
+    let cas_references = manifest
+        .envelopes
+        .cas_references
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("CAS-addressed bundle is missing CAS references"))?;
+    let export = WscCasAddressedWalExport {
+        profile: WscCausalHistoryExportProfileKind::CasAddressed,
+        projection_envelope: read_envelope(bundle, &manifest.envelopes.projection)?,
+        cas_reference_envelope: read_envelope(bundle, cas_references)?,
+        accepted_submission_envelope: read_envelope(
+            bundle,
+            &manifest.envelopes.accepted_submissions,
+        )?,
+        receipt_correlation_envelope: read_envelope(
+            bundle,
+            &manifest.envelopes.receipt_correlations,
+        )?,
+    };
+    match validate_wsc_cas_addressed_wal_export(&export, root, &UnavailableCasStore) {
+        Ok(imported) => Ok(verify_output(
+            bundle,
+            "cas-addressed",
+            root,
+            VerificationSummary {
+                result: "pass",
+                accepted_submission_count: imported.accepted_submissions.len(),
+                receipt_count: imported.receipts.len(),
+                correlation_count: imported.correlations.len(),
+                projection_node_count: imported.projection.node_count,
+                obstructions: Vec::new(),
+            },
+        )),
+        Err(error) => Ok(verify_output(
+            bundle,
+            "cas-addressed",
+            root,
+            VerificationSummary {
+                result: "obstructed",
+                accepted_submission_count: 0,
+                receipt_count: 0,
+                correlation_count: 0,
+                projection_node_count: 0,
+                obstructions: vec![MaterialObstruction {
+                    kind: format!("{error:?}"),
+                    segment_id: None,
+                    content_hash: None,
+                    semantic_coordinate_digest: None,
+                }],
+            },
+        )),
+    }
+}
+
+struct VerificationSummary {
+    result: &'static str,
+    accepted_submission_count: usize,
+    receipt_count: usize,
+    correlation_count: usize,
+    projection_node_count: u64,
+    obstructions: Vec<MaterialObstruction>,
+}
+
+fn verify_output(
+    bundle: &Path,
+    profile: &str,
+    root: &WalRoot,
+    summary: VerificationSummary,
+) -> BundleVerifyOutput {
+    BundleVerifyOutput {
+        bundle: bundle.display().to_string(),
+        profile: profile.to_owned(),
+        result: summary.result.to_owned(),
+        root_identity_digest: hex_hash(&root.identity_digest()),
+        accepted_submission_count: summary.accepted_submission_count,
+        receipt_count: summary.receipt_count,
+        correlation_count: summary.correlation_count,
+        projection_posture: format!(
+            "{:?}",
+            WalProjectionGraphObservationPosture::ObservationOnly
+        ),
+        projection_node_count: summary.projection_node_count,
+        obstructions: summary.obstructions,
+    }
+}
+
+fn emit_export_report(
+    command: &str,
+    out: &Path,
+    manifest: &BundleManifest,
+    format: &OutputFormat,
+) -> Result<()> {
+    let root = manifest.root.to_wal_root()?;
+    let report = BundleExportOutput {
+        command: command.to_owned(),
+        bundle: out.display().to_string(),
+        profile: manifest.profile.clone(),
+        root_identity_digest: hex_hash(&root.identity_digest()),
+        manifest: BUNDLE_MANIFEST.to_owned(),
+        envelopes: manifest.envelopes.clone(),
+    };
+    let text = format!(
+        "echo-cli wsc causal-history {command}\nBundle: {}\nProfile: {}\nRoot identity: {}\n",
+        report.bundle, report.profile, report.root_identity_digest
+    );
+    let json = serde_json::to_value(&report)?;
+    emit(format, &text, &json)
+}
+
+fn write_envelope(out: &Path, name: &str, envelope: &WscStoreEnvelope) -> Result<()> {
+    let path = out.join(name);
+    fs::write(&path, envelope.encode())
+        .with_context(|| format!("failed to write WSC envelope {}", path.display()))
+}
+
+fn read_envelope(bundle: &Path, name: &str) -> Result<WscStoreEnvelope> {
+    let path = bundle.join(name);
+    let bytes = fs::read(&path)
+        .with_context(|| format!("failed to read WSC envelope {}", path.display()))?;
+    WscStoreEnvelope::decode(&bytes).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to decode WSC envelope {}: {error:?}",
+            path.display()
+        )
+    })
+}
+
+fn write_manifest(out: &Path, manifest: &BundleManifest) -> Result<()> {
+    let path = out.join(BUNDLE_MANIFEST);
+    let json = serde_json::to_vec_pretty(manifest)?;
+    fs::write(&path, json)
+        .with_context(|| format!("failed to write WSC bundle manifest {}", path.display()))
+}
+
+fn read_manifest(bundle: &Path) -> Result<BundleManifest> {
+    let path = bundle.join(BUNDLE_MANIFEST);
+    let bytes = fs::read(&path)
+        .with_context(|| format!("failed to read WSC bundle manifest {}", path.display()))?;
+    let manifest: BundleManifest = serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to decode WSC bundle manifest {}", path.display()))?;
+    if manifest.schema_version != 1 {
+        bail!(
+            "unsupported WSC bundle schema version {}",
+            manifest.schema_version
+        );
+    }
+    Ok(manifest)
+}
+
+fn read_writer_epochs(path: &Path) -> Result<Vec<WalWriterEpoch>> {
+    let bytes = fs::read(path)
+        .with_context(|| format!("failed to read writer epoch evidence {}", path.display()))?;
+    let epochs: Vec<WriterEpochJson> = serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to decode writer epoch evidence {}", path.display()))?;
+    epochs
+        .into_iter()
+        .map(|epoch| epoch.to_wal_writer_epoch())
+        .collect()
+}
+
+fn envelope_summary(bundle: &Path, role: &str, path: &str) -> Result<EnvelopeSummary> {
+    let envelope = read_envelope(bundle, path)?;
+    Ok(EnvelopeSummary {
+        role: role.to_owned(),
+        path: path.to_owned(),
+        envelope_id: hex_hash(&envelope.id().as_hash()),
+        basis_digest: hex_hash(envelope.basis_digest()),
+        schema_hash: hex_hash(envelope.schema_hash()),
+        wsc_digest: hex_hash(envelope.wsc_digest()),
+        tick: envelope.tick(),
+        encoded_len: envelope.encode().len(),
+    })
+}
+
+fn hash_from_hex(input: &str) -> Result<Hash> {
+    let bytes = hex::decode(input)?;
+    if bytes.len() != 32 {
+        bail!(
+            "expected a 64-character hex hash, got {} bytes",
+            bytes.len()
+        );
+    }
+    let mut hash = [0_u8; 32];
+    hash.copy_from_slice(&bytes);
+    Ok(hash)
+}
+
+fn optional_hash_from_hex(input: Option<&String>) -> Result<Option<Hash>> {
+    input.map(String::as_str).map(hash_from_hex).transpose()
+}
+
+fn optional_writer_epoch_id(input: Option<&String>) -> Result<Option<WriterEpochId>> {
+    optional_hash_from_hex(input).map(|value| value.map(WriterEpochId::from_hash))
+}
+
+fn optional_lsn(input: Option<u64>) -> Option<Lsn> {
+    input.map(Lsn::from_raw)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BundleManifest {
+    schema_version: u32,
+    profile: String,
+    root: WalRootJson,
+    envelopes: BundleEnvelopePaths,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BundleEnvelopePaths {
+    projection: String,
+    accepted_submissions: String,
+    receipt_correlations: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    segment_material: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cas_references: Option<String>,
+}
+
+impl BundleEnvelopePaths {
+    fn paths(&self) -> Vec<(&'static str, &str)> {
+        let mut paths = vec![
+            ("projection", self.projection.as_str()),
+            ("accepted_submissions", self.accepted_submissions.as_str()),
+            ("receipt_correlations", self.receipt_correlations.as_str()),
+        ];
+        if let Some(path) = self.segment_material.as_deref() {
+            paths.push(("segment_material", path));
+        }
+        if let Some(path) = self.cas_references.as_deref() {
+            paths.push(("cas_references", path));
+        }
+        paths
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct BundleExportOutput {
+    command: String,
+    bundle: String,
+    profile: String,
+    root_identity_digest: String,
+    manifest: String,
+    envelopes: BundleEnvelopePaths,
+}
+
+#[derive(Debug, Serialize)]
+struct BundleInspectOutput {
+    bundle: String,
+    profile: String,
+    root_identity_digest: String,
+    envelope_count: usize,
+    envelopes: Vec<EnvelopeSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct BundleVerifyOutput {
+    bundle: String,
+    profile: String,
+    result: String,
+    root_identity_digest: String,
+    accepted_submission_count: usize,
+    receipt_count: usize,
+    correlation_count: usize,
+    projection_posture: String,
+    projection_node_count: u64,
+    obstructions: Vec<MaterialObstruction>,
+}
+
+#[derive(Debug, Serialize)]
+struct MaterialObstruction {
+    kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    segment_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    semantic_coordinate_digest: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EnvelopeSummary {
+    role: String,
+    path: String,
+    envelope_id: String,
+    basis_digest: String,
+    schema_hash: String,
+    wsc_digest: String,
+    tick: u64,
+    encoded_len: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WalRootJson {
+    root_digest: String,
+    writer_epochs: Vec<WriterEpochJson>,
+    segments: Vec<WalSegmentRefJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recovery_certificate: Option<RecoveryCertificateRefJson>,
+}
+
+impl WalRootJson {
+    fn from_wal_root(root: &WalRoot) -> Self {
+        Self {
+            root_digest: hex_hash(&root.root_digest),
+            writer_epochs: root
+                .writer_epochs
+                .iter()
+                .map(WriterEpochJson::from_wal_writer_epoch)
+                .collect(),
+            segments: root
+                .segments
+                .iter()
+                .map(WalSegmentRefJson::from_wal_segment_ref)
+                .collect(),
+            recovery_certificate: root
+                .recovery_certificate
+                .as_ref()
+                .map(RecoveryCertificateRefJson::from_recovery_certificate_ref),
+        }
+    }
+
+    fn to_wal_root(&self) -> Result<WalRoot> {
+        Ok(WalRoot {
+            root_digest: hash_from_hex(&self.root_digest)?,
+            writer_epochs: self
+                .writer_epochs
+                .iter()
+                .map(WriterEpochJson::to_wal_writer_epoch)
+                .collect::<Result<Vec<_>>>()?,
+            segments: self
+                .segments
+                .iter()
+                .map(WalSegmentRefJson::to_wal_segment_ref)
+                .collect::<Result<Vec<_>>>()?,
+            recovery_certificate: self
+                .recovery_certificate
+                .as_ref()
+                .map(RecoveryCertificateRefJson::to_recovery_certificate_ref)
+                .transpose()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WriterEpochJson {
+    epoch_id: String,
+    storage_fencing_token: String,
+    process_identity: String,
+    host_identity: String,
+    started_at_lsn: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    previous_epoch_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    previous_epoch_final_commit_digest: Option<String>,
+    lease_or_lock_evidence: String,
+}
+
+impl WriterEpochJson {
+    fn from_wal_writer_epoch(epoch: &WalWriterEpoch) -> Self {
+        Self {
+            epoch_id: hex_hash(&epoch.epoch_id.as_hash()),
+            storage_fencing_token: hex_hash(&epoch.storage_fencing_token),
+            process_identity: hex_hash(&epoch.process_identity),
+            host_identity: hex_hash(&epoch.host_identity),
+            started_at_lsn: epoch.started_at_lsn.as_u64(),
+            previous_epoch_id: epoch
+                .previous_epoch_id
+                .map(|epoch_id| hex_hash(&epoch_id.as_hash())),
+            previous_epoch_final_commit_digest: epoch
+                .previous_epoch_final_commit_digest
+                .map(|digest| hex_hash(&digest)),
+            lease_or_lock_evidence: hex_hash(&epoch.lease_or_lock_evidence),
+        }
+    }
+
+    fn to_wal_writer_epoch(&self) -> Result<WalWriterEpoch> {
+        Ok(WalWriterEpoch {
+            epoch_id: WriterEpochId::from_hash(hash_from_hex(&self.epoch_id)?),
+            storage_fencing_token: hash_from_hex(&self.storage_fencing_token)?,
+            process_identity: hash_from_hex(&self.process_identity)?,
+            host_identity: hash_from_hex(&self.host_identity)?,
+            started_at_lsn: Lsn::from_raw(self.started_at_lsn),
+            previous_epoch_id: optional_writer_epoch_id(self.previous_epoch_id.as_ref())?,
+            previous_epoch_final_commit_digest: optional_hash_from_hex(
+                self.previous_epoch_final_commit_digest.as_ref(),
+            )?,
+            lease_or_lock_evidence: hash_from_hex(&self.lease_or_lock_evidence)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WalSegmentRefJson {
+    writer_epoch: String,
+    segment_id: u64,
+    first_lsn: u64,
+    last_lsn: u64,
+    previous_commit_digest: String,
+    final_commit_digest: String,
+    segment_digest: String,
+    commit_anchors: Vec<WalCommitAnchorJson>,
+    seal_posture: WalSegmentSealPostureJson,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    storage_locator: Option<WalSegmentStorageLocatorJson>,
+}
+
+impl WalSegmentRefJson {
+    fn from_wal_segment_ref(segment: &warp_core::causal_wal::WalSegmentRef) -> Self {
+        Self {
+            writer_epoch: hex_hash(&segment.writer_epoch.as_hash()),
+            segment_id: segment.segment_id.as_u64(),
+            first_lsn: segment.first_lsn.as_u64(),
+            last_lsn: segment.last_lsn.as_u64(),
+            previous_commit_digest: hex_hash(&segment.previous_commit_digest),
+            final_commit_digest: hex_hash(&segment.final_commit_digest),
+            segment_digest: hex_hash(&segment.segment_digest),
+            commit_anchors: segment
+                .commit_anchors
+                .iter()
+                .map(WalCommitAnchorJson::from_wal_commit_anchor)
+                .collect(),
+            seal_posture: WalSegmentSealPostureJson::from_wal_segment_seal_posture(
+                &segment.seal_posture,
+            ),
+            storage_locator: segment
+                .storage_locator
+                .as_ref()
+                .map(WalSegmentStorageLocatorJson::from_wal_segment_storage_locator),
+        }
+    }
+
+    fn to_wal_segment_ref(&self) -> Result<warp_core::causal_wal::WalSegmentRef> {
+        Ok(warp_core::causal_wal::WalSegmentRef {
+            writer_epoch: WriterEpochId::from_hash(hash_from_hex(&self.writer_epoch)?),
+            segment_id: WalSegmentId::from_raw(self.segment_id),
+            first_lsn: Lsn::from_raw(self.first_lsn),
+            last_lsn: Lsn::from_raw(self.last_lsn),
+            previous_commit_digest: hash_from_hex(&self.previous_commit_digest)?,
+            final_commit_digest: hash_from_hex(&self.final_commit_digest)?,
+            segment_digest: hash_from_hex(&self.segment_digest)?,
+            commit_anchors: self
+                .commit_anchors
+                .iter()
+                .map(WalCommitAnchorJson::to_wal_commit_anchor)
+                .collect::<Result<Vec<_>>>()?,
+            seal_posture: self.seal_posture.to_wal_segment_seal_posture(),
+            storage_locator: self
+                .storage_locator
+                .as_ref()
+                .map(WalSegmentStorageLocatorJson::to_wal_segment_storage_locator),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WalCommitAnchorJson {
+    transaction_id: String,
+    commit_digest: String,
+    first_lsn: u64,
+    last_lsn: u64,
+    record_count: u64,
+}
+
+impl WalCommitAnchorJson {
+    fn from_wal_commit_anchor(anchor: &WalCommitAnchor) -> Self {
+        Self {
+            transaction_id: hex_hash(&anchor.transaction_id.as_hash()),
+            commit_digest: hex_hash(&anchor.commit_digest),
+            first_lsn: anchor.first_lsn.as_u64(),
+            last_lsn: anchor.last_lsn.as_u64(),
+            record_count: anchor.record_count,
+        }
+    }
+
+    fn to_wal_commit_anchor(&self) -> Result<WalCommitAnchor> {
+        Ok(WalCommitAnchor {
+            transaction_id: WalTransactionId::from_hash(hash_from_hex(&self.transaction_id)?),
+            commit_digest: hash_from_hex(&self.commit_digest)?,
+            first_lsn: Lsn::from_raw(self.first_lsn),
+            last_lsn: Lsn::from_raw(self.last_lsn),
+            record_count: self.record_count,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+enum WalSegmentSealPostureJson {
+    Open,
+    Sealed { sealed_lsn: Option<u64> },
+}
+
+impl WalSegmentSealPostureJson {
+    fn from_wal_segment_seal_posture(posture: &WalSegmentSealPosture) -> Self {
+        match posture {
+            WalSegmentSealPosture::Open => Self::Open,
+            WalSegmentSealPosture::Sealed { sealed_lsn } => Self::Sealed {
+                sealed_lsn: sealed_lsn.map(Lsn::as_u64),
+            },
+        }
+    }
+
+    fn to_wal_segment_seal_posture(&self) -> WalSegmentSealPosture {
+        match self {
+            Self::Open => WalSegmentSealPosture::Open,
+            Self::Sealed { sealed_lsn } => WalSegmentSealPosture::Sealed {
+                sealed_lsn: optional_lsn(*sealed_lsn),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+enum WalSegmentStorageLocatorJson {
+    RelativePath { path: PathBuf },
+    AbsolutePath { path: PathBuf },
+}
+
+impl WalSegmentStorageLocatorJson {
+    fn from_wal_segment_storage_locator(locator: &WalSegmentStorageLocator) -> Self {
+        match locator {
+            WalSegmentStorageLocator::RelativePath(path) => {
+                Self::RelativePath { path: path.clone() }
+            }
+            WalSegmentStorageLocator::AbsolutePath(path) => {
+                Self::AbsolutePath { path: path.clone() }
+            }
+        }
+    }
+
+    fn to_wal_segment_storage_locator(&self) -> WalSegmentStorageLocator {
+        match self {
+            Self::RelativePath { path } => WalSegmentStorageLocator::RelativePath(path.clone()),
+            Self::AbsolutePath { path } => WalSegmentStorageLocator::AbsolutePath(path.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RecoveryCertificateRefJson {
+    certificate_digest: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    checkpoint_used: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_lsn: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_lsn: Option<u64>,
+    tail_posture: RecoveryTailPostureJson,
+    recovered_frontier_root: String,
+    recovered_indexes_root: String,
+}
+
+impl RecoveryCertificateRefJson {
+    fn from_recovery_certificate_ref(certificate: &RecoveryCertificateRef) -> Self {
+        Self {
+            certificate_digest: hex_hash(&certificate.certificate_digest),
+            checkpoint_used: certificate.checkpoint_used.map(|digest| hex_hash(&digest)),
+            first_lsn: certificate.first_lsn.map(Lsn::as_u64),
+            last_lsn: certificate.last_lsn.map(Lsn::as_u64),
+            tail_posture: RecoveryTailPostureJson::from_recovery_tail_posture(
+                certificate.tail_posture,
+            ),
+            recovered_frontier_root: hex_hash(&certificate.recovered_frontier_root),
+            recovered_indexes_root: hex_hash(&certificate.recovered_indexes_root),
+        }
+    }
+
+    fn to_recovery_certificate_ref(&self) -> Result<RecoveryCertificateRef> {
+        Ok(RecoveryCertificateRef {
+            certificate_digest: hash_from_hex(&self.certificate_digest)?,
+            checkpoint_used: optional_hash_from_hex(self.checkpoint_used.as_ref())?,
+            first_lsn: optional_lsn(self.first_lsn),
+            last_lsn: optional_lsn(self.last_lsn),
+            tail_posture: self.tail_posture.to_recovery_tail_posture(),
+            recovered_frontier_root: hash_from_hex(&self.recovered_frontier_root)?,
+            recovered_indexes_root: hash_from_hex(&self.recovered_indexes_root)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+enum RecoveryTailPostureJson {
+    Clean,
+    TruncatedAll,
+    TruncatedAfter { lsn: u64 },
+    WouldTruncateAll,
+    WouldTruncateAfter { lsn: u64 },
+}
+
+impl RecoveryTailPostureJson {
+    fn from_recovery_tail_posture(posture: RecoveryTailPosture) -> Self {
+        match posture {
+            RecoveryTailPosture::Clean => Self::Clean,
+            RecoveryTailPosture::TruncatedAll => Self::TruncatedAll,
+            RecoveryTailPosture::TruncatedAfter(lsn) => Self::TruncatedAfter { lsn: lsn.as_u64() },
+            RecoveryTailPosture::WouldTruncateAll => Self::WouldTruncateAll,
+            RecoveryTailPosture::WouldTruncateAfter(lsn) => {
+                Self::WouldTruncateAfter { lsn: lsn.as_u64() }
+            }
+        }
+    }
+
+    fn to_recovery_tail_posture(&self) -> RecoveryTailPosture {
+        match self {
+            Self::Clean => RecoveryTailPosture::Clean,
+            Self::TruncatedAll => RecoveryTailPosture::TruncatedAll,
+            Self::TruncatedAfter { lsn } => {
+                RecoveryTailPosture::TruncatedAfter(Lsn::from_raw(*lsn))
+            }
+            Self::WouldTruncateAll => RecoveryTailPosture::WouldTruncateAll,
+            Self::WouldTruncateAfter { lsn } => {
+                RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(*lsn))
+            }
+        }
+    }
+}
+
+struct UnavailableCasStore;
+
+impl WscCasBlobStorePort for UnavailableCasStore {
+    fn cas_blob_bytes(&self, _content_hash: &Hash) -> Option<Vec<u8>> {
+        None
+    }
+}

--- a/crates/warp-cli/tests/cli_integration.rs
+++ b/crates/warp-cli/tests/cli_integration.rs
@@ -9,7 +9,7 @@
 
 use std::error::Error;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use assert_cmd::cargo::cargo_bin;
 use predicates::prelude::*;
@@ -18,7 +18,7 @@ use warp_core::causal_wal::{
     build_submission_acceptance_transaction, build_tick_transaction, AffectedFrontier,
     AffectedFrontierKind, FilesystemWalStore, Lsn, PayloadCodecId, PayloadSchemaId,
     SubmissionAcceptanceRecord, TickReceiptRecord, WalAppendAuthority, WalDurabilityMode,
-    WalReceiptCorrelationRecord, WalSegmentId, WalStorePort, WalTickDecision,
+    WalManifest, WalReceiptCorrelationRecord, WalSegmentId, WalStorePort, WalTickDecision,
     WalTransactionBuilder, WalTransactionId, WalTransactionKind, WriterEpochId, WriterEpochRequest,
 };
 use warp_core::wsc::{build_one_warp_input, write_wsc_one_warp};
@@ -186,6 +186,135 @@ fn filesystem_wal_with_committed_submission() -> TestResult<TempDir> {
 
 fn filesystem_wal_with_decided_submission() -> TestResult<TempDir> {
     filesystem_wal_with_decided_submission_decision("decided", WalTickDecision::Applied)
+}
+
+struct ProjectableWalFixture {
+    root: TempDir,
+    writer_epochs: PathBuf,
+}
+
+fn filesystem_wal_with_projectable_decided_submission() -> TestResult<ProjectableWalFixture> {
+    let root = TempDir::new()?;
+    let writer_epoch = writer_epoch_request();
+    let mut store = FilesystemWalStore::open(root.path(), WalSegmentId::from_raw(1))?;
+    store.acquire_writer_epoch(writer_epoch.clone())?;
+    let label = "wsc-cli";
+    let acceptance = build_submission_acceptance_transaction(
+        WalTransactionBuilder::new(
+            writer_epoch.epoch_id,
+            WalSegmentId::from_raw(1),
+            WalTransactionId::from_hash(digest(&format!("transaction:{label}:accepted"))),
+            WalTransactionKind::SubmissionIntake,
+            WalAppendAuthority::SubmissionIntake,
+            Lsn::from_raw(0),
+            digest("previous-frame"),
+            digest("previous-commit"),
+            WalDurabilityMode::Buffered,
+            PayloadCodecId::from_hash(digest("codec")),
+            PayloadSchemaId::from_hash(digest("schema")),
+            1,
+            1,
+            digest("domain"),
+        ),
+        SubmissionAcceptanceRecord {
+            submission_id: digest(&format!("submission:{label}")),
+            canonical_envelope_digest: digest(&format!("envelope:{label}")),
+            idempotency_key_digest: None,
+            acceptance_evidence_digest: digest(&format!("evidence:{label}")),
+        },
+        vec![AffectedFrontier {
+            kind: AffectedFrontierKind::SubmissionQueue,
+            before_digest: digest("submission-frontier-before"),
+            after_digest: digest("submission-frontier-after"),
+        }],
+    )?;
+    store.append_transaction(acceptance)?;
+    let receipt = TickReceiptRecord {
+        submission_id: digest(&format!("submission:{label}")),
+        ticket_digest: digest(&format!("ticket:{label}")),
+        receipt_digest: digest(&format!("receipt:{label}")),
+        decision: WalTickDecision::Applied,
+    };
+    let correlation = WalReceiptCorrelationRecord {
+        submission_id: receipt.submission_id,
+        ticket_digest: receipt.ticket_digest,
+        receipt_digest: receipt.receipt_digest,
+    };
+    let tick = build_tick_transaction(
+        WalTransactionBuilder::new(
+            writer_epoch.epoch_id,
+            WalSegmentId::from_raw(1),
+            WalTransactionId::from_hash(digest(&format!("transaction:{label}:ticked"))),
+            WalTransactionKind::SchedulerTick,
+            WalAppendAuthority::TrustedScheduler,
+            Lsn::from_raw(2),
+            digest("tick-previous-frame"),
+            digest("tick-previous-commit"),
+            WalDurabilityMode::Buffered,
+            PayloadCodecId::from_hash(digest("codec")),
+            PayloadSchemaId::from_hash(digest("schema")),
+            1,
+            1,
+            digest("domain"),
+        ),
+        receipt,
+        correlation,
+        digest(&format!("state-delta:{label}")),
+        vec![
+            AffectedFrontier {
+                kind: AffectedFrontierKind::ReceiptIndex,
+                before_digest: digest("receipt-frontier-before"),
+                after_digest: digest("receipt-frontier-after"),
+            },
+            AffectedFrontier {
+                kind: AffectedFrontierKind::RuntimeState,
+                before_digest: digest("runtime-frontier-before"),
+                after_digest: digest("runtime-frontier-after"),
+            },
+        ],
+    )?;
+    store.append_transaction(tick)?;
+    store.seal_segment(writer_epoch.epoch_id, WalSegmentId::from_raw(1))?;
+    let last_commit_digest = store
+        .read_commits()
+        .last()
+        .map(|commit| commit.commit_digest);
+    store.publish_manifest(
+        writer_epoch.epoch_id,
+        WalManifest {
+            manifest_digest: digest("wsc-cli:manifest"),
+            last_committed_lsn: Some(Lsn::from_raw(4)),
+            last_commit_digest,
+            sealed_segment_count: 1,
+        },
+    )?;
+    let writer_epochs = root.path().join("writer-epochs.json");
+    write_writer_epoch_sidecar(&writer_epochs, &writer_epoch)?;
+    Ok(ProjectableWalFixture {
+        root,
+        writer_epochs,
+    })
+}
+
+fn write_writer_epoch_sidecar(path: &Path, epoch: &WriterEpochRequest) -> TestResult {
+    let writer_epochs = serde_json::json!([
+        {
+            "epoch_id": hex::encode(epoch.epoch_id.as_hash()),
+            "storage_fencing_token": hex::encode(epoch.storage_fencing_token),
+            "process_identity": hex::encode(epoch.process_identity),
+            "host_identity": hex::encode(epoch.host_identity),
+            "started_at_lsn": epoch.started_at_lsn.as_u64(),
+            "previous_epoch_id": epoch
+                .previous_epoch_id
+                .map(|epoch_id| hex::encode(epoch_id.as_hash())),
+            "previous_epoch_final_commit_digest": epoch
+                .previous_epoch_final_commit_digest
+                .map(hex::encode),
+            "lease_or_lock_evidence": hex::encode(epoch.lease_or_lock_evidence),
+        }
+    ]);
+    fs::write(path, serde_json::to_vec_pretty(&writer_epochs)?)?;
+    Ok(())
 }
 
 fn filesystem_wal_with_decided_submission_decision(
@@ -525,6 +654,137 @@ fn wal_submission_posture_json_reports_decided_rejected_status() -> TestResult {
         json["ticket_digest"],
         hex::encode(digest("ticket:rejected"))
     );
+    Ok(())
+}
+
+#[test]
+fn wsc_causal_history_exports_and_verifies_profiles() -> TestResult {
+    let fixture = filesystem_wal_with_projectable_decided_submission()?;
+    let ref_only_bundle = TempDir::new()?;
+    let export = echo_cli()
+        .args([
+            "--format",
+            "json",
+            "wsc",
+            "causal-history",
+            "export-ref-only",
+            fixture
+                .root
+                .path()
+                .to_str()
+                .ok_or("WAL root is not UTF-8")?,
+            "--writer-epochs",
+            fixture
+                .writer_epochs
+                .to_str()
+                .ok_or("writer epoch path is not UTF-8")?,
+            "--out",
+            ref_only_bundle
+                .path()
+                .to_str()
+                .ok_or("ref-only bundle path is not UTF-8")?,
+        ])
+        .assert()
+        .success();
+    let export_json: serde_json::Value = serde_json::from_slice(&export.get_output().stdout)?;
+    assert_eq!(export_json["profile"], "ref-only");
+
+    let verify = echo_cli()
+        .args([
+            "--format",
+            "json",
+            "wsc",
+            "causal-history",
+            "verify",
+            ref_only_bundle
+                .path()
+                .to_str()
+                .ok_or("ref-only bundle path is not UTF-8")?,
+        ])
+        .assert()
+        .success();
+    let json: serde_json::Value = serde_json::from_slice(&verify.get_output().stdout)?;
+
+    assert_eq!(json["profile"], "ref-only");
+    assert_eq!(json["result"], "obstructed");
+    assert_eq!(json["accepted_submission_count"], 1);
+    assert_eq!(json["receipt_count"], 1);
+    assert_eq!(json["correlation_count"], 1);
+    assert_eq!(
+        json["obstructions"][0]["kind"],
+        "ExternalSegmentBytesUnavailable"
+    );
+    assert_eq!(json["obstructions"][0]["segment_id"], 1);
+
+    let self_contained_bundle = TempDir::new()?;
+    echo_cli()
+        .args([
+            "--format",
+            "json",
+            "wsc",
+            "causal-history",
+            "export-self-contained",
+            fixture
+                .root
+                .path()
+                .to_str()
+                .ok_or("WAL root is not UTF-8")?,
+            "--writer-epochs",
+            fixture
+                .writer_epochs
+                .to_str()
+                .ok_or("writer epoch path is not UTF-8")?,
+            "--out",
+            self_contained_bundle
+                .path()
+                .to_str()
+                .ok_or("self-contained bundle path is not UTF-8")?,
+        ])
+        .assert()
+        .success();
+
+    let inspect = echo_cli()
+        .args([
+            "--format",
+            "json",
+            "wsc",
+            "causal-history",
+            "inspect",
+            self_contained_bundle
+                .path()
+                .to_str()
+                .ok_or("self-contained bundle path is not UTF-8")?,
+        ])
+        .assert()
+        .success();
+    let inspect_json: serde_json::Value = serde_json::from_slice(&inspect.get_output().stdout)?;
+    assert_eq!(inspect_json["profile"], "self-contained");
+    assert_eq!(inspect_json["envelope_count"], 4);
+
+    drop(fixture);
+
+    let verify = echo_cli()
+        .args([
+            "--format",
+            "json",
+            "wsc",
+            "causal-history",
+            "verify",
+            self_contained_bundle
+                .path()
+                .to_str()
+                .ok_or("self-contained bundle path is not UTF-8")?,
+        ])
+        .assert()
+        .success();
+    let json: serde_json::Value = serde_json::from_slice(&verify.get_output().stdout)?;
+
+    assert_eq!(json["profile"], "self-contained");
+    assert_eq!(json["result"], "pass");
+    assert_eq!(json["accepted_submission_count"], 1);
+    assert_eq!(json["receipt_count"], 1);
+    assert_eq!(json["correlation_count"], 1);
+    assert_eq!(json["obstructions"].as_array().map(Vec::len), Some(0));
     Ok(())
 }
 

--- a/crates/warp-cli/tests/golden/echo-cli-help.txt
+++ b/crates/warp-cli/tests/golden/echo-cli-help.txt
@@ -7,6 +7,7 @@ Commands:
   bench    Run benchmarks and format results
   inspect  Inspect a WSC snapshot
   wal      Inspect Echo WAL recovery posture without mutating storage
+  wsc      Export and verify WSC causal-history bundles without importing history
 
 Options:
       --format <FORMAT>  Output format (text or json) [default: text]

--- a/docs/man/echo-cli-wsc-causal-history-export-ref-only.1
+++ b/docs/man/echo-cli-wsc-causal-history-export-ref-only.1
@@ -1,0 +1,22 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wsc-causal-history-export-ref-only 1  "echo-cli-wsc-causal-history-export-ref-only "
+.SH NAME
+echo\-cli\-wsc\-causal\-history\-export\-ref\-only \- Export a ref\-only WSC causal\-history bundle from a filesystem WAL root
+.SH SYNOPSIS
+\fBecho\-cli\-wsc\-causal\-history\-export\-ref\-only\fR <\fB\-\-writer\-epochs\fR> <\fB\-\-out\fR> [\fB\-h\fR|\fB\-\-help\fR] <\fIWAL_ROOT\fR>
+.SH DESCRIPTION
+Export a ref\-only WSC causal\-history bundle from a filesystem WAL root
+.SH OPTIONS
+.TP
+\fB\-\-writer\-epochs\fR \fI<WRITER_EPOCHS>\fR
+JSON file containing writer\-epoch projection evidence
+.TP
+\fB\-\-out\fR \fI<OUT>\fR
+Output bundle directory
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIWAL_ROOT\fR>
+Filesystem WAL root to inspect

--- a/docs/man/echo-cli-wsc-causal-history-export-self-contained.1
+++ b/docs/man/echo-cli-wsc-causal-history-export-self-contained.1
@@ -1,0 +1,22 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wsc-causal-history-export-self-contained 1  "echo-cli-wsc-causal-history-export-self-contained "
+.SH NAME
+echo\-cli\-wsc\-causal\-history\-export\-self\-contained \- Export a self\-contained WSC causal\-history bundle from a filesystem WAL root
+.SH SYNOPSIS
+\fBecho\-cli\-wsc\-causal\-history\-export\-self\-contained\fR <\fB\-\-writer\-epochs\fR> <\fB\-\-out\fR> [\fB\-h\fR|\fB\-\-help\fR] <\fIWAL_ROOT\fR>
+.SH DESCRIPTION
+Export a self\-contained WSC causal\-history bundle from a filesystem WAL root
+.SH OPTIONS
+.TP
+\fB\-\-writer\-epochs\fR \fI<WRITER_EPOCHS>\fR
+JSON file containing writer\-epoch projection evidence
+.TP
+\fB\-\-out\fR \fI<OUT>\fR
+Output bundle directory
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIWAL_ROOT\fR>
+Filesystem WAL root to inspect

--- a/docs/man/echo-cli-wsc-causal-history-inspect.1
+++ b/docs/man/echo-cli-wsc-causal-history-inspect.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wsc-causal-history-inspect 1  "echo-cli-wsc-causal-history-inspect "
+.SH NAME
+echo\-cli\-wsc\-causal\-history\-inspect \- Inspect a WSC causal\-history bundle manifest and envelopes
+.SH SYNOPSIS
+\fBecho\-cli\-wsc\-causal\-history\-inspect\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIBUNDLE\fR>
+.SH DESCRIPTION
+Inspect a WSC causal\-history bundle manifest and envelopes
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIBUNDLE\fR>
+Bundle directory to inspect

--- a/docs/man/echo-cli-wsc-causal-history-verify.1
+++ b/docs/man/echo-cli-wsc-causal-history-verify.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wsc-causal-history-verify 1  "echo-cli-wsc-causal-history-verify "
+.SH NAME
+echo\-cli\-wsc\-causal\-history\-verify \- Verify a WSC causal\-history bundle without importing Echo history
+.SH SYNOPSIS
+\fBecho\-cli\-wsc\-causal\-history\-verify\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIBUNDLE\fR>
+.SH DESCRIPTION
+Verify a WSC causal\-history bundle without importing Echo history
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIBUNDLE\fR>
+Bundle directory to verify

--- a/docs/man/echo-cli-wsc-causal-history.1
+++ b/docs/man/echo-cli-wsc-causal-history.1
@@ -1,0 +1,29 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wsc-causal-history 1  "echo-cli-wsc-causal-history "
+.SH NAME
+echo\-cli\-wsc\-causal\-history \- Work with WAL causal\-history WSC bundles
+.SH SYNOPSIS
+\fBecho\-cli\-wsc\-causal\-history\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Work with WAL causal\-history WSC bundles
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.SH SUBCOMMANDS
+.TP
+echo\-cli\-wsc\-causal\-history\-export\-ref\-only(1)
+Export a ref\-only WSC causal\-history bundle from a filesystem WAL root
+.TP
+echo\-cli\-wsc\-causal\-history\-export\-self\-contained(1)
+Export a self\-contained WSC causal\-history bundle from a filesystem WAL root
+.TP
+echo\-cli\-wsc\-causal\-history\-inspect(1)
+Inspect a WSC causal\-history bundle manifest and envelopes
+.TP
+echo\-cli\-wsc\-causal\-history\-verify(1)
+Verify a WSC causal\-history bundle without importing Echo history
+.TP
+echo\-cli\-wsc\-causal\-history\-help(1)
+Print this message or the help of the given subcommand(s)

--- a/docs/man/echo-cli-wsc.1
+++ b/docs/man/echo-cli-wsc.1
@@ -1,0 +1,20 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH echo-cli-wsc 1  "echo-cli-wsc "
+.SH NAME
+echo\-cli\-wsc \- Export and verify WSC causal\-history bundles without importing history
+.SH SYNOPSIS
+\fBecho\-cli\-wsc\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Export and verify WSC causal\-history bundles without importing history
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.SH SUBCOMMANDS
+.TP
+echo\-cli\-wsc\-causal\-history(1)
+Work with WAL causal\-history WSC bundles
+.TP
+echo\-cli\-wsc\-help(1)
+Print this message or the help of the given subcommand(s)

--- a/docs/man/echo-cli.1
+++ b/docs/man/echo-cli.1
@@ -30,5 +30,8 @@ Inspect a WSC snapshot
 .TP
 echo\-cli\-wal(1)
 Inspect Echo WAL recovery posture without mutating storage
+.TP
+echo\-cli\-wsc(1)
+Export and verify WSC causal\-history bundles without importing history
 .SH VERSION
 v0.1.0

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -756,6 +756,14 @@ fn build_test_slice_commands(slice: TestSlice) -> Vec<Command> {
             cargo_command([
                 "test",
                 "-p",
+                "warp-cli",
+                "--test",
+                "cli_integration",
+                "wsc_causal_history",
+            ]),
+            cargo_command([
+                "test",
+                "-p",
                 "warp-core",
                 "--test",
                 "wsc_store_tests",
@@ -6695,7 +6703,7 @@ mod tests {
     #[test]
     fn test_slice_durability_release_stays_explicit() {
         let commands = build_test_slice_commands(TestSlice::DurabilityRelease);
-        assert_eq!(commands.len(), 10);
+        assert_eq!(commands.len(), 11);
 
         let expected = [
             (
@@ -6733,6 +6741,17 @@ mod tests {
                     "--test",
                     "cli_integration",
                     "wal_submission_posture",
+                ],
+            ),
+            (
+                "cargo",
+                vec![
+                    "test",
+                    "-p",
+                    "warp-cli",
+                    "--test",
+                    "cli_integration",
+                    "wsc_causal_history",
                 ],
             ),
             (


### PR DESCRIPTION
## Summary

- Add read-only `echo-cli wsc causal-history` commands for ref-only and self-contained WAL WSC bundle export, bundle inspection, and verification.
- Verify self-contained bundles without the original WAL root and report ref-only missing segment bytes as typed JSON material obstructions.
- Regenerate `echo-cli` man pages and wire the focused WSC CLI witness into the `durability-release` test slice.

Closes #568.

## Validation

- `cargo fmt --check`
- `cargo check -p warp-cli`
- `cargo clippy -p warp-cli --lib --tests -- -D warnings`
- `cargo clippy -p xtask -- -D warnings`
- `cargo test -p warp-cli parse_wsc_causal_history`
- `cargo test -p warp-cli --test cli_integration wsc_causal_history`
- `cargo test -p warp-cli --test cli_integration`
- `cargo test -p xtask test_slice_durability_release_stays_explicit`
- `cargo xtask man-pages --check`
- `cargo xtask test-slice durability-release`
- `npx markdownlint-cli2 CHANGELOG.md crates/warp-cli/README.md`
- `git diff --check`

## Test-loop note

The new WSC CLI acceptance coverage uses one shared projectable WAL fixture and the release slice runs the filtered `wsc_causal_history` integration witness instead of expanding to the full CLI integration file.
