### PR TITLE
Accept Edict Target IR obstruction receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Added
 
+- `warp-core` now exposes a narrow Edict `echo.span-ir/v1` Target IR fixture
+  bridge that accepts strict lowercase digest-locked pre-step
+  `continueObstructed` requirements, evaluates deterministic basis freshness
+  facts, and emits versioned attempt receipt objects bound to the supplied
+  Target IR digest. The bridge distinguishes accepted artifacts from executed
+  receipts, obstructed attempts from invalid proposals, and obstruction from
+  legal unselected counterfactuals without claiming bundle admission, Jim
+  semantics, scheduler counterfactual exploration, canonical Echo receipt
+  bytes, or receipt digests.
 - `warp-core` now exposes WAL projection fact records for `WalRoot`,
   `WalWriterEpoch`, `WalSegmentRef`, `WalCommitAnchor`, and
   `RecoveryCertificateRef`; `WalSegmentRef::identity_digest()` binds writer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apollo-parser"

--- a/crates/warp-core/src/edict_target_ir.rs
+++ b/crates/warp-core/src/edict_target_ir.rs
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Narrow Edict `echo.span-ir/v1` fixture acceptance and attempt receipts.
+//!
+//! This module is a fixture bridge for the Edict obstruction-strand corridor. It
+//! accepts the small Target IR subset Edict currently emits for Echo pre-step
+//! `continueObstructed` requirements and produces deterministic attempt receipts
+//! bound to the supplied Target IR artifact digest. It is not general Edict
+//! bundle admission, target plugin dispatch, or scheduler counterfactual
+//! retention.
+
+use std::collections::BTreeMap;
+
+use crate::ident::Hash;
+use crate::{ContractObstruction, ContractObstructionKind};
+
+/// Supported Edict Target IR artifact domain for this bridge.
+pub const EDICT_ECHO_TARGET_IR_DOMAIN: &str = "echo.span-ir/v1";
+
+/// Version marker for the non-canonical Echo attempt receipt shape.
+///
+/// This string versions the Rust review/fixture shape only. It does not freeze
+/// canonical Echo receipt bytes and must not be treated as a receipt digest
+/// domain.
+pub const EDICT_ECHO_ATTEMPT_RECEIPT_SCHEMA: &str = "echo.edict-target-ir.attempt-receipt/v0";
+
+/// Test-owned representation of the Edict Target IR artifact envelope Echo
+/// accepts in this slice.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdictEchoTargetIrArtifact {
+    /// Target IR domain. The only supported value is
+    /// [`EDICT_ECHO_TARGET_IR_DOMAIN`].
+    pub domain: String,
+    /// Target profile coordinate selected by Edict.
+    pub target_profile_coordinate: String,
+    /// Lowercase strict `sha256:<64-lower-hex>` target profile digest.
+    pub target_profile_digest: String,
+    /// Lowercase strict `sha256:<64-lower-hex>` Target IR artifact digest.
+    pub target_ir_digest: String,
+    /// Coordinate or review handle for the source Core artifact.
+    pub source_core_coordinate: String,
+    /// Source-ordered Target IR intents represented by the fixture.
+    pub intents: Vec<EdictEchoTargetIrIntent>,
+}
+
+/// Test-owned representation of an Edict Target IR intent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdictEchoTargetIrIntent {
+    /// Intent name emitted by Edict.
+    pub name: String,
+    /// Pre-step requirements emitted for this intent.
+    pub requirements: Vec<EdictEchoTargetIrRequirement>,
+}
+
+/// A pre-step Target IR requirement accepted by the Echo fixture bridge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdictEchoTargetIrRequirement {
+    /// Requirement identifier emitted by Edict.
+    pub id: String,
+    /// Predicate Echo can evaluate for this fixture bridge.
+    pub predicate: EdictEchoTargetIrPredicate,
+    /// Failure disposition emitted by Edict.
+    pub on_failure: EdictEchoTargetIrRequirementFailure,
+}
+
+/// Requirement predicates supported by this fixture bridge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EdictEchoTargetIrPredicate {
+    /// Checks whether the supplied input basis is fresh at execution time.
+    BasisFresh,
+}
+
+/// Requirement failure dispositions represented in Edict Target IR.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EdictEchoTargetIrRequirementFailure {
+    /// Terminal hard rejection disposition.
+    Terminal {
+        /// Opaque Edict obstruction reason attached to the disposition.
+        reason: EdictEchoObstructionReason,
+    },
+    /// Continue into an obstructed attempt rather than hard rejection.
+    ContinueObstructed {
+        /// Opaque Edict obstruction reason attached to the disposition.
+        reason: EdictEchoObstructionReason,
+    },
+}
+
+/// Opaque Edict obstruction reason carried through Echo receipt evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdictEchoObstructionReason {
+    /// Stable reason kind emitted by Edict.
+    pub kind: String,
+    /// Opaque deterministic payload fields emitted by Edict for review.
+    pub payload: BTreeMap<String, String>,
+}
+
+/// Stable digest field names used by acceptance errors.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EdictEchoTargetIrDigestField {
+    /// `target_profile_digest` failed lowercase strict `sha256:` validation.
+    TargetProfileDigest,
+    /// `target_ir_digest` failed lowercase strict `sha256:` validation.
+    TargetIrDigest,
+}
+
+/// Stable acceptance error kind for the narrow Edict Echo fixture bridge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EdictEchoTargetIrAcceptanceErrorKind {
+    /// The artifact domain was not `echo.span-ir/v1`.
+    WrongDomain,
+    /// A required digest field was absent, malformed, or not lowercase strict.
+    MalformedDigest,
+    /// The fixture carried no accepted pre-step requirements.
+    MissingRequirement,
+    /// The fixture carried more than one pre-step requirement, which this
+    /// bridge does not execute yet.
+    UnsupportedRequirementCount,
+    /// The fixture carried a requirement disposition not supported by this
+    /// bridge.
+    UnsupportedRequirementDisposition,
+    /// The fixture carried an unsupported requirement predicate.
+    UnsupportedRequirementPredicate,
+}
+
+/// Structured acceptance failure for an Edict Echo Target IR fixture.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdictEchoTargetIrAcceptanceError {
+    /// Stable failure kind.
+    pub kind: EdictEchoTargetIrAcceptanceErrorKind,
+    /// Digest field associated with [`EdictEchoTargetIrAcceptanceErrorKind::MalformedDigest`].
+    pub digest_field: Option<EdictEchoTargetIrDigestField>,
+}
+
+impl EdictEchoTargetIrAcceptanceError {
+    /// Returns the attempt outcome family associated with this acceptance
+    /// failure.
+    #[must_use]
+    pub const fn outcome_kind(&self) -> EdictEchoAttemptOutcomeKind {
+        EdictEchoAttemptOutcomeKind::InvalidProposal
+    }
+
+    const fn new(kind: EdictEchoTargetIrAcceptanceErrorKind) -> Self {
+        Self {
+            kind,
+            digest_field: None,
+        }
+    }
+
+    const fn malformed_digest(field: EdictEchoTargetIrDigestField) -> Self {
+        Self {
+            kind: EdictEchoTargetIrAcceptanceErrorKind::MalformedDigest,
+            digest_field: Some(field),
+        }
+    }
+}
+
+/// Accepted fixture state. Acceptance is separate from execution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AcceptedEdictEchoTargetIr {
+    target_profile_digest: Hash,
+    target_ir_digest: Hash,
+    requirement: AcceptedEdictEchoRequirement,
+}
+
+impl AcceptedEdictEchoTargetIr {
+    /// Returns the accepted target profile digest bytes.
+    #[must_use]
+    pub const fn target_profile_digest(&self) -> Hash {
+        self.target_profile_digest
+    }
+
+    /// Returns the accepted Target IR digest bytes.
+    #[must_use]
+    pub const fn target_ir_digest(&self) -> Hash {
+        self.target_ir_digest
+    }
+
+    /// Returns the number of pre-step requirements accepted by this bridge.
+    #[must_use]
+    pub const fn requirement_count(&self) -> usize {
+        1
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AcceptedEdictEchoRequirement {
+    predicate: EdictEchoTargetIrPredicate,
+    on_failure: AcceptedEdictEchoRequirementFailure,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum AcceptedEdictEchoRequirementFailure {
+    ContinueObstructed { reason: EdictEchoObstructionReason },
+}
+
+/// Deterministic input facts supplied by the Echo test harness for one attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EdictEchoAttemptInput {
+    /// Whether the supplied basis is fresh under the host's deterministic test
+    /// facts.
+    pub basis_is_fresh: bool,
+    /// Digest of the basis supplied by the caller.
+    pub input_basis_digest: Hash,
+    /// Digest of the basis observed by Echo during the attempt.
+    pub observed_basis_digest: Hash,
+}
+
+/// Attempt outcome vocabulary used by the Edict Echo fixture bridge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EdictEchoAttemptOutcomeKind {
+    /// Echo accepted and executed the fixture path successfully.
+    CommittedSuccess,
+    /// Echo accepted the fixture but the attempt continued into an obstruction.
+    ObstructedAttempt,
+    /// Echo rejected the artifact before execution as invalid for this bridge.
+    InvalidProposal,
+    /// Reserved for admitted legal candidates not selected by a scheduler.
+    LegalUnselectedCounterfactual,
+    /// Reserved for runtime faults rather than lawful domain obstructions.
+    RuntimeFault,
+}
+
+/// Obstruction evidence attached to an obstructed Edict Echo attempt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdictEchoAttemptObstruction {
+    /// Generic Echo contract obstruction posture.
+    pub contract: ContractObstruction,
+    /// Opaque Edict reason carried through for review.
+    pub reason: EdictEchoObstructionReason,
+}
+
+/// Deterministic attempt receipt for the narrow Edict Echo Target IR bridge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdictEchoAttemptReceipt {
+    /// Version marker for this Rust fixture receipt shape.
+    pub receipt_schema: &'static str,
+    /// Target IR digest supplied by and checked during fixture acceptance.
+    pub target_ir_digest: Hash,
+    /// Attempt outcome family.
+    pub outcome_kind: EdictEchoAttemptOutcomeKind,
+    /// Caller-supplied basis digest used for basis freshness evaluation.
+    pub input_basis_digest: Hash,
+    /// Echo-observed basis digest used for basis freshness evaluation.
+    pub observed_basis_digest: Hash,
+    /// Obstruction evidence for [`EdictEchoAttemptOutcomeKind::ObstructedAttempt`].
+    pub obstruction: Option<EdictEchoAttemptObstruction>,
+}
+
+/// Accepts the supported Edict `echo.span-ir/v1` Target IR fixture subset.
+///
+/// Acceptance validates artifact identity and shape only. It does not execute
+/// the requirement, tick the scheduler, admit bundles, or produce an attempt
+/// receipt.
+pub fn accept_edict_echo_target_ir(
+    artifact: &EdictEchoTargetIrArtifact,
+) -> Result<AcceptedEdictEchoTargetIr, EdictEchoTargetIrAcceptanceError> {
+    if artifact.domain != EDICT_ECHO_TARGET_IR_DOMAIN {
+        return Err(EdictEchoTargetIrAcceptanceError::new(
+            EdictEchoTargetIrAcceptanceErrorKind::WrongDomain,
+        ));
+    }
+
+    let target_profile_digest = parse_sha256_review_string(
+        &artifact.target_profile_digest,
+        EdictEchoTargetIrDigestField::TargetProfileDigest,
+    )?;
+    let target_ir_digest = parse_sha256_review_string(
+        &artifact.target_ir_digest,
+        EdictEchoTargetIrDigestField::TargetIrDigest,
+    )?;
+
+    let mut requirements = artifact
+        .intents
+        .iter()
+        .flat_map(|intent| intent.requirements.iter());
+    let Some(requirement) = requirements.next() else {
+        return Err(EdictEchoTargetIrAcceptanceError::new(
+            EdictEchoTargetIrAcceptanceErrorKind::MissingRequirement,
+        ));
+    };
+    if requirements.next().is_some() {
+        return Err(EdictEchoTargetIrAcceptanceError::new(
+            EdictEchoTargetIrAcceptanceErrorKind::UnsupportedRequirementCount,
+        ));
+    }
+
+    let on_failure = match &requirement.on_failure {
+        EdictEchoTargetIrRequirementFailure::ContinueObstructed { reason } => {
+            AcceptedEdictEchoRequirementFailure::ContinueObstructed {
+                reason: reason.clone(),
+            }
+        }
+        EdictEchoTargetIrRequirementFailure::Terminal { .. } => {
+            return Err(EdictEchoTargetIrAcceptanceError::new(
+                EdictEchoTargetIrAcceptanceErrorKind::UnsupportedRequirementDisposition,
+            ));
+        }
+    };
+
+    match requirement.predicate {
+        EdictEchoTargetIrPredicate::BasisFresh => {}
+    }
+
+    Ok(AcceptedEdictEchoTargetIr {
+        target_profile_digest,
+        target_ir_digest,
+        requirement: AcceptedEdictEchoRequirement {
+            predicate: requirement.predicate,
+            on_failure,
+        },
+    })
+}
+
+/// Executes one accepted Edict Echo Target IR fixture attempt.
+///
+/// Execution here means evaluating the supported pre-step requirement against
+/// deterministic input facts. It does not dispatch a general Echo scheduler
+/// candidate set and never produces legal-unselected counterfactuals.
+#[must_use]
+pub fn execute_accepted_edict_echo_target_ir(
+    accepted: &AcceptedEdictEchoTargetIr,
+    input: EdictEchoAttemptInput,
+) -> EdictEchoAttemptReceipt {
+    let requirement_satisfied = match accepted.requirement.predicate {
+        EdictEchoTargetIrPredicate::BasisFresh => input.basis_is_fresh,
+    };
+
+    if requirement_satisfied {
+        return EdictEchoAttemptReceipt {
+            receipt_schema: EDICT_ECHO_ATTEMPT_RECEIPT_SCHEMA,
+            target_ir_digest: accepted.target_ir_digest,
+            outcome_kind: EdictEchoAttemptOutcomeKind::CommittedSuccess,
+            input_basis_digest: input.input_basis_digest,
+            observed_basis_digest: input.observed_basis_digest,
+            obstruction: None,
+        };
+    }
+
+    let AcceptedEdictEchoRequirementFailure::ContinueObstructed { reason } =
+        &accepted.requirement.on_failure;
+    EdictEchoAttemptReceipt {
+        receipt_schema: EDICT_ECHO_ATTEMPT_RECEIPT_SCHEMA,
+        target_ir_digest: accepted.target_ir_digest,
+        outcome_kind: EdictEchoAttemptOutcomeKind::ObstructedAttempt,
+        input_basis_digest: input.input_basis_digest,
+        observed_basis_digest: input.observed_basis_digest,
+        obstruction: Some(EdictEchoAttemptObstruction {
+            contract: ContractObstruction::new(
+                ContractObstructionKind::StaleBasis,
+                crate::ContractObstructionSubject::Unspecified,
+            ),
+            reason: reason.clone(),
+        }),
+    }
+}
+
+fn parse_sha256_review_string(
+    value: &str,
+    field: EdictEchoTargetIrDigestField,
+) -> Result<Hash, EdictEchoTargetIrAcceptanceError> {
+    let Some(hex_value) = value.strip_prefix("sha256:") else {
+        return Err(EdictEchoTargetIrAcceptanceError::malformed_digest(field));
+    };
+    if hex_value.len() != 64 || !hex_value.bytes().all(is_lowercase_hex_digit) {
+        return Err(EdictEchoTargetIrAcceptanceError::malformed_digest(field));
+    }
+
+    let mut digest = [0_u8; 32];
+    hex::decode_to_slice(hex_value, &mut digest)
+        .map_err(|_| EdictEchoTargetIrAcceptanceError::malformed_digest(field))?;
+    Ok(digest)
+}
+
+fn is_lowercase_hex_digit(byte: u8) -> bool {
+    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
+}

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -54,6 +54,7 @@ mod contract_registry;
 /// Domain separation prefixes for hashing.
 pub mod domain;
 mod dynamic_binding;
+mod edict_target_ir;
 mod engine_impl;
 mod footprint;
 /// Footprint enforcement guard for parallel execution.
@@ -210,6 +211,15 @@ pub use dynamic_binding::{
     DynamicBindingRuntimeError, RangeClosureBindingRequest, RelationSlotBinding,
     ResolvedClosureBinding, ResolvedSlotBinding, StructuredBindingResolver,
     StructuredBindingRuntime, StructuredRuntimeBindings,
+};
+pub use edict_target_ir::{
+    accept_edict_echo_target_ir, execute_accepted_edict_echo_target_ir, AcceptedEdictEchoTargetIr,
+    EdictEchoAttemptInput, EdictEchoAttemptObstruction, EdictEchoAttemptOutcomeKind,
+    EdictEchoAttemptReceipt, EdictEchoObstructionReason, EdictEchoTargetIrAcceptanceError,
+    EdictEchoTargetIrAcceptanceErrorKind, EdictEchoTargetIrArtifact, EdictEchoTargetIrDigestField,
+    EdictEchoTargetIrIntent, EdictEchoTargetIrPredicate, EdictEchoTargetIrRequirement,
+    EdictEchoTargetIrRequirementFailure, EDICT_ECHO_ATTEMPT_RECEIPT_SCHEMA,
+    EDICT_ECHO_TARGET_IR_DOMAIN,
 };
 pub use engine_impl::{
     scope_hash, ApplyResult, CommitOutcome, DispatchDisposition, Engine, EngineBuilder,

--- a/crates/warp-core/tests/edict_target_ir_receipt_tests.rs
+++ b/crates/warp-core/tests/edict_target_ir_receipt_tests.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Edict Target IR obstruction receipt bridge tests.
+
+use warp_core::{
+    accept_edict_echo_target_ir, execute_accepted_edict_echo_target_ir, ContractObstructionKind,
+    EdictEchoAttemptInput, EdictEchoAttemptOutcomeKind, EdictEchoObstructionReason,
+    EdictEchoTargetIrAcceptanceErrorKind, EdictEchoTargetIrArtifact, EdictEchoTargetIrDigestField,
+    EdictEchoTargetIrIntent, EdictEchoTargetIrPredicate, EdictEchoTargetIrRequirement,
+    EdictEchoTargetIrRequirementFailure, EDICT_ECHO_ATTEMPT_RECEIPT_SCHEMA,
+    EDICT_ECHO_TARGET_IR_DOMAIN,
+};
+
+const TARGET_PROFILE_DIGEST: &str =
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const TARGET_IR_DIGEST: &str =
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+#[test]
+fn edict_echo_target_ir_obstructed_attempt_binds_digest() -> Result<(), String> {
+    let accepted = accept_edict_echo_target_ir(&supported_artifact())
+        .map_err(|error| format!("supported fixture rejected: {error:?}"))?;
+
+    let receipt_a = execute_accepted_edict_echo_target_ir(&accepted, stale_basis_input());
+    let receipt_b = execute_accepted_edict_echo_target_ir(&accepted, stale_basis_input());
+
+    assert_eq!(receipt_a, receipt_b);
+    assert_eq!(receipt_a.receipt_schema, EDICT_ECHO_ATTEMPT_RECEIPT_SCHEMA);
+    assert_eq!(receipt_a.target_ir_digest, digest(0xbb));
+    assert_eq!(
+        receipt_a.outcome_kind,
+        EdictEchoAttemptOutcomeKind::ObstructedAttempt
+    );
+    assert_ne!(
+        receipt_a.outcome_kind,
+        EdictEchoAttemptOutcomeKind::InvalidProposal
+    );
+    assert_ne!(
+        receipt_a.outcome_kind,
+        EdictEchoAttemptOutcomeKind::LegalUnselectedCounterfactual
+    );
+
+    let Some(obstruction) = receipt_a.obstruction.as_ref() else {
+        return Err("stale basis produced no obstruction evidence".to_owned());
+    };
+    assert_eq!(
+        obstruction.contract.kind,
+        ContractObstructionKind::StaleBasis
+    );
+    assert_eq!(obstruction.reason.kind, "jim.EditObstruction.StaleBase");
+    assert_eq!(
+        obstruction.reason.payload.get("provided"),
+        Some(&"input.basis".to_owned())
+    );
+    assert_eq!(receipt_a.input_basis_digest, digest(0x11));
+    assert_eq!(receipt_a.observed_basis_digest, digest(0x22));
+    Ok(())
+}
+
+#[test]
+fn accepted_artifact_and_execution_receipt_are_separate_steps() -> Result<(), String> {
+    let accepted = accept_edict_echo_target_ir(&supported_artifact())
+        .map_err(|error| format!("supported fixture rejected: {error:?}"))?;
+
+    assert_eq!(accepted.target_ir_digest(), digest(0xbb));
+    assert_eq!(accepted.requirement_count(), 1);
+
+    let receipt = execute_accepted_edict_echo_target_ir(&accepted, fresh_basis_input());
+    assert_eq!(
+        receipt.outcome_kind,
+        EdictEchoAttemptOutcomeKind::CommittedSuccess
+    );
+    assert!(receipt.obstruction.is_none());
+    assert_eq!(receipt.target_ir_digest, accepted.target_ir_digest());
+    Ok(())
+}
+
+#[test]
+fn unsupported_fixture_shapes_reject_with_stable_errors() -> Result<(), String> {
+    let mut wrong_domain = supported_artifact();
+    wrong_domain.domain = "gitwarp.commit-reducer-ir/v1".to_owned();
+    assert_acceptance_error(
+        &wrong_domain,
+        EdictEchoTargetIrAcceptanceErrorKind::WrongDomain,
+        None,
+    )?;
+
+    let mut missing_requirement = supported_artifact();
+    missing_requirement.intents[0].requirements.clear();
+    assert_acceptance_error(
+        &missing_requirement,
+        EdictEchoTargetIrAcceptanceErrorKind::MissingRequirement,
+        None,
+    )?;
+
+    let mut extra_requirement = supported_artifact();
+    let duplicate_requirement = extra_requirement.intents[0].requirements[0].clone();
+    extra_requirement.intents[0]
+        .requirements
+        .push(duplicate_requirement);
+    assert_acceptance_error(
+        &extra_requirement,
+        EdictEchoTargetIrAcceptanceErrorKind::UnsupportedRequirementCount,
+        None,
+    )?;
+
+    let mut unsupported_disposition = supported_artifact();
+    unsupported_disposition.intents[0].requirements[0].on_failure =
+        EdictEchoTargetIrRequirementFailure::Terminal {
+            reason: stale_reason(),
+        };
+    assert_acceptance_error(
+        &unsupported_disposition,
+        EdictEchoTargetIrAcceptanceErrorKind::UnsupportedRequirementDisposition,
+        None,
+    )?;
+
+    let mut malformed_target_ir_digest = supported_artifact();
+    malformed_target_ir_digest.target_ir_digest =
+        "sha256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned();
+    assert_acceptance_error(
+        &malformed_target_ir_digest,
+        EdictEchoTargetIrAcceptanceErrorKind::MalformedDigest,
+        Some(EdictEchoTargetIrDigestField::TargetIrDigest),
+    )?;
+
+    let mut malformed_profile_digest = supported_artifact();
+    malformed_profile_digest.target_profile_digest =
+        "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned();
+    assert_acceptance_error(
+        &malformed_profile_digest,
+        EdictEchoTargetIrAcceptanceErrorKind::MalformedDigest,
+        Some(EdictEchoTargetIrDigestField::TargetProfileDigest),
+    )?;
+    Ok(())
+}
+
+fn assert_acceptance_error(
+    artifact: &EdictEchoTargetIrArtifact,
+    expected_kind: EdictEchoTargetIrAcceptanceErrorKind,
+    expected_field: Option<EdictEchoTargetIrDigestField>,
+) -> Result<(), String> {
+    let Err(error) = accept_edict_echo_target_ir(artifact) else {
+        return Err("unsupported fixture unexpectedly accepted".to_owned());
+    };
+    assert_eq!(error.kind, expected_kind);
+    assert_eq!(error.digest_field, expected_field);
+    assert_eq!(
+        error.outcome_kind(),
+        EdictEchoAttemptOutcomeKind::InvalidProposal
+    );
+    Ok(())
+}
+
+fn supported_artifact() -> EdictEchoTargetIrArtifact {
+    EdictEchoTargetIrArtifact {
+        domain: EDICT_ECHO_TARGET_IR_DOMAIN.to_owned(),
+        target_profile_coordinate: "echo.dpo@1".to_owned(),
+        target_profile_digest: TARGET_PROFILE_DIGEST.to_owned(),
+        target_ir_digest: TARGET_IR_DIGEST.to_owned(),
+        source_core_coordinate: "core://obstruction-strands/stale-basis".to_owned(),
+        intents: vec![EdictEchoTargetIrIntent {
+            name: "edit".to_owned(),
+            requirements: vec![EdictEchoTargetIrRequirement {
+                id: "edit.require.0".to_owned(),
+                predicate: EdictEchoTargetIrPredicate::BasisFresh,
+                on_failure: EdictEchoTargetIrRequirementFailure::ContinueObstructed {
+                    reason: stale_reason(),
+                },
+            }],
+        }],
+    }
+}
+
+fn stale_reason() -> EdictEchoObstructionReason {
+    EdictEchoObstructionReason {
+        kind: "jim.EditObstruction.StaleBase".to_owned(),
+        payload: std::iter::once(("provided".to_owned(), "input.basis".to_owned())).collect(),
+    }
+}
+
+fn stale_basis_input() -> EdictEchoAttemptInput {
+    EdictEchoAttemptInput {
+        basis_is_fresh: false,
+        input_basis_digest: digest(0x11),
+        observed_basis_digest: digest(0x22),
+    }
+}
+
+fn fresh_basis_input() -> EdictEchoAttemptInput {
+    EdictEchoAttemptInput {
+        basis_is_fresh: true,
+        input_basis_digest: digest(0x33),
+        observed_basis_digest: digest(0x33),
+    }
+}
+
+fn digest(byte: u8) -> [u8; 32] {
+    [byte; 32]
+}

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -20,6 +20,9 @@ artifacts record motion.
 The WARP paper-to-Echo noun map is maintained in
 `docs/design/warp-optic-implementation-map.md`.
 
+The Edict Target IR obstruction receipt bridge is maintained in
+`docs/design/edict-target-ir-obstruction-receipt-bridge.md`.
+
 The post-PR #545 strands and braids hardening roadmap is maintained in
 `docs/design/braids-and-strands-roadmap.md`.
 

--- a/docs/design/edict-target-ir-obstruction-receipt-bridge.md
+++ b/docs/design/edict-target-ir-obstruction-receipt-bridge.md
@@ -1,0 +1,217 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+title: "PLATFORM-641 - Edict Target IR Obstruction Receipt Bridge"
+legend: "PLATFORM"
+lane: "design"
+issue: "https://github.com/flyingrobots/echo/issues/641"
+status: "active"
+owners:
+  - "@flyingrobots"
+created: "2026-07-05"
+updated: "2026-07-05"
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# PLATFORM-641 - Edict Target IR Obstruction Receipt Bridge
+
+## Linked Issue
+
+- [Issue #641](https://github.com/flyingrobots/echo/issues/641)
+
+## Decision Summary
+
+Echo exposes a narrow `warp-core` fixture bridge for Edict-produced
+`echo.span-ir/v1` Target IR requirements. The bridge accepts a supported
+pre-step `continueObstructed` requirement shape, evaluates a deterministic
+`BasisFresh` fact supplied by the test harness, and returns a versioned attempt
+receipt object bound to the Target IR artifact digest.
+
+## Sponsored Human
+
+An Edict author wants to see the first honest Echo-side receipt for a
+preserved obstruction strand so that the source-to-runtime corridor can advance
+without waiting for full Jim admission or scheduler counterfactual exploration.
+
+## Sponsored Agent
+
+An integration agent needs a stable Rust API witness that separates Target IR
+artifact acceptance from execution-attempt evidence, without inferring Echo
+scheduler behavior from Edict review JSON or editor projections.
+
+## Hill
+
+By the end of this cycle, `warp-core` can accept the supported Edict Echo
+Target IR fixture shape and emit deterministic attempt receipts for fresh and
+stale basis facts, proven by
+`cargo test -p warp-core --test edict_target_ir_receipt_tests`.
+
+## Current Truth
+
+On the merge target, Echo already has generic contract obstruction posture and
+product-facing intent outcome observation, but it has no Edict Target IR
+fixture bridge.
+
+- `ContractObstructionKind::StaleBasis` exists for generic contract-hosted
+  obstruction posture.
+  [`crates/warp-core/src/contract_obstruction.rs#28:9ef21d2dbd618cc4e52ad3552e63c42b476d49d5`](https://github.com/flyingrobots/echo/blob/9ef21d2dbd618cc4e52ad3552e63c42b476d49d5/crates/warp-core/src/contract_obstruction.rs#L28)
+- `IntentOutcome` separates applied, rejected, pending, unknown, and obstructed
+  observed submission outcomes.
+  [`crates/warp-core/src/coordinator.rs#746:9ef21d2dbd618cc4e52ad3552e63c42b476d49d5`](https://github.com/flyingrobots/echo/blob/9ef21d2dbd618cc4e52ad3552e63c42b476d49d5/crates/warp-core/src/coordinator.rs#L746)
+- `TickReceiptDisposition` still represents scheduler-owned applied or
+  rejected tick candidates, not Edict Target IR attempt receipts.
+  [`crates/warp-core/src/receipt.rs#103:9ef21d2dbd618cc4e52ad3552e63c42b476d49d5`](https://github.com/flyingrobots/echo/blob/9ef21d2dbd618cc4e52ad3552e63c42b476d49d5/crates/warp-core/src/receipt.rs#L103)
+
+## Problem
+
+Edict can now emit Echo Target IR requirements for preserved obstruction
+continuations, but Echo has no executable consumer witness for that artifact
+shape. Without an Echo-side bridge, the obstruction-strand corridor stops at
+Target IR review artifacts and cannot prove that Echo can distinguish a valid
+obstructed attempt from an invalid proposal or scheduler counterfactual.
+
+## Scope
+
+This cycle includes:
+
+- a public `warp-core` fixture model for the supported Edict Echo Target IR
+  subset;
+- strict lowercase `sha256:<64-lower-hex>` validation for target profile and
+  Target IR digest references;
+- acceptance errors for wrong domain, malformed digests, missing requirements,
+  extra requirements, unsupported requirement dispositions, and unsupported
+  predicates;
+- deterministic attempt receipts for fresh and stale basis facts;
+- explicit `ObstructedAttempt`, `InvalidProposal`, and
+  `LegalUnselectedCounterfactual` outcome vocabulary;
+- a focused integration test proving the accepted-artifact step and execution
+  receipt step remain separate.
+
+## Non-Goals
+
+This cycle does not include:
+
+- general Edict bundle admission;
+- participant policy evaluation;
+- Jim product operation semantics;
+- XYPH or Quest settlement;
+- scheduler counterfactual exploration;
+- canonical Echo receipt bytes or receipt digests;
+- a general target plugin registry;
+- parsing Edict review JSON as a stable wire contract.
+
+## User Experience / Product Shape
+
+Not applicable. This cycle exposes a Rust fixture bridge and tests. It does not
+change a rendered UI, CLI command, or editor surface.
+
+### User Journey
+
+```mermaid
+flowchart TD
+  EdictIR[Edict echo.span-ir/v1 fixture] --> Accept[Echo accepts fixture shape]
+  Accept --> Fresh{basis fresh?}
+  Fresh -->|yes| Success[CommittedSuccess receipt object]
+  Fresh -->|no| Obstructed[ObstructedAttempt receipt object]
+  EdictIR --> Invalid[Invalid proposal]
+```
+
+### Wide UI Mockup
+
+Not applicable.
+
+### Narrow UI Mockup
+
+Not applicable.
+
+### Accessibility Considerations
+
+Not applicable. The API returns structured Rust values with explicit outcome
+variants and stable error kinds.
+
+## Runtime / API Contract
+
+The public `warp-core` contract is:
+
+- `accept_edict_echo_target_ir(...)`
+- `execute_accepted_edict_echo_target_ir(...)`
+- `EdictEchoTargetIrArtifact`
+- `AcceptedEdictEchoTargetIr`
+- `EdictEchoAttemptInput`
+- `EdictEchoAttemptReceipt`
+- `EdictEchoAttemptOutcomeKind`
+- `EdictEchoTargetIrAcceptanceErrorKind`
+
+Acceptance validates artifact identity and shape. Execution evaluates the
+accepted pre-step requirement against deterministic input facts and returns a
+receipt object. The receipt object includes:
+
+- receipt schema marker;
+- Target IR digest bytes;
+- attempt outcome kind;
+- input basis digest;
+- observed basis digest;
+- optional obstruction evidence.
+
+The receipt shape is versioned but not canonically encoded in this cycle. No
+receipt digest is produced.
+
+## Lower Modes
+
+The lower mode is the Rust integration test. No network, filesystem state,
+wall-clock, scheduler tick, retained evidence store, or external Edict process
+is required.
+
+## Data / State Model
+
+Source of truth:
+Edict-produced Target IR fixture fields supplied to `warp-core`.
+
+Derived state:
+Accepted fixture state and deterministic attempt receipt values.
+
+Invalid states:
+Wrong domain, malformed digest, missing requirement, extra requirement, and
+unsupported disposition.
+
+Reset behavior:
+No persistent state is written.
+
+Serialization:
+None in this cycle. Receipt bytes are not canonicalized.
+
+Deterministic assumptions:
+Basis freshness and basis digests are explicit inputs.
+
+## Echo Authority Boundary
+
+Echo owns fixture acceptance and attempt receipt production for this narrow
+bridge. Edict owns source syntax, Core meaning, Target IR lowering, Target IR
+bytes, and Target IR digest generation. The test harness supplies deterministic
+basis facts.
+
+Echo does not claim full admission, scheduler selection, Jim semantics, or
+counterfactual retention here.
+
+## Witness
+
+The executable witness is:
+
+```bash
+cargo test -p warp-core --test edict_target_ir_receipt_tests
+```
+
+The witness proves:
+
+- supported Edict Echo Target IR fixture acceptance;
+- strict digest rejection;
+- accepted artifact versus execution receipt separation;
+- stale basis maps to `ObstructedAttempt` and generic `StaleBasis`
+  obstruction posture;
+- fresh basis maps to `CommittedSuccess`;
+- obstructed attempts are distinct from invalid proposals and legal unselected
+  counterfactuals.


### PR DESCRIPTION
## Summary

- Adds a narrow `warp-core` Edict `echo.span-ir/v1` Target IR fixture bridge.
- Accepts exactly one pre-step `continueObstructed` requirement with strict lowercase `sha256:` target-profile and Target IR digest references.
- Emits deterministic attempt receipt objects bound to the supplied Target IR digest for fresh and stale basis facts.
- Records the boundary in a design note, BEARING, and CHANGELOG.

## Boundary

This is the Echo-side obstruction-strand fixture bridge after Edict PR #132. It separates artifact acceptance from execution-attempt receipt production and distinguishes obstructed attempts from invalid proposals and legal unselected counterfactuals.

It does not implement general Edict bundle admission, participant policy, Jim product semantics, scheduler counterfactual exploration, canonical Echo receipt bytes, receipt digests, XYPH settlement, or a target plugin registry.

## RED

- `cargo test -p warp-core --test edict_target_ir_receipt_tests` failed with unresolved imports for the missing Edict Target IR receipt bridge API.

## GREEN

- `cargo test -p warp-core --test edict_target_ir_receipt_tests`
- `cargo test -p warp-core --test contract_obstruction_taxonomy_tests`
- `cargo check -p warp-core`
- `cargo clippy -p warp-core --lib -- -D warnings`
- `cargo clippy -p warp-core --test edict_target_ir_receipt_tests -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm exec markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/edict-target-ir-obstruction-receipt-bridge.md`
- `scripts/check_spdx.sh`
- `scripts/check-no-app-nouns-in-core.sh`
- `git diff --check`

Pre-push also passed:

- `cargo test -p warp-core --lib` (565 tests)
- `cargo test -p warp-core --test edict_target_ir_receipt_tests`
- Prettier check for touched Markdown

Closes #641.
Supports #583, #589, and #640.
