### PR TITLE
feat(warp-core): add WAL evidence segment catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,9 @@ Continuum is the protocol for lawful causal-history exchange.
 
 ## Trace Architecture Principle
 
-> Echo execution traces are emitted as a bounded, append-only, canonical stream of WSC-derived trace events. Trace storage is chunked. Sparse selector columns may be encoded as compressed bitsets. Dense witness data must remain in canonical dense columns or WSC segments. Prover-specific rectangular traces are projections, not the source of truth.
+> Graph is truth. Delta log is transport. Roaring is index. Matrix is projection. Receipt is proof.
+
+Echo execution traces are not a separate event-sourcing reality. They are a bounded, append-only, canonical streaming log of WSC `NodeRow`, `EdgeRow`, and `AttRow` deltas. Trace storage is chunked. Sparse selector columns may be encoded as compressed bitsets, but they are derived indexes, not the source of truth. Prover-specific rectangular traces are downstream projections of the delta log.
 
 ## Git Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ Materialized graphs are optional readings.
 Continuum is the protocol for lawful causal-history exchange.
 ```
 
+## Trace Architecture Principle
+
+> Echo execution traces are emitted as a bounded, append-only, canonical stream of WSC-derived trace events. Trace storage is chunked. Sparse selector columns may be encoded as compressed bitsets. Dense witness data must remain in canonical dense columns or WSC segments. Prover-specific rectangular traces are projections, not the source of truth.
+
 ## Git Rules
 
 - **NEVER** amend commits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ### Added
 
+- `warp-core` now exposes a recovered WAL evidence segment catalog derived from
+  `RecoveryScanReport`, with a non-authoritative live cache in
+  `TrustedRuntimeWal` that marks cache-update failures as rebuild posture
+  without turning committed WAL transactions into failures.
+
 - `warp-core` now exposes a narrow Edict `echo.span-ir/v1` Target IR fixture
   bridge that accepts strict lowercase digest-locked pre-step
   `continueObstructed` requirements, evaluates deterministic basis freshness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -855,7 +855,9 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
 - `warp-core` recovered filesystem WAL ACK paths now rebuild the live evidence
   catalog before returning recovered success, live catalog-update failures record
   the last commit where the catalog was actually fresh, and committed evidence
-  segments now populate `coverings_by_range` for their exact LSN range.
+  segments now populate `coverings_by_range` for their exact LSN range. Rebuilt
+  evidence catalogs now reject malformed commit/frame evidence before admitting
+  `ExactCommittedWal` segments.
 - `Cargo.lock` now pins `crossbeam-epoch` to `0.9.20`, clearing
   `RUSTSEC-2026-0204` for the benchmark-only `rayon` dependency path.
 - `warp-core` evolving braid logs now reject unchecked incremental mutations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,6 +852,10 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
 
 ### Fixed
 
+- `warp-core` recovered filesystem WAL ACK paths now rebuild the live evidence
+  catalog before returning recovered success, live catalog-update failures record
+  the last commit where the catalog was actually fresh, and committed evidence
+  segments now populate `coverings_by_range` for their exact LSN range.
 - `warp-core` evolving braid logs now reject unchecked incremental mutations:
   `Braid::apply` returns typed lifecycle errors, rejects duplicate member
   weaving and mixed revealed/sealed membership, refuses empty-frontier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -856,6 +856,8 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   catalog before returning recovered success, live catalog-update failures record
   the last commit where the catalog was actually fresh, and committed evidence
   segments now populate `coverings_by_range` for their exact LSN range.
+- `Cargo.lock` now pins `crossbeam-epoch` to `0.9.20`, clearing
+  `RUSTSEC-2026-0204` for the benchmark-only `rayon` dependency path.
 - `warp-core` evolving braid logs now reject unchecked incremental mutations:
   `Braid::apply` returns typed lifecycle errors, rejects duplicate member
   weaving and mixed revealed/sealed membership, refuses empty-frontier

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "echo-trace"
+version = "0.1.0"
+
+[[package]]
 name = "echo-ttd"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ members = [
     "crates/ttd-protocol-rs",
     "crates/echo-ttd",
     "crates/method",
-    "xtask"
-, "crates/echo-trace"]
+    "xtask",
+    "crates/echo-trace",
+]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
     "crates/echo-ttd",
     "crates/method",
     "xtask"
-]
+, "crates/echo-trace"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/echo-trace/Cargo.toml
+++ b/crates/echo-trace/Cargo.toml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
 [package]
 name = "echo-trace"
 version = "0.1.0"
@@ -5,6 +7,10 @@ edition = "2024"
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+description = "Canonical causal trace boundary for Echo graph delta streams"
+readme = "README.md"
+keywords = ["echo", "trace", "causal", "graph"]
+categories = ["data-structures", "development-tools"]
 
 [dependencies]
 

--- a/crates/echo-trace/Cargo.toml
+++ b/crates/echo-trace/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "echo-trace"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/echo-trace/README.md
+++ b/crates/echo-trace/README.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# echo-trace
+
+Canonical causal trace boundary for Echo graph delta streams.
+
+`echo-trace` defines the small trait and data shapes used by trace sinks that
+consume ordered graph deltas, seal deterministic chunks, and return receipts.
+The crate is intentionally transport-neutral: it names the boundary between a
+causal producer and a trace sink without owning storage, replay, or rendering.

--- a/crates/echo-trace/src/lib.rs
+++ b/crates/echo-trace/src/lib.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0
+
+//! Echo Trace
+//! 
+//! Trace owns observation. It provides the bounded, append-only, canonical stream
+//! of WSC-derived trace events.
+
+/// Represents an execution tick identifier.
+pub type TickId = u64;
+
+/// Represents a sparse boolean control column identifier.
+pub type SelectorId = u32;
+
+/// A placeholder for the canonical WSC delta event.
+pub struct CanonicalWscDelta {
+    // To be implemented.
+}
+
+/// Metadata describing an execution trace run.
+pub struct TraceRunMeta {
+    /// The starting tick of the execution trace run.
+    pub start_tick: TickId,
+    // Add additional metadata (e.g. root hash) as needed.
+}
+
+/// A receipt for a sealed trace chunk.
+pub struct TraceChunkReceipt {
+    /// The starting tick of this chunk.
+    pub start_tick: TickId,
+    /// The total number of ticks contained in this chunk.
+    pub tick_count: u64,
+    /// The cryptographic hash of the prior chunk.
+    pub prior_chunk_hash: [u8; 32],
+    /// The cryptographic hash of the current chunk.
+    pub chunk_hash: [u8; 32],
+}
+
+/// A receipt for a completed trace run.
+pub struct TraceRunReceipt {
+    /// The total number of chunks generated in the run.
+    pub chunks: usize,
+    /// The final cryptographic hash representing the entire trace run.
+    pub final_hash: [u8; 32],
+}
+
+/// A generic error type for trace operations.
+#[derive(Debug)]
+pub enum TraceError {
+    /// An I/O error occurred while writing or reading the trace sink.
+    IoError,
+    /// The trace chunk could not be sealed.
+    SealError,
+    /// The tick recorded does not match the expected contiguous sequence.
+    TickMismatch,
+}
+
+/// The trace boundary trait.
+/// 
+/// Echo execution emits trace events into this sink. It does not care whether
+/// the sink is a human-readable JSON file, a canonical chunked stream, or a 
+/// sparse Roaring-encoded accelerator.
+pub trait TraceSink {
+    /// Start a new trace run.
+    fn begin_run(&mut self, meta: &TraceRunMeta) -> Result<(), TraceError>;
+
+    /// Begin a new execution tick.
+    fn begin_tick(&mut self, tick: TickId) -> Result<(), TraceError>;
+
+    /// Record a canonical WSC delta within the current tick.
+    fn record_wsc_delta(&mut self, delta: &CanonicalWscDelta) -> Result<(), TraceError>;
+
+    /// Record that a specific sparse selector was activated at this tick.
+    fn record_selector(&mut self, selector: SelectorId, tick: TickId) -> Result<(), TraceError>;
+
+    /// End the current execution tick.
+    fn end_tick(&mut self, tick: TickId) -> Result<(), TraceError>;
+
+    /// Seal the current chunk and return its cryptographic receipt.
+    fn seal_chunk(&mut self) -> Result<TraceChunkReceipt, TraceError>;
+
+    /// Finish the entire trace run and return the final receipt.
+    fn finish_run(&mut self) -> Result<TraceRunReceipt, TraceError>;
+}
+
+/// A baseline sink that incurs near-zero overhead and does nothing.
+pub struct NullTraceSink;
+
+impl TraceSink for NullTraceSink {
+    fn begin_run(&mut self, _meta: &TraceRunMeta) -> Result<(), TraceError> { Ok(()) }
+    fn begin_tick(&mut self, _tick: TickId) -> Result<(), TraceError> { Ok(()) }
+    fn record_wsc_delta(&mut self, _delta: &CanonicalWscDelta) -> Result<(), TraceError> { Ok(()) }
+    fn record_selector(&mut self, _selector: SelectorId, _tick: TickId) -> Result<(), TraceError> { Ok(()) }
+    fn end_tick(&mut self, _tick: TickId) -> Result<(), TraceError> { Ok(()) }
+    fn seal_chunk(&mut self) -> Result<TraceChunkReceipt, TraceError> {
+        Ok(TraceChunkReceipt {
+            start_tick: 0,
+            tick_count: 0,
+            prior_chunk_hash: [0; 32],
+            chunk_hash: [0; 32],
+        })
+    }
+    fn finish_run(&mut self) -> Result<TraceRunReceipt, TraceError> {
+        Ok(TraceRunReceipt {
+            chunks: 0,
+            final_hash: [0; 32],
+        })
+    }
+}

--- a/crates/echo-trace/src/lib.rs
+++ b/crates/echo-trace/src/lib.rs
@@ -1,10 +1,11 @@
-// SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
 
 //! Echo Trace
-//! 
+//!
 //! Graph is truth. Delta log is transport. Roaring is index.
 //! Matrix is projection. Receipt is proof.
-//! 
+//!
 //! This crate defines the canonical causal delta stream boundary.
 
 /// Represents an execution tick identifier.
@@ -70,7 +71,7 @@ pub enum TraceError {
 }
 
 /// The trace boundary trait.
-/// 
+///
 /// Consumes canonical graph deltas, bounded in chunked streams.
 pub trait TraceSink<N, E, A> {
     /// Start a new trace run.
@@ -90,8 +91,15 @@ pub trait TraceSink<N, E, A> {
 pub struct NullTraceSink;
 
 impl<N, E, A> TraceSink<N, E, A> for NullTraceSink {
-    fn begin_run(&mut self, _meta: &TraceRunMeta) -> Result<(), TraceError> { Ok(()) }
-    fn append_delta(&mut self, _delta: &CanonicalGraphDelta<'_, N, E, A>) -> Result<(), TraceError> { Ok(()) }
+    fn begin_run(&mut self, _meta: &TraceRunMeta) -> Result<(), TraceError> {
+        Ok(())
+    }
+    fn append_delta(
+        &mut self,
+        _delta: &CanonicalGraphDelta<'_, N, E, A>,
+    ) -> Result<(), TraceError> {
+        Ok(())
+    }
     fn seal_chunk(&mut self) -> Result<TraceChunkReceipt, TraceError> {
         Ok(TraceChunkReceipt {
             start_tick: 0,

--- a/crates/echo-trace/src/lib.rs
+++ b/crates/echo-trace/src/lib.rs
@@ -2,25 +2,40 @@
 
 //! Echo Trace
 //! 
-//! Trace owns observation. It provides the bounded, append-only, canonical stream
-//! of WSC-derived trace events.
+//! Graph is truth. Delta log is transport. Roaring is index.
+//! Matrix is projection. Receipt is proof.
+//! 
+//! This crate defines the canonical causal delta stream boundary.
 
 /// Represents an execution tick identifier.
 pub type TickId = u64;
 
-/// Represents a sparse boolean control column identifier.
-pub type SelectorId = u32;
+/// A digest representing a causal frontier in the WARP graph.
+pub type FrontierDigest = [u8; 32];
 
-/// A placeholder for the canonical WSC delta event.
-pub struct CanonicalWscDelta {
-    // To be implemented.
+/// The core graph delta, encapsulating the exact WSC rows appended in a tick.
+/// Parameterized over the row types to avoid circular dependencies with `warp-core`.
+pub struct CanonicalGraphDelta<'a, N, E, A> {
+    /// The tick at which this delta occurred.
+    pub tick: TickId,
+    /// The causal frontier digest before this delta.
+    pub causal_frontier_before: FrontierDigest,
+    /// The canonical NodeRows appended.
+    pub node_rows: &'a [N],
+    /// The canonical EdgeRows appended.
+    pub edge_rows: &'a [E],
+    /// The canonical AttRows appended.
+    pub att_rows: &'a [A],
+    /// The causal frontier digest after this delta.
+    pub causal_frontier_after: FrontierDigest,
 }
 
 /// Metadata describing an execution trace run.
 pub struct TraceRunMeta {
     /// The starting tick of the execution trace run.
     pub start_tick: TickId,
-    // Add additional metadata (e.g. root hash) as needed.
+    /// The root causal frontier digest.
+    pub root_frontier: FrontierDigest,
 }
 
 /// A receipt for a sealed trace chunk.
@@ -50,30 +65,19 @@ pub enum TraceError {
     IoError,
     /// The trace chunk could not be sealed.
     SealError,
-    /// The tick recorded does not match the expected contiguous sequence.
-    TickMismatch,
+    /// A causal boundary violation occurred.
+    BoundaryMismatch,
 }
 
 /// The trace boundary trait.
 /// 
-/// Echo execution emits trace events into this sink. It does not care whether
-/// the sink is a human-readable JSON file, a canonical chunked stream, or a 
-/// sparse Roaring-encoded accelerator.
-pub trait TraceSink {
+/// Consumes canonical graph deltas, bounded in chunked streams.
+pub trait TraceSink<N, E, A> {
     /// Start a new trace run.
     fn begin_run(&mut self, meta: &TraceRunMeta) -> Result<(), TraceError>;
 
-    /// Begin a new execution tick.
-    fn begin_tick(&mut self, tick: TickId) -> Result<(), TraceError>;
-
-    /// Record a canonical WSC delta within the current tick.
-    fn record_wsc_delta(&mut self, delta: &CanonicalWscDelta) -> Result<(), TraceError>;
-
-    /// Record that a specific sparse selector was activated at this tick.
-    fn record_selector(&mut self, selector: SelectorId, tick: TickId) -> Result<(), TraceError>;
-
-    /// End the current execution tick.
-    fn end_tick(&mut self, tick: TickId) -> Result<(), TraceError>;
+    /// Append a canonical graph delta to the stream.
+    fn append_delta(&mut self, delta: &CanonicalGraphDelta<'_, N, E, A>) -> Result<(), TraceError>;
 
     /// Seal the current chunk and return its cryptographic receipt.
     fn seal_chunk(&mut self) -> Result<TraceChunkReceipt, TraceError>;
@@ -85,12 +89,9 @@ pub trait TraceSink {
 /// A baseline sink that incurs near-zero overhead and does nothing.
 pub struct NullTraceSink;
 
-impl TraceSink for NullTraceSink {
+impl<N, E, A> TraceSink<N, E, A> for NullTraceSink {
     fn begin_run(&mut self, _meta: &TraceRunMeta) -> Result<(), TraceError> { Ok(()) }
-    fn begin_tick(&mut self, _tick: TickId) -> Result<(), TraceError> { Ok(()) }
-    fn record_wsc_delta(&mut self, _delta: &CanonicalWscDelta) -> Result<(), TraceError> { Ok(()) }
-    fn record_selector(&mut self, _selector: SelectorId, _tick: TickId) -> Result<(), TraceError> { Ok(()) }
-    fn end_tick(&mut self, _tick: TickId) -> Result<(), TraceError> { Ok(()) }
+    fn append_delta(&mut self, _delta: &CanonicalGraphDelta<'_, N, E, A>) -> Result<(), TraceError> { Ok(()) }
     fn seal_chunk(&mut self) -> Result<TraceChunkReceipt, TraceError> {
         Ok(TraceChunkReceipt {
             start_tick: 0,

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -4300,6 +4300,8 @@ pub enum FilesystemWalFaultTarget {
     AppendFrame,
     /// Fail the next commit flush before writing the commit marker.
     FlushCommit,
+    /// Fail after writing and syncing the next commit marker.
+    CommitMarkerSynced,
     /// Fail the next manifest publish before writing manifest material.
     PublishManifest,
 }
@@ -4310,6 +4312,7 @@ pub enum FilesystemWalFaultTarget {
 pub struct FilesystemWalFaultPlan {
     append_frame: u32,
     flush_commit: u32,
+    commit_marker_synced: u32,
     publish_manifest: u32,
 }
 
@@ -4322,16 +4325,25 @@ impl FilesystemWalFaultPlan {
             FilesystemWalFaultTarget::AppendFrame => Self {
                 append_frame: 1,
                 flush_commit: 0,
+                commit_marker_synced: 0,
                 publish_manifest: 0,
             },
             FilesystemWalFaultTarget::FlushCommit => Self {
                 append_frame: 0,
                 flush_commit: 1,
+                commit_marker_synced: 0,
+                publish_manifest: 0,
+            },
+            FilesystemWalFaultTarget::CommitMarkerSynced => Self {
+                append_frame: 0,
+                flush_commit: 0,
+                commit_marker_synced: 1,
                 publish_manifest: 0,
             },
             FilesystemWalFaultTarget::PublishManifest => Self {
                 append_frame: 0,
                 flush_commit: 0,
+                commit_marker_synced: 0,
                 publish_manifest: 1,
             },
         }
@@ -4341,6 +4353,7 @@ impl FilesystemWalFaultPlan {
         let remaining = match target {
             FilesystemWalFaultTarget::AppendFrame => &mut self.append_frame,
             FilesystemWalFaultTarget::FlushCommit => &mut self.flush_commit,
+            FilesystemWalFaultTarget::CommitMarkerSynced => &mut self.commit_marker_synced,
             FilesystemWalFaultTarget::PublishManifest => &mut self.publish_manifest,
         };
         if *remaining == 0 {
@@ -4590,6 +4603,15 @@ impl WalStorePort for FilesystemWalStore {
             FilesystemSyncBoundary::CommitFileSynced,
             transaction_id,
         ));
+        #[cfg(any(test, feature = "host_test"))]
+        if self
+            .fault_plan
+            .should_fail(FilesystemWalFaultTarget::CommitMarkerSynced)
+        {
+            return Err(WalStoreError::Io(
+                "injected filesystem WAL commit_marker_synced failure".to_owned(),
+            ));
+        }
         Ok(())
     }
 

--- a/crates/warp-core/src/causal_wal.rs
+++ b/crates/warp-core/src/causal_wal.rs
@@ -850,6 +850,14 @@ impl WalTransactionCommit {
         self.compute_digest()
     }
 
+    pub(crate) fn validate_frame_evidence(
+        &self,
+        frames: &[WalFrame],
+    ) -> Result<(), WalValidationError> {
+        validate_transaction_frames(frames, self)?;
+        validate_transaction_semantics(frames, self.transaction_kind)
+    }
+
     fn compute_digest(&self) -> Hash {
         let mut h = blake3::Hasher::new();
         h.update(WAL_COMMIT_DOMAIN);

--- a/crates/warp-core/src/evidence.rs
+++ b/crates/warp-core/src/evidence.rs
@@ -223,6 +223,13 @@ impl CausalSegmentCatalog {
                 self.base_by_transaction_id.insert(tx_id, id);
             }
             self.base_by_lsn_start.insert(segment.first_lsn, id);
+            self.coverings_by_range
+                .entry(EvidenceRangeKey {
+                    first_lsn: segment.first_lsn,
+                    last_lsn: segment.last_lsn,
+                })
+                .or_default()
+                .push(id);
         }
         self.segments_by_id.insert(id, segment);
     }
@@ -403,6 +410,34 @@ mod tests {
         assert_eq!(
             segment.affected_frontiers_root,
             tx.commit.affected_frontiers_root
+        );
+    }
+
+    #[test]
+    fn test_base_segments_populate_covering_range_index() {
+        let tx = make_test_commit(
+            WalTransactionKind::SubmissionIntake,
+            b"tx1",
+            Lsn::from_raw(7),
+        );
+        let report = RecoveryScanReport {
+            transactions: vec![tx.clone()],
+            tail_posture: RecoveryTailPosture::Clean,
+        };
+
+        let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
+        let segment = catalog.segments_by_id.values().next().unwrap();
+        let range_key = EvidenceRangeKey {
+            first_lsn: tx.commit.first_lsn,
+            last_lsn: tx.commit.last_lsn,
+        };
+
+        assert_eq!(
+            catalog
+                .coverings_by_range
+                .get(&range_key)
+                .map(Vec::as_slice),
+            Some(&[segment.id][..])
         );
     }
 

--- a/crates/warp-core/src/evidence.rs
+++ b/crates/warp-core/src/evidence.rs
@@ -1,11 +1,31 @@
 //! Evidence and catalog layer for deriving causal segments from WAL history.
 
+use std::collections::BTreeMap;
 use crate::causal_wal::{
     Lsn, RecoveryScanReport, RecoveryTailPosture, WalFrame, WalRecoveredTransaction, WalSegmentRef,
-    WalTransactionCommit, WriterEpochId,
+    WalTransactionCommit, WalTransactionId, WalTransactionKind, WriterEpochId,
 };
 use crate::wsc::WscStoreEnvelopeId;
 use blake3::Hash;
+
+/// The unique identifier of a causal evidence segment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EvidenceSegmentId(pub u64);
+
+/// The kind of segment, denoting how it was derived and what it covers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvidenceSegmentKind {
+    /// A base segment derived from a single committed WAL transaction.
+    CommittedTransaction,
+    /// A derived segment representing a sealed WAL storage segment.
+    WalStorageSegment,
+    /// A derived segment representing a checkpoint range.
+    CheckpointRange,
+    /// A derived segment representing a WSC bundle.
+    WscBundle,
+    /// A derived segment representing a ZK wormhole proof.
+    ZkWormhole,
+}
 
 /// The compaction tier of an evidence segment.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -21,6 +41,8 @@ pub enum EvidenceTier {
 /// The available posture of the material contained in an evidence segment.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpeningPosture {
+    /// Exact committed WAL representation available.
+    ExactCommittedWal,
     /// Exact raw row/patch material available.
     Exact,
     /// Exact material available via sparse index lookup.
@@ -48,34 +70,56 @@ pub struct TickRange {
     pub end: u64,
 }
 
+/// A key for querying derived segments by LSN range.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EvidenceRangeKey {
+    /// The first WAL Log Sequence Number in this segment's causal range.
+    pub first_lsn: Lsn,
+    /// The last WAL Log Sequence Number in this segment's causal range.
+    pub last_lsn: Lsn,
+}
+
 /// A derived catalog entry mapping WAL ranges to causal state or proofs.
 #[derive(Clone, Debug)]
 pub struct CausalEvidenceSegment {
+    /// The local unique identifier for this segment.
+    pub id: EvidenceSegmentId,
+    /// The kind of this segment.
+    pub kind: EvidenceSegmentKind,
     /// The writer epoch of the transactions covering this segment.
     pub writer_epoch: WriterEpochId,
     /// The first WAL Log Sequence Number in this segment's causal range.
     pub first_lsn: Lsn,
     /// The last WAL Log Sequence Number in this segment's causal range.
     pub last_lsn: Lsn,
-    /// Digest of the first transaction commit in this segment.
-    pub first_commit_digest: Hash,
-    /// Digest of the last transaction commit in this segment.
-    pub last_commit_digest: Hash,
+    /// The transaction ID if this segment maps exactly to one transaction.
+    pub transaction_id: Option<WalTransactionId>,
+    /// The transaction kind if this segment maps exactly to one transaction.
+    pub transaction_kind: Option<WalTransactionKind>,
+    /// The number of records in this segment.
+    pub record_count: u64,
+    /// The number of frames in this segment.
+    pub frame_count: u64,
+    /// The records root digest.
+    pub records_root: [u8; 32],
+    /// Digest of the previous committed transaction.
+    pub previous_committed_transaction_digest: [u8; 32],
+    /// Digest of the commit marker if this is a single transaction segment.
+    pub commit_digest: [u8; 32],
     /// The semantic tick range covered, if applicable.
     pub tick_range: Option<TickRange>,
     /// The affected frontiers root recorded by the transaction commit marker.
-    /// Used instead of full before/after boundaries to accommodate recovery posture.
-    pub affected_frontiers_root: Hash,
+    pub affected_frontiers_root: [u8; 32],
     /// References to the underlying WAL material backing this segment.
     pub wal_segment_refs: Vec<WalSegmentRef>,
     /// References to the deterministic WSC envelopes materialized for this segment.
     pub wsc_envelope_refs: Vec<WscStoreEnvelopeId>,
     /// The root digest of the sparse selector index (Roaring bitmap) for this segment.
-    pub selector_index_root: Option<Hash>,
+    pub selector_index_root: Option<[u8; 32]>,
     /// The root digest of the retained evidence material.
-    pub retained_material_root: Option<Hash>,
+    pub retained_material_root: Option<[u8; 32]>,
     /// The root of the ZK wormhole proof, if this is a Cold segment.
-    pub wormhole_proof_root: Option<Hash>,
+    pub wormhole_proof_root: Option<[u8; 32]>,
     /// The compaction tier of this segment.
     pub tier: EvidenceTier,
     /// The degree to which data within this segment can be queried.
@@ -87,6 +131,8 @@ pub struct CausalEvidenceSegment {
 pub enum EvidenceCatalogError {
     /// The provided WAL transaction was invalid or malformed.
     InvalidTransaction,
+    /// The frame count does not match the record count for the transaction.
+    FrameCountMismatch,
 }
 
 /// A lightweight borrowed view of a committed transaction and its frames.
@@ -109,8 +155,18 @@ pub trait CommittedWalObserver {
 
 /// An indexed catalog mapping ranges of causal history to their underlying evidence.
 pub struct CausalSegmentCatalog {
-    /// The ordered list of causal evidence segments.
-    pub segments: Vec<CausalEvidenceSegment>,
+    /// All segments indexed by local segment ID.
+    pub segments_by_id: BTreeMap<EvidenceSegmentId, CausalEvidenceSegment>,
+    /// Index mapping commit digest to base segment ID.
+    pub base_by_commit_digest: BTreeMap<[u8; 32], EvidenceSegmentId>,
+    /// Index mapping transaction ID to base segment ID.
+    pub base_by_transaction_id: BTreeMap<WalTransactionId, EvidenceSegmentId>,
+    /// Index mapping start LSN to base segment ID.
+    pub base_by_lsn_start: BTreeMap<Lsn, EvidenceSegmentId>,
+    /// Index mapping ranges to derived segment IDs covering that range.
+    pub coverings_by_range: BTreeMap<EvidenceRangeKey, Vec<EvidenceSegmentId>>,
+    /// Next available local segment ID.
+    next_id: u64,
 }
 
 impl CausalSegmentCatalog {
@@ -118,7 +174,12 @@ impl CausalSegmentCatalog {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            segments: Vec::new(),
+            segments_by_id: BTreeMap::new(),
+            base_by_commit_digest: BTreeMap::new(),
+            base_by_transaction_id: BTreeMap::new(),
+            base_by_lsn_start: BTreeMap::new(),
+            coverings_by_range: BTreeMap::new(),
+            next_id: 0,
         }
     }
 
@@ -144,9 +205,28 @@ impl CausalSegmentCatalog {
         })
     }
 
+    /// Inserts a base segment into the layered indexes.
+    pub fn insert_base_segment(&mut self, segment: CausalEvidenceSegment) {
+        let id = segment.id;
+        if segment.kind == EvidenceSegmentKind::CommittedTransaction {
+            self.base_by_commit_digest.insert(segment.commit_digest, id);
+            if let Some(tx_id) = segment.transaction_id {
+                self.base_by_transaction_id.insert(tx_id, id);
+            }
+            self.base_by_lsn_start.insert(segment.first_lsn, id);
+        }
+        self.segments_by_id.insert(id, segment);
+    }
+
     /// Concludes the catalog build, optionally recording truncation intent based on tail posture.
     pub fn finish(&mut self, _tail_posture: RecoveryTailPosture) -> Result<(), EvidenceCatalogError> {
         Ok(())
+    }
+    
+    fn next_id(&mut self) -> EvidenceSegmentId {
+        let id = self.next_id;
+        self.next_id += 1;
+        EvidenceSegmentId(id)
     }
 }
 
@@ -159,9 +239,40 @@ impl Default for CausalSegmentCatalog {
 impl CommittedWalObserver for CausalSegmentCatalog {
     fn observe_committed_wal(
         &mut self,
-        _view: CommittedWalView<'_>,
+        view: CommittedWalView<'_>,
     ) -> Result<(), EvidenceCatalogError> {
-        // TODO: derive evidence segments from transactions
+        let commit = view.commit;
+        let frame_count = view.frames.len() as u64;
+        
+        if frame_count != commit.record_count {
+            return Err(EvidenceCatalogError::FrameCountMismatch);
+        }
+        
+        let id = self.next_id();
+        let segment = CausalEvidenceSegment {
+            id,
+            kind: EvidenceSegmentKind::CommittedTransaction,
+            writer_epoch: commit.writer_epoch,
+            first_lsn: commit.first_lsn,
+            last_lsn: commit.last_lsn,
+            transaction_id: Some(commit.transaction_id),
+            transaction_kind: Some(commit.transaction_kind),
+            record_count: commit.record_count,
+            frame_count,
+            records_root: commit.records_root,
+            affected_frontiers_root: commit.affected_frontiers_root,
+            previous_committed_transaction_digest: commit.previous_committed_transaction_digest,
+            commit_digest: commit.commit_digest,
+            tick_range: None,
+            wal_segment_refs: Vec::new(),
+            wsc_envelope_refs: Vec::new(),
+            selector_index_root: None,
+            retained_material_root: None,
+            wormhole_proof_root: None,
+            tier: EvidenceTier::Hot,
+            opening_posture: OpeningPosture::ExactCommittedWal,
+        };
+        self.insert_base_segment(segment);
         Ok(())
     }
 }
@@ -169,50 +280,112 @@ impl CommittedWalObserver for CausalSegmentCatalog {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::causal_wal::{
-        Lsn, WalAppendAuthority, WalFrame, WalFrameHeader, WalSegmentId, WalTransactionBuilder,
-        WalTransactionId, WalTransactionKind,
-    };
+    use crate::causal_wal::Lsn;
 
-    fn make_test_commit() -> WalTransactionCommit {
-        let builder = WalTransactionBuilder::new(
-            WriterEpochId::from_hash(blake3::hash(b"test")),
-            WalSegmentId::from_raw(1),
-            Lsn::from_raw(1),
-            WalTransactionKind::SubmissionIntake,
-            WalAppendAuthority::SubmissionIntake,
-            WalTransactionId::from_hash(blake3::hash(b"tx")),
-        );
-        let commit = builder.commit(vec![]).unwrap();
-        commit.commit.clone()
+    fn make_test_commit(tx_kind: WalTransactionKind, tx_id_hash: &[u8], start_lsn: Lsn) -> WalRecoveredTransaction {
+        let commit = WalTransactionCommit {
+            writer_epoch: WriterEpochId::from_hash(*blake3::hash(b"test").as_bytes()),
+            transaction_id: WalTransactionId::from_hash(*blake3::hash(tx_id_hash).as_bytes()),
+            transaction_kind: tx_kind,
+            first_lsn: start_lsn,
+            last_lsn: start_lsn,
+            record_count: 0,
+            records_root: *blake3::hash(b"records").as_bytes(),
+            affected_frontiers_root: *blake3::hash(b"frontiers").as_bytes(),
+            previous_committed_transaction_digest: *blake3::hash(b"prev").as_bytes(),
+            durability_mode: crate::causal_wal::WalDurabilityMode::StrictFilesystem,
+            schema_version: 0,
+            commit_digest: *blake3::hash(tx_id_hash).as_bytes(),
+        };
+        WalRecoveredTransaction {
+            commit,
+            frames: vec![],
+        }
     }
 
     #[test]
     fn test_committed_transactions_become_catalog_segments() {
-        let commit = make_test_commit();
+        let tx = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
         let report = RecoveryScanReport {
-            transactions: vec![WalRecoveredTransaction {
-                commit,
-                frames: vec![],
-            }],
+            transactions: vec![tx],
             tail_posture: RecoveryTailPosture::Clean,
         };
 
         let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
-        // Since the `observe_committed_wal` is a TODO, it just succeeds without adding segments yet, 
-        // but this verifies the plumbing correctly routes the `WalRecoveredTransaction`.
-        assert!(catalog.segments.is_empty()); 
+        assert_eq!(catalog.segments_by_id.len(), 1);
+        let segment = catalog.segments_by_id.values().next().unwrap();
+        assert_eq!(segment.kind, EvidenceSegmentKind::CommittedTransaction);
+    }
+    
+    #[test]
+    fn test_multiple_transactions_produce_multiple_segments() {
+        let tx1 = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
+        let tx2 = make_test_commit(WalTransactionKind::SchedulerTick, b"tx2", Lsn::from_raw(2));
+        
+        let report = RecoveryScanReport {
+            transactions: vec![tx1.clone(), tx2.clone()],
+            tail_posture: RecoveryTailPosture::Clean,
+        };
+        
+        let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
+        assert_eq!(catalog.segments_by_id.len(), 2);
+        
+        let seg1 = catalog.base_by_commit_digest.get(&tx1.commit.commit_digest).and_then(|id| catalog.segments_by_id.get(id)).unwrap();
+        assert_eq!(seg1.transaction_kind, Some(WalTransactionKind::SubmissionIntake));
+        
+        let seg2 = catalog.base_by_commit_digest.get(&tx2.commit.commit_digest).and_then(|id| catalog.segments_by_id.get(id)).unwrap();
+        assert_eq!(seg2.transaction_kind, Some(WalTransactionKind::SchedulerTick));
+    }
+    
+    #[test]
+    fn test_base_segment_preserves_transaction_properties() {
+        let tx = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
+        let report = RecoveryScanReport {
+            transactions: vec![tx.clone()],
+            tail_posture: RecoveryTailPosture::Clean,
+        };
+        let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
+        let segment = catalog.segments_by_id.values().next().unwrap();
+        
+        // base segment preserves transaction_kind
+        assert_eq!(segment.transaction_kind, Some(tx.commit.transaction_kind));
+        // base segment lsn range equals commit.first_lsn..commit.last_lsn
+        assert_eq!(segment.first_lsn, tx.commit.first_lsn);
+        assert_eq!(segment.last_lsn, tx.commit.last_lsn);
+        // base segment records_root equals commit.records_root
+        assert_eq!(segment.records_root, tx.commit.records_root);
+        // base segment affected_frontiers_root equals commit.affected_frontiers_root
+        assert_eq!(segment.affected_frontiers_root, tx.commit.affected_frontiers_root);
     }
 
     #[test]
     fn test_uncommitted_tail_frames_do_not_become_catalog_segments() {
-        // Just setting up the RecoveryScanReport correctly models how it's handed to the catalog
         let report = RecoveryScanReport {
             transactions: vec![],
             tail_posture: RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(5)),
         };
 
         let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
-        assert!(catalog.segments.is_empty());
+        assert!(catalog.segments_by_id.is_empty());
+    }
+    
+    #[test]
+    fn test_rebuilding_catalog_yields_identical_segments() {
+        let tx1 = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
+        let tx2 = make_test_commit(WalTransactionKind::SchedulerTick, b"tx2", Lsn::from_raw(2));
+        let report = RecoveryScanReport {
+            transactions: vec![tx1, tx2],
+            tail_posture: RecoveryTailPosture::Clean,
+        };
+        
+        let catalog1 = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
+        let catalog2 = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
+        
+        assert_eq!(catalog1.segments_by_id.len(), catalog2.segments_by_id.len());
+        for (id, seg1) in &catalog1.segments_by_id {
+            let seg2 = catalog2.segments_by_id.get(id).unwrap();
+            assert_eq!(seg1.commit_digest, seg2.commit_digest);
+            assert_eq!(seg1.first_lsn, seg2.first_lsn);
+        }
     }
 }

--- a/crates/warp-core/src/evidence.rs
+++ b/crates/warp-core/src/evidence.rs
@@ -1,0 +1,132 @@
+//! Evidence and catalog layer for deriving causal segments from WAL history.
+
+use crate::causal_wal::{Lsn, WalCommittedTransaction, WalFrame, WalSegmentRef, WriterEpochId};
+use crate::wsc::WscStoreEnvelopeId;
+use blake3::Hash;
+
+/// The compaction tier of an evidence segment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvidenceTier {
+    /// Hot, uncompressed material (exact WAL/WSC representations).
+    Hot,
+    /// Warm, compressed material with derived indexes.
+    Warm,
+    /// Cold, proof-carrying wormhole.
+    Cold,
+}
+
+/// The available posture of the material contained in an evidence segment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpeningPosture {
+    /// Exact raw row/patch material available.
+    Exact,
+    /// Exact material available via sparse index lookup.
+    Indexed,
+    /// Compressed WSC material, requiring lazy open/replay.
+    CompressedButOpenable,
+    /// Proof only (ZK Wormhole), material unavailable.
+    ProofOnly,
+    /// Purged prior to a checkpoint, inherently un-openable.
+    PrunedWithCheckpoint,
+    /// Data missing unexpectedly (obstruction).
+    ObstructedMissingMaterial,
+    /// Data is corrupt and unreadable.
+    Corrupt,
+    /// Segment is known to exist but cannot be reached.
+    Unavailable,
+}
+
+/// A contiguous semantic tick range covered by an evidence segment.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TickRange {
+    /// The starting tick of the causal range.
+    pub start: u64,
+    /// The ending tick of the causal range.
+    pub end: u64,
+}
+
+/// A derived catalog entry mapping WAL ranges to causal state or proofs.
+#[derive(Clone, Debug)]
+pub struct CausalEvidenceSegment {
+    /// The writer epoch of the transactions covering this segment.
+    pub writer_epoch: WriterEpochId,
+    /// The first WAL Log Sequence Number in this segment's causal range.
+    pub first_lsn: Lsn,
+    /// The last WAL Log Sequence Number in this segment's causal range.
+    pub last_lsn: Lsn,
+    /// Digest of the first transaction commit in this segment.
+    pub first_commit_digest: Hash,
+    /// Digest of the last transaction commit in this segment.
+    pub last_commit_digest: Hash,
+    /// The semantic tick range covered, if applicable.
+    pub tick_range: Option<TickRange>,
+    /// The causal frontier root before this segment began.
+    pub frontier_before: Hash,
+    /// The causal frontier root after this segment concluded.
+    pub frontier_after: Hash,
+    /// References to the underlying WAL material backing this segment.
+    pub wal_segment_refs: Vec<WalSegmentRef>,
+    /// References to the deterministic WSC envelopes materialized for this segment.
+    pub wsc_envelope_refs: Vec<WscStoreEnvelopeId>,
+    /// The root digest of the sparse selector index (Roaring bitmap) for this segment.
+    pub selector_index_root: Option<Hash>,
+    /// The root digest of the retained evidence material.
+    pub retained_material_root: Option<Hash>,
+    /// The root of the ZK wormhole proof, if this is a Cold segment.
+    pub wormhole_proof_root: Option<Hash>,
+    /// The compaction tier of this segment.
+    pub tier: EvidenceTier,
+    /// The degree to which data within this segment can be queried.
+    pub opening_posture: OpeningPosture,
+}
+
+/// Errors occurring during the extraction or indexing of causal evidence.
+#[derive(Debug)]
+pub enum EvidenceError {
+    /// The provided WAL transaction was invalid or malformed.
+    InvalidTransaction,
+}
+
+/// Observer trait for tailing or recovering WAL transactions into higher-level evidence.
+pub trait CommittedWalObserver {
+    /// Observes a committed transaction, mutating the observer's internal state.
+    fn observe_committed_transaction(
+        &mut self,
+        tx: &WalCommittedTransaction,
+        frames: &[WalFrame],
+    ) -> Result<(), EvidenceError>;
+}
+
+/// An indexed catalog mapping ranges of causal history to their underlying evidence.
+pub struct CausalSegmentCatalog {
+    /// The ordered list of causal evidence segments.
+    pub segments: Vec<CausalEvidenceSegment>,
+}
+
+impl CausalSegmentCatalog {
+    /// Creates a new, empty causal segment catalog.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            segments: Vec::new(),
+        }
+    }
+}
+
+impl Default for CausalSegmentCatalog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommittedWalObserver for CausalSegmentCatalog {
+    fn observe_committed_transaction(
+        &mut self,
+        _tx: &WalCommittedTransaction,
+        _frames: &[WalFrame],
+    ) -> Result<(), EvidenceError> {
+        // Build initial catalog from recovered WAL.
+        // Implementation will tail transactions and derive Evidence segments.
+        Ok(())
+    }
+}

--- a/crates/warp-core/src/evidence.rs
+++ b/crates/warp-core/src/evidence.rs
@@ -1,12 +1,11 @@
 //! Evidence and catalog layer for deriving causal segments from WAL history.
 
-use std::collections::BTreeMap;
 use crate::causal_wal::{
     Lsn, RecoveryScanReport, RecoveryTailPosture, WalFrame, WalRecoveredTransaction, WalSegmentRef,
     WalTransactionCommit, WalTransactionId, WalTransactionKind, WriterEpochId,
 };
 use crate::wsc::WscStoreEnvelopeId;
-use blake3::Hash;
+use std::collections::BTreeMap;
 
 /// The unique identifier of a causal evidence segment.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -127,12 +126,19 @@ pub struct CausalEvidenceSegment {
 }
 
 /// Errors occurring during the extraction or indexing of causal evidence.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum EvidenceCatalogError {
     /// The provided WAL transaction was invalid or malformed.
+    #[error("invalid WAL transaction evidence")]
     InvalidTransaction,
-    /// The frame count does not match the record count for the transaction.
-    FrameCountMismatch,
+    /// A frame count mismatch occurred.
+    #[error("frame count mismatch: expected {expected}, observed {observed}")]
+    FrameCountMismatch {
+        /// The expected number of frames.
+        expected: u64,
+        /// The observed number of frames.
+        observed: usize,
+    },
 }
 
 /// A lightweight borrowed view of a committed transaction and its frames.
@@ -154,6 +160,7 @@ pub trait CommittedWalObserver {
 }
 
 /// An indexed catalog mapping ranges of causal history to their underlying evidence.
+#[derive(Clone, Debug)]
 pub struct CausalSegmentCatalog {
     /// All segments indexed by local segment ID.
     pub segments_by_id: BTreeMap<EvidenceSegmentId, CausalEvidenceSegment>,
@@ -219,10 +226,13 @@ impl CausalSegmentCatalog {
     }
 
     /// Concludes the catalog build, optionally recording truncation intent based on tail posture.
-    pub fn finish(&mut self, _tail_posture: RecoveryTailPosture) -> Result<(), EvidenceCatalogError> {
+    pub fn finish(
+        &mut self,
+        _tail_posture: RecoveryTailPosture,
+    ) -> Result<(), EvidenceCatalogError> {
         Ok(())
     }
-    
+
     fn next_id(&mut self) -> EvidenceSegmentId {
         let id = self.next_id;
         self.next_id += 1;
@@ -243,11 +253,14 @@ impl CommittedWalObserver for CausalSegmentCatalog {
     ) -> Result<(), EvidenceCatalogError> {
         let commit = view.commit;
         let frame_count = view.frames.len() as u64;
-        
-        if frame_count != commit.record_count {
-            return Err(EvidenceCatalogError::FrameCountMismatch);
+
+        if view.commit.record_count != view.frames.len() as u64 {
+            return Err(EvidenceCatalogError::FrameCountMismatch {
+                expected: view.commit.record_count,
+                observed: view.frames.len(),
+            });
         }
-        
+
         let id = self.next_id();
         let segment = CausalEvidenceSegment {
             id,
@@ -282,7 +295,11 @@ mod tests {
     use super::*;
     use crate::causal_wal::Lsn;
 
-    fn make_test_commit(tx_kind: WalTransactionKind, tx_id_hash: &[u8], start_lsn: Lsn) -> WalRecoveredTransaction {
+    fn make_test_commit(
+        tx_kind: WalTransactionKind,
+        tx_id_hash: &[u8],
+        start_lsn: Lsn,
+    ) -> WalRecoveredTransaction {
         let commit = WalTransactionCommit {
             writer_epoch: WriterEpochId::from_hash(*blake3::hash(b"test").as_bytes()),
             transaction_id: WalTransactionId::from_hash(*blake3::hash(tx_id_hash).as_bytes()),
@@ -305,7 +322,11 @@ mod tests {
 
     #[test]
     fn test_committed_transactions_become_catalog_segments() {
-        let tx = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
+        let tx = make_test_commit(
+            WalTransactionKind::SubmissionIntake,
+            b"tx1",
+            Lsn::from_raw(1),
+        );
         let report = RecoveryScanReport {
             transactions: vec![tx],
             tail_posture: RecoveryTailPosture::Clean,
@@ -316,37 +337,59 @@ mod tests {
         let segment = catalog.segments_by_id.values().next().unwrap();
         assert_eq!(segment.kind, EvidenceSegmentKind::CommittedTransaction);
     }
-    
+
     #[test]
     fn test_multiple_transactions_produce_multiple_segments() {
-        let tx1 = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
+        let tx1 = make_test_commit(
+            WalTransactionKind::SubmissionIntake,
+            b"tx1",
+            Lsn::from_raw(1),
+        );
         let tx2 = make_test_commit(WalTransactionKind::SchedulerTick, b"tx2", Lsn::from_raw(2));
-        
+
         let report = RecoveryScanReport {
             transactions: vec![tx1.clone(), tx2.clone()],
             tail_posture: RecoveryTailPosture::Clean,
         };
-        
+
         let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
         assert_eq!(catalog.segments_by_id.len(), 2);
-        
-        let seg1 = catalog.base_by_commit_digest.get(&tx1.commit.commit_digest).and_then(|id| catalog.segments_by_id.get(id)).unwrap();
-        assert_eq!(seg1.transaction_kind, Some(WalTransactionKind::SubmissionIntake));
-        
-        let seg2 = catalog.base_by_commit_digest.get(&tx2.commit.commit_digest).and_then(|id| catalog.segments_by_id.get(id)).unwrap();
-        assert_eq!(seg2.transaction_kind, Some(WalTransactionKind::SchedulerTick));
+
+        let seg1 = catalog
+            .base_by_commit_digest
+            .get(&tx1.commit.commit_digest)
+            .and_then(|id| catalog.segments_by_id.get(id))
+            .unwrap();
+        assert_eq!(
+            seg1.transaction_kind,
+            Some(WalTransactionKind::SubmissionIntake)
+        );
+
+        let seg2 = catalog
+            .base_by_commit_digest
+            .get(&tx2.commit.commit_digest)
+            .and_then(|id| catalog.segments_by_id.get(id))
+            .unwrap();
+        assert_eq!(
+            seg2.transaction_kind,
+            Some(WalTransactionKind::SchedulerTick)
+        );
     }
-    
+
     #[test]
     fn test_base_segment_preserves_transaction_properties() {
-        let tx = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
+        let tx = make_test_commit(
+            WalTransactionKind::SubmissionIntake,
+            b"tx1",
+            Lsn::from_raw(1),
+        );
         let report = RecoveryScanReport {
             transactions: vec![tx.clone()],
             tail_posture: RecoveryTailPosture::Clean,
         };
         let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
         let segment = catalog.segments_by_id.values().next().unwrap();
-        
+
         // base segment preserves transaction_kind
         assert_eq!(segment.transaction_kind, Some(tx.commit.transaction_kind));
         // base segment lsn range equals commit.first_lsn..commit.last_lsn
@@ -355,7 +398,10 @@ mod tests {
         // base segment records_root equals commit.records_root
         assert_eq!(segment.records_root, tx.commit.records_root);
         // base segment affected_frontiers_root equals commit.affected_frontiers_root
-        assert_eq!(segment.affected_frontiers_root, tx.commit.affected_frontiers_root);
+        assert_eq!(
+            segment.affected_frontiers_root,
+            tx.commit.affected_frontiers_root
+        );
     }
 
     #[test]
@@ -368,19 +414,23 @@ mod tests {
         let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
         assert!(catalog.segments_by_id.is_empty());
     }
-    
+
     #[test]
     fn test_rebuilding_catalog_yields_identical_segments() {
-        let tx1 = make_test_commit(WalTransactionKind::SubmissionIntake, b"tx1", Lsn::from_raw(1));
+        let tx1 = make_test_commit(
+            WalTransactionKind::SubmissionIntake,
+            b"tx1",
+            Lsn::from_raw(1),
+        );
         let tx2 = make_test_commit(WalTransactionKind::SchedulerTick, b"tx2", Lsn::from_raw(2));
         let report = RecoveryScanReport {
             transactions: vec![tx1, tx2],
             tail_posture: RecoveryTailPosture::Clean,
         };
-        
+
         let catalog1 = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
         let catalog2 = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
-        
+
         assert_eq!(catalog1.segments_by_id.len(), catalog2.segments_by_id.len());
         for (id, seg1) in &catalog1.segments_by_id {
             let seg2 = catalog2.segments_by_id.get(id).unwrap();

--- a/crates/warp-core/src/evidence.rs
+++ b/crates/warp-core/src/evidence.rs
@@ -1,6 +1,9 @@
 //! Evidence and catalog layer for deriving causal segments from WAL history.
 
-use crate::causal_wal::{Lsn, WalCommittedTransaction, WalFrame, WalSegmentRef, WriterEpochId};
+use crate::causal_wal::{
+    Lsn, RecoveryScanReport, RecoveryTailPosture, WalFrame, WalRecoveredTransaction, WalSegmentRef,
+    WalTransactionCommit, WriterEpochId,
+};
 use crate::wsc::WscStoreEnvelopeId;
 use blake3::Hash;
 
@@ -60,10 +63,9 @@ pub struct CausalEvidenceSegment {
     pub last_commit_digest: Hash,
     /// The semantic tick range covered, if applicable.
     pub tick_range: Option<TickRange>,
-    /// The causal frontier root before this segment began.
-    pub frontier_before: Hash,
-    /// The causal frontier root after this segment concluded.
-    pub frontier_after: Hash,
+    /// The affected frontiers root recorded by the transaction commit marker.
+    /// Used instead of full before/after boundaries to accommodate recovery posture.
+    pub affected_frontiers_root: Hash,
     /// References to the underlying WAL material backing this segment.
     pub wal_segment_refs: Vec<WalSegmentRef>,
     /// References to the deterministic WSC envelopes materialized for this segment.
@@ -82,19 +84,27 @@ pub struct CausalEvidenceSegment {
 
 /// Errors occurring during the extraction or indexing of causal evidence.
 #[derive(Debug)]
-pub enum EvidenceError {
+pub enum EvidenceCatalogError {
     /// The provided WAL transaction was invalid or malformed.
     InvalidTransaction,
 }
 
-/// Observer trait for tailing or recovering WAL transactions into higher-level evidence.
+/// A lightweight borrowed view of a committed transaction and its frames.
+/// Works for both live `WalCommittedTransaction` and `WalRecoveredTransaction`.
+pub struct CommittedWalView<'a> {
+    /// The transaction commit marker.
+    pub commit: &'a WalTransactionCommit,
+    /// The transaction frames.
+    pub frames: &'a [WalFrame],
+}
+
+/// Observer trait for tailing WAL transactions into higher-level evidence.
 pub trait CommittedWalObserver {
     /// Observes a committed transaction, mutating the observer's internal state.
-    fn observe_committed_transaction(
+    fn observe_committed_wal(
         &mut self,
-        tx: &WalCommittedTransaction,
-        frames: &[WalFrame],
-    ) -> Result<(), EvidenceError>;
+        view: CommittedWalView<'_>,
+    ) -> Result<(), EvidenceCatalogError>;
 }
 
 /// An indexed catalog mapping ranges of causal history to their underlying evidence.
@@ -111,6 +121,33 @@ impl CausalSegmentCatalog {
             segments: Vec::new(),
         }
     }
+
+    /// Rebuilds a complete `CausalSegmentCatalog` from a recovery scan report.
+    /// This is a read-only projection over committed evidence that does not invoke live side effects.
+    pub fn from_recovery_scan(report: &RecoveryScanReport) -> Result<Self, EvidenceCatalogError> {
+        let mut catalog = Self::new();
+        for tx in &report.transactions {
+            catalog.observe_recovered_transaction(tx)?;
+        }
+        catalog.finish(report.tail_posture)?;
+        Ok(catalog)
+    }
+
+    /// Observes a single recovered transaction.
+    pub fn observe_recovered_transaction(
+        &mut self,
+        tx: &WalRecoveredTransaction,
+    ) -> Result<(), EvidenceCatalogError> {
+        self.observe_committed_wal(CommittedWalView {
+            commit: &tx.commit,
+            frames: &tx.frames,
+        })
+    }
+
+    /// Concludes the catalog build, optionally recording truncation intent based on tail posture.
+    pub fn finish(&mut self, _tail_posture: RecoveryTailPosture) -> Result<(), EvidenceCatalogError> {
+        Ok(())
+    }
 }
 
 impl Default for CausalSegmentCatalog {
@@ -120,13 +157,62 @@ impl Default for CausalSegmentCatalog {
 }
 
 impl CommittedWalObserver for CausalSegmentCatalog {
-    fn observe_committed_transaction(
+    fn observe_committed_wal(
         &mut self,
-        _tx: &WalCommittedTransaction,
-        _frames: &[WalFrame],
-    ) -> Result<(), EvidenceError> {
-        // Build initial catalog from recovered WAL.
-        // Implementation will tail transactions and derive Evidence segments.
+        _view: CommittedWalView<'_>,
+    ) -> Result<(), EvidenceCatalogError> {
+        // TODO: derive evidence segments from transactions
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::causal_wal::{
+        Lsn, WalAppendAuthority, WalFrame, WalFrameHeader, WalSegmentId, WalTransactionBuilder,
+        WalTransactionId, WalTransactionKind,
+    };
+
+    fn make_test_commit() -> WalTransactionCommit {
+        let builder = WalTransactionBuilder::new(
+            WriterEpochId::from_hash(blake3::hash(b"test")),
+            WalSegmentId::from_raw(1),
+            Lsn::from_raw(1),
+            WalTransactionKind::SubmissionIntake,
+            WalAppendAuthority::SubmissionIntake,
+            WalTransactionId::from_hash(blake3::hash(b"tx")),
+        );
+        let commit = builder.commit(vec![]).unwrap();
+        commit.commit.clone()
+    }
+
+    #[test]
+    fn test_committed_transactions_become_catalog_segments() {
+        let commit = make_test_commit();
+        let report = RecoveryScanReport {
+            transactions: vec![WalRecoveredTransaction {
+                commit,
+                frames: vec![],
+            }],
+            tail_posture: RecoveryTailPosture::Clean,
+        };
+
+        let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
+        // Since the `observe_committed_wal` is a TODO, it just succeeds without adding segments yet, 
+        // but this verifies the plumbing correctly routes the `WalRecoveredTransaction`.
+        assert!(catalog.segments.is_empty()); 
+    }
+
+    #[test]
+    fn test_uncommitted_tail_frames_do_not_become_catalog_segments() {
+        // Just setting up the RecoveryScanReport correctly models how it's handed to the catalog
+        let report = RecoveryScanReport {
+            transactions: vec![],
+            tail_posture: RecoveryTailPosture::WouldTruncateAfter(Lsn::from_raw(5)),
+        };
+
+        let catalog = CausalSegmentCatalog::from_recovery_scan(&report).unwrap();
+        assert!(catalog.segments.is_empty());
     }
 }

--- a/crates/warp-core/src/evidence.rs
+++ b/crates/warp-core/src/evidence.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
 //! Evidence and catalog layer for deriving causal segments from WAL history.
 
 use crate::causal_wal::{

--- a/crates/warp-core/src/evidence.rs
+++ b/crates/warp-core/src/evidence.rs
@@ -269,6 +269,9 @@ impl CommittedWalObserver for CausalSegmentCatalog {
                 observed: view.frames.len(),
             });
         }
+        commit
+            .validate_frame_evidence(view.frames)
+            .map_err(|_| EvidenceCatalogError::InvalidTransaction)?;
 
         let id = self.next_id();
         let segment = CausalEvidenceSegment {
@@ -302,30 +305,89 @@ impl CommittedWalObserver for CausalSegmentCatalog {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::causal_wal::Lsn;
+    use crate::causal_wal::{
+        AffectedFrontier, AffectedFrontierKind, PayloadCodecId, PayloadSchemaId,
+        WalAppendAuthority, WalDurabilityMode, WalRecordKind, WalSegmentId, WalTransactionBuilder,
+    };
+    use crate::{causal_wal::Lsn, Hash};
+
+    fn test_hash(label: &[u8]) -> Hash {
+        *blake3::hash(label).as_bytes()
+    }
+
+    fn test_wal_shape(
+        tx_kind: WalTransactionKind,
+    ) -> (WalAppendAuthority, WalRecordKind, AffectedFrontierKind) {
+        match tx_kind {
+            WalTransactionKind::SubmissionIntake => (
+                WalAppendAuthority::SubmissionIntake,
+                WalRecordKind::SubmissionAcceptedRecorded,
+                AffectedFrontierKind::SubmissionQueue,
+            ),
+            WalTransactionKind::SchedulerTick => (
+                WalAppendAuthority::TrustedScheduler,
+                WalRecordKind::TickReceiptRecorded,
+                AffectedFrontierKind::ReceiptIndex,
+            ),
+            WalTransactionKind::RuntimePosture => (
+                WalAppendAuthority::RuntimeControl,
+                WalRecordKind::TrustedRuntimeControlRecorded,
+                AffectedFrontierKind::RuntimeControl,
+            ),
+            WalTransactionKind::Checkpoint => (
+                WalAppendAuthority::Recovery,
+                WalRecordKind::CheckpointPublicationRecorded,
+                AffectedFrontierKind::CheckpointIndex,
+            ),
+            WalTransactionKind::MaterializationOutbox => (
+                WalAppendAuthority::TrustedScheduler,
+                WalRecordKind::MaterializationIntentRecorded,
+                AffectedFrontierKind::ReceiptIndex,
+            ),
+            WalTransactionKind::TopologyIntent => (
+                WalAppendAuthority::TrustedScheduler,
+                WalRecordKind::TopologyStrandForkRecorded,
+                AffectedFrontierKind::TopologyIndex,
+            ),
+        }
+    }
 
     fn make_test_commit(
         tx_kind: WalTransactionKind,
         tx_id_hash: &[u8],
         start_lsn: Lsn,
     ) -> WalRecoveredTransaction {
-        let commit = WalTransactionCommit {
-            writer_epoch: WriterEpochId::from_hash(*blake3::hash(b"test").as_bytes()),
-            transaction_id: WalTransactionId::from_hash(*blake3::hash(tx_id_hash).as_bytes()),
-            transaction_kind: tx_kind,
-            first_lsn: start_lsn,
-            last_lsn: start_lsn,
-            record_count: 0,
-            records_root: *blake3::hash(b"records").as_bytes(),
-            affected_frontiers_root: *blake3::hash(b"frontiers").as_bytes(),
-            previous_committed_transaction_digest: *blake3::hash(b"prev").as_bytes(),
-            durability_mode: crate::causal_wal::WalDurabilityMode::StrictFilesystem,
-            schema_version: 0,
-            commit_digest: *blake3::hash(tx_id_hash).as_bytes(),
-        };
+        let (authority, record_kind, frontier_kind) = test_wal_shape(tx_kind);
+        let transaction_id = WalTransactionId::from_hash(test_hash(tx_id_hash));
+        let mut builder = WalTransactionBuilder::new(
+            WriterEpochId::from_hash(test_hash(b"test-writer-epoch")),
+            WalSegmentId::from_raw(1),
+            transaction_id,
+            tx_kind,
+            authority,
+            start_lsn,
+            test_hash(b"previous-frame"),
+            test_hash(b"previous-commit"),
+            WalDurabilityMode::StrictFilesystem,
+            PayloadCodecId::from_hash(test_hash(b"payload-codec")),
+            PayloadSchemaId::from_hash(test_hash(b"payload-schema")),
+            1,
+            1,
+            test_hash(b"digest-domain"),
+        );
+        builder
+            .push_record(record_kind, tx_id_hash.to_vec())
+            .expect("test WAL record should build");
+        let transaction = builder
+            .commit(vec![AffectedFrontier {
+                kind: frontier_kind,
+                before_digest: test_hash(b"frontier-before"),
+                after_digest: test_hash(b"frontier-after"),
+            }])
+            .expect("test WAL transaction should validate");
         WalRecoveredTransaction {
-            commit,
-            frames: vec![],
+            commit: transaction.commit,
+            frames: transaction.frames,
         }
     }
 
@@ -439,6 +501,25 @@ mod tests {
                 .map(Vec::as_slice),
             Some(&[segment.id][..])
         );
+    }
+
+    #[test]
+    fn test_malformed_recovered_transaction_is_rejected() {
+        let mut tx = make_test_commit(
+            WalTransactionKind::SubmissionIntake,
+            b"tx1",
+            Lsn::from_raw(7),
+        );
+        tx.commit.commit_digest = test_hash(b"forged-commit-digest");
+        let report = RecoveryScanReport {
+            transactions: vec![tx],
+            tail_posture: RecoveryTailPosture::Clean,
+        };
+
+        assert!(matches!(
+            CausalSegmentCatalog::from_recovery_scan(&report),
+            Err(EvidenceCatalogError::InvalidTransaction)
+        ));
     }
 
     #[test]

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -45,7 +45,6 @@ mod braid;
 mod braid_shell;
 mod causal_facts;
 pub mod causal_wal;
-pub mod evidence;
 mod clock;
 mod cmd;
 mod constants;
@@ -57,6 +56,7 @@ pub mod domain;
 mod dynamic_binding;
 mod edict_target_ir;
 mod engine_impl;
+pub mod evidence;
 mod footprint;
 /// Footprint enforcement guard for parallel execution.
 ///
@@ -400,8 +400,9 @@ pub use tick_patch::{
 };
 #[cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
 pub use trusted_runtime_host::{
-    TrustedRuntimeApp, TrustedRuntimeHost, TrustedRuntimeHostError, TrustedRuntimeHostRunReport,
-    TrustedRuntimeWal, TrustedRuntimeWalConfig, TrustedRuntimeWalError, TrustedRuntimeWalStoreKind,
+    EvidenceCatalogPosture, TrustedRuntimeApp, TrustedRuntimeHost, TrustedRuntimeHostError,
+    TrustedRuntimeHostRunReport, TrustedRuntimeWal, TrustedRuntimeWalConfig,
+    TrustedRuntimeWalError, TrustedRuntimeWalStoreKind,
 };
 pub use tx::TxId;
 pub use warp_state::{WarpInstance, WarpState};

--- a/crates/warp-core/src/lib.rs
+++ b/crates/warp-core/src/lib.rs
@@ -45,6 +45,7 @@ mod braid;
 mod braid_shell;
 mod causal_facts;
 pub mod causal_wal;
+pub mod evidence;
 mod clock;
 mod cmd;
 mod constants;

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -532,6 +532,8 @@ pub struct TrustedRuntimeWal {
     store: TrustedRuntimeWalStore,
     evidence_catalog: Option<crate::evidence::CausalSegmentCatalog>,
     evidence_catalog_posture: EvidenceCatalogPosture,
+    #[cfg(any(test, feature = "host_test"))]
+    fail_next_evidence_catalog_update: bool,
     writer_epoch: WriterEpochId,
     segment_id: WalSegmentId,
     next_lsn: Lsn,
@@ -602,6 +604,8 @@ impl TrustedRuntimeWal {
             runtime_state_frontier_digest: recovered_cursor.runtime_state_frontier_digest,
             evidence_catalog: Some(evidence_catalog),
             evidence_catalog_posture: EvidenceCatalogPosture::Fresh,
+            #[cfg(any(test, feature = "host_test"))]
+            fail_next_evidence_catalog_update: false,
         })
     }
 
@@ -874,13 +878,14 @@ impl TrustedRuntimeWal {
             .last_lsn
             .checked_next()
             .ok_or(WalBuildError::LsnOverflow)?;
+        let last_good_commit = self.previous_committed_transaction_digest;
         let commit = transaction.commit.clone();
         let frames = transaction.frames.clone();
         self.store.append_transaction(transaction)?;
         self.next_lsn = next_lsn;
         self.previous_frame_digest = last_frame_digest;
         self.previous_committed_transaction_digest = commit.commit_digest;
-        self.try_update_evidence_catalog_after_commit(&commit, &frames);
+        self.try_update_evidence_catalog_after_commit(&commit, &frames, last_good_commit);
         Ok(commit)
     }
 
@@ -888,14 +893,24 @@ impl TrustedRuntimeWal {
         &mut self,
         commit: &WalTransactionCommit,
         frames: &[crate::causal_wal::WalFrame],
+        last_good_commit: Hash,
     ) {
         use crate::evidence::CommittedWalObserver;
+        #[cfg(any(test, feature = "host_test"))]
+        if self.fail_next_evidence_catalog_update {
+            self.fail_next_evidence_catalog_update = false;
+            self.evidence_catalog_posture = EvidenceCatalogPosture::NeedsRebuild {
+                reason: *blake3::hash(b"catalog_update_error").as_bytes(),
+                last_good_commit,
+            };
+            return;
+        }
         if let Some(catalog) = self.evidence_catalog.as_mut() {
             let view = crate::evidence::CommittedWalView { commit, frames };
             if catalog.observe_committed_wal(view).is_err() {
                 self.evidence_catalog_posture = EvidenceCatalogPosture::NeedsRebuild {
                     reason: *blake3::hash(b"catalog_update_error").as_bytes(),
-                    last_good_commit: self.previous_committed_transaction_digest,
+                    last_good_commit,
                 };
             }
         }
@@ -1299,6 +1314,11 @@ impl TrustedRuntimeWal {
         self.next_lsn = next_lsn;
         self.previous_frame_digest = last_frame_digest;
         Ok(())
+    }
+
+    /// Forces the next live evidence catalog update to fail after WAL commit.
+    pub fn fail_next_evidence_catalog_update_for_test(&mut self) {
+        self.fail_next_evidence_catalog_update = true;
     }
 }
 

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -83,6 +83,9 @@ pub enum TrustedRuntimeWalError {
     /// WAL recovery failed while rebuilding runtime evidence.
     #[error("trusted runtime WAL recovery error: {0}")]
     Recovery(#[from] WalRecoveryError),
+    /// Evidence catalog operations failed.
+    #[error("trusted runtime evidence catalog error: {0}")]
+    EvidenceCatalog(#[from] crate::evidence::EvidenceCatalogError),
     /// Runtime outcome evidence could not be matched to the receipt correlation.
     #[error(
         "trusted runtime WAL tick outcome unavailable for submission {submission_id:?} receipt {receipt_digest:?}"
@@ -509,10 +512,26 @@ impl TrustedRuntimeHost {
     }
 }
 
+/// Represents the live cache posture of the derived evidence catalog.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvidenceCatalogPosture {
+    /// The live catalog is synchronized with committed history.
+    Fresh,
+    /// The live catalog failed to update and requires recovery rebuild.
+    NeedsRebuild {
+        /// A digest indicating the reason for the rebuild.
+        reason: Hash,
+        /// The last transaction digest where the catalog was known to be fresh.
+        last_good_commit: Hash,
+    },
+}
+
 /// Minimal trusted-runtime WAL adapter for ACK-boundary integration tests.
 #[derive(Clone, Debug)]
 pub struct TrustedRuntimeWal {
     store: TrustedRuntimeWalStore,
+    evidence_catalog: Option<crate::evidence::CausalSegmentCatalog>,
+    evidence_catalog_posture: EvidenceCatalogPosture,
     writer_epoch: WriterEpochId,
     segment_id: WalSegmentId,
     next_lsn: Lsn,
@@ -541,8 +560,9 @@ impl TrustedRuntimeWal {
     pub fn from_config(config: TrustedRuntimeWalConfig) -> Result<Self, TrustedRuntimeWalError> {
         let TrustedRuntimeWalConfig { store, next_lsn } = config;
         let mut store = TrustedRuntimeWalStore::open(store)?;
-        let recovered_cursor =
-            TrustedRuntimeWalCursor::from_recovery(&store.recover_for_writer()?)?;
+        let recovery_report = store.recover_for_writer()?;
+        let recovered_cursor = TrustedRuntimeWalCursor::from_recovery(&recovery_report)?;
+        let evidence_catalog = crate::evidence::CausalSegmentCatalog::from_recovery_scan(&recovery_report)?;
         let next_lsn = if recovered_cursor.has_committed_history {
             recovered_cursor.next_lsn
         } else {
@@ -579,6 +599,8 @@ impl TrustedRuntimeWal {
             submission_frontier_digest: recovered_cursor.submission_frontier_digest,
             receipt_frontier_digest: recovered_cursor.receipt_frontier_digest,
             runtime_state_frontier_digest: recovered_cursor.runtime_state_frontier_digest,
+            evidence_catalog: Some(evidence_catalog),
+            evidence_catalog_posture: EvidenceCatalogPosture::Fresh,
         })
     }
 
@@ -618,6 +640,15 @@ impl TrustedRuntimeWal {
             submissions,
             receipts,
         })
+    }
+
+    /// Recovers the causal segment catalog from committed WAL transactions.
+    pub fn recover_evidence_catalog_read_only(
+        &self,
+    ) -> Result<crate::evidence::CausalSegmentCatalog, TrustedRuntimeWalError> {
+        let report = self.store.recover_read_only()?;
+        crate::evidence::CausalSegmentCatalog::from_recovery_scan(&report)
+            .map_err(TrustedRuntimeWalError::EvidenceCatalog)
     }
 
     /// Returns the number of committed submission-intake transactions.
@@ -819,11 +850,31 @@ impl TrustedRuntimeWal {
             .checked_next()
             .ok_or(WalBuildError::LsnOverflow)?;
         let commit = transaction.commit.clone();
+        let frames = transaction.frames.clone();
         self.store.append_transaction(transaction)?;
         self.next_lsn = next_lsn;
         self.previous_frame_digest = last_frame_digest;
         self.previous_committed_transaction_digest = commit.commit_digest;
+        self.try_update_evidence_catalog_after_commit(&commit, &frames);
         Ok(commit)
+    }
+
+    fn try_update_evidence_catalog_after_commit(
+        &mut self,
+        commit: &WalTransactionCommit,
+        frames: &[crate::causal_wal::WalFrame],
+    ) {
+        if let Some(catalog) = self.evidence_catalog.as_mut() {
+            let view = crate::evidence::CommittedWalView { commit, frames };
+            use crate::evidence::CommittedWalObserver;
+            if catalog.observe_committed_wal(view).is_err() {
+                self.evidence_catalog_posture =
+                    EvidenceCatalogPosture::NeedsRebuild {
+                        reason: *blake3::hash(b"catalog_update_error").as_bytes(),
+                        last_good_commit: self.previous_committed_transaction_digest,
+                    };
+            }
+        }
     }
 
     fn builder(

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -562,7 +562,8 @@ impl TrustedRuntimeWal {
         let mut store = TrustedRuntimeWalStore::open(store)?;
         let recovery_report = store.recover_for_writer()?;
         let recovered_cursor = TrustedRuntimeWalCursor::from_recovery(&recovery_report)?;
-        let evidence_catalog = crate::evidence::CausalSegmentCatalog::from_recovery_scan(&recovery_report)?;
+        let evidence_catalog =
+            crate::evidence::CausalSegmentCatalog::from_recovery_scan(&recovery_report)?;
         let next_lsn = if recovered_cursor.has_committed_history {
             recovered_cursor.next_lsn
         } else {
@@ -649,6 +650,18 @@ impl TrustedRuntimeWal {
         let report = self.store.recover_read_only()?;
         crate::evidence::CausalSegmentCatalog::from_recovery_scan(&report)
             .map_err(TrustedRuntimeWalError::EvidenceCatalog)
+    }
+
+    /// Returns the live evidence catalog if it exists.
+    #[must_use]
+    pub fn evidence_catalog(&self) -> Option<&crate::evidence::CausalSegmentCatalog> {
+        self.evidence_catalog.as_ref()
+    }
+
+    /// Returns the current posture of the live evidence catalog cache.
+    #[must_use]
+    pub fn evidence_catalog_posture(&self) -> &EvidenceCatalogPosture {
+        &self.evidence_catalog_posture
     }
 
     /// Returns the number of committed submission-intake transactions.
@@ -864,15 +877,14 @@ impl TrustedRuntimeWal {
         commit: &WalTransactionCommit,
         frames: &[crate::causal_wal::WalFrame],
     ) {
+        use crate::evidence::CommittedWalObserver;
         if let Some(catalog) = self.evidence_catalog.as_mut() {
             let view = crate::evidence::CommittedWalView { commit, frames };
-            use crate::evidence::CommittedWalObserver;
             if catalog.observe_committed_wal(view).is_err() {
-                self.evidence_catalog_posture =
-                    EvidenceCatalogPosture::NeedsRebuild {
-                        reason: *blake3::hash(b"catalog_update_error").as_bytes(),
-                        last_good_commit: self.previous_committed_transaction_digest,
-                    };
+                self.evidence_catalog_posture = EvidenceCatalogPosture::NeedsRebuild {
+                    reason: *blake3::hash(b"catalog_update_error").as_bytes(),
+                    last_good_commit: self.previous_committed_transaction_digest,
+                };
             }
         }
     }

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -718,6 +718,18 @@ impl TrustedRuntimeWal {
     fn refresh_cursor_from_store_for_writer(&mut self) -> Result<(), TrustedRuntimeWalError> {
         let report = self.store.recover_for_writer()?;
         let cursor = TrustedRuntimeWalCursor::from_recovery(&report)?;
+        match crate::evidence::CausalSegmentCatalog::from_recovery_scan(&report) {
+            Ok(catalog) => {
+                self.evidence_catalog = Some(catalog);
+                self.evidence_catalog_posture = EvidenceCatalogPosture::Fresh;
+            }
+            Err(_) => {
+                self.evidence_catalog_posture = EvidenceCatalogPosture::NeedsRebuild {
+                    reason: *blake3::hash(b"catalog_recovery_rebuild_error").as_bytes(),
+                    last_good_commit: self.previous_committed_transaction_digest,
+                };
+            }
+        }
         self.next_lsn = cursor.next_lsn;
         self.previous_frame_digest = cursor.previous_frame_digest;
         self.previous_committed_transaction_digest = cursor.previous_committed_transaction_digest;

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -1578,6 +1578,49 @@ fn runtime_wal_live_evidence_catalog_matches_read_only_recovery_after_submission
 }
 
 #[test]
+fn runtime_wal_live_evidence_catalog_rebuilds_after_recovered_filesystem_ack() {
+    let wal_root = temp_runtime_wal_dir("catalog-recovered-filesystem-ack");
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_runtime_wal(
+        TrustedRuntimeWalConfig::filesystem_with_fault_plan_for_test(
+            &wal_root,
+            FilesystemWalFaultPlan::fail_next(FilesystemWalFaultTarget::CommitMarkerSynced),
+        ),
+    )
+    .expect("host should configure faulting filesystem runtime WAL adapter");
+
+    let _submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect("recoverable commit marker failure should still ACK")
+    };
+
+    let wal = host.runtime_wal().expect("runtime WAL should exist");
+    assert_eq!(
+        *wal.evidence_catalog_posture(),
+        EvidenceCatalogPosture::Fresh,
+        "recovered ACK should leave the live catalog fresh"
+    );
+
+    let live_catalog = wal.evidence_catalog().expect("live catalog should exist");
+    let recovered_catalog = wal
+        .recover_evidence_catalog_read_only()
+        .expect("read-only rebuild should succeed");
+    assert_eq!(
+        recovered_catalog.segments_by_id.len(),
+        1,
+        "recovered WAL should contain the committed submission segment"
+    );
+    assert_eq!(
+        live_catalog.segments_by_id.len(),
+        recovered_catalog.segments_by_id.len(),
+        "live catalog must include the recovered committed submission"
+    );
+}
+
+#[test]
 fn runtime_wal_live_evidence_catalog_failure_marks_needs_rebuild_without_failing_commit() {
     // This requires forcing the catalog to fail while WAL succeeds.
     // For now we just implement the stub and it will pass/fail appropriately.

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -1520,3 +1520,71 @@ fn runtime_wal_ack_recover_read_only_exposes_recovery_certificate() {
     assert!(recovery.certificate.first_lsn.is_some());
     assert!(recovery.certificate.last_lsn.is_some());
 }
+
+use warp_core::EvidenceCatalogPosture;
+
+#[test]
+fn runtime_wal_live_evidence_catalog_matches_read_only_recovery_after_submission() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_in_memory_runtime_wal()
+        .expect("runtime WAL should initialize");
+    host.register_contract_package(package())
+        .expect("host should install package");
+
+    let _submission = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_id))
+            .expect("submission acceptance should commit before ACK")
+    };
+
+    let wal = host.runtime_wal().expect("runtime WAL should exist");
+
+    // Live catalog must exist and be fresh
+    let live_catalog = wal.evidence_catalog().expect("live catalog should exist");
+    assert_eq!(
+        *wal.evidence_catalog_posture(),
+        EvidenceCatalogPosture::Fresh,
+        "live catalog should be fresh"
+    );
+
+    // Recovered catalog from pristine read-only scan
+    let recovered_catalog = wal
+        .recover_evidence_catalog_read_only()
+        .expect("rebuild should succeed");
+
+    assert_eq!(
+        live_catalog.segments_by_id.len(),
+        1,
+        "submission should produce 1 base segment"
+    );
+    assert_eq!(
+        live_catalog.segments_by_id.len(),
+        recovered_catalog.segments_by_id.len(),
+        "live catalog must match recovered catalog length"
+    );
+
+    for (id, live_seg) in &live_catalog.segments_by_id {
+        let rec_seg = recovered_catalog
+            .segments_by_id
+            .get(id)
+            .expect("recovered catalog missing segment");
+        assert_eq!(
+            live_seg.commit_digest, rec_seg.commit_digest,
+            "segment commit digest must match"
+        );
+    }
+}
+
+#[test]
+fn runtime_wal_live_evidence_catalog_failure_marks_needs_rebuild_without_failing_commit() {
+    // This requires forcing the catalog to fail while WAL succeeds.
+    // For now we just implement the stub and it will pass/fail appropriately.
+    // To cleanly test this we would need to mock the catalog or feed it bad frames,
+    // but the frame check is internal. We can inject an error if we can mutate frames,
+    // but the test is asserting the architectural property.
+    // Wait, we can't easily force an observer failure without changing TrustedRuntimeWal.
+    // Let's at least write a placeholder that compiles so we don't break the build.
+    // If it's hard to force without mocks, I'll just write a trivial test for now and we can expand.
+}

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -1622,12 +1622,49 @@ fn runtime_wal_live_evidence_catalog_rebuilds_after_recovered_filesystem_ack() {
 
 #[test]
 fn runtime_wal_live_evidence_catalog_failure_marks_needs_rebuild_without_failing_commit() {
-    // This requires forcing the catalog to fail while WAL succeeds.
-    // For now we just implement the stub and it will pass/fail appropriately.
-    // To cleanly test this we would need to mock the catalog or feed it bad frames,
-    // but the frame check is internal. We can inject an error if we can mutate frames,
-    // but the test is asserting the architectural property.
-    // Wait, we can't easily force an observer failure without changing TrustedRuntimeWal.
-    // Let's at least write a placeholder that compiles so we don't break the build.
-    // If it's hard to force without mocks, I'll just write a trivial test for now and we can expand.
+    let (runtime, worldline_a, worldline_b) = runtime_pair();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.enable_in_memory_runtime_wal()
+        .expect("runtime WAL should initialize");
+
+    let _first = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_a))
+            .expect("first submission acceptance should commit before ACK")
+    };
+    let last_good_commit = host
+        .runtime_wal()
+        .expect("runtime WAL should exist")
+        .commits()
+        .last()
+        .expect("first commit should exist")
+        .commit_digest;
+
+    let mut faulting_wal = host
+        .runtime_wal()
+        .expect("runtime WAL should exist")
+        .clone();
+    faulting_wal.fail_next_evidence_catalog_update_for_test();
+    host.replace_runtime_wal_for_test(faulting_wal);
+
+    let _second = {
+        let mut app = host.app();
+        app.submit_intent_with_runtime_wal_ack(eint_envelope(worldline_b))
+            .expect("catalog update failure should not reject committed WAL acceptance")
+    };
+
+    let wal = host.runtime_wal().expect("runtime WAL should exist");
+    assert_eq!(
+        wal.commits().len(),
+        2,
+        "WAL commit should succeed even when the derived catalog fails"
+    );
+    assert!(matches!(
+        wal.evidence_catalog_posture(),
+        EvidenceCatalogPosture::NeedsRebuild {
+            last_good_commit: observed,
+            ..
+        } if *observed == last_good_commit
+    ));
 }


### PR DESCRIPTION
## Summary

- Adds a rebuildable `CausalSegmentCatalog` over committed WAL recovery evidence, with one base evidence segment per committed WAL transaction.
- Adds a non-authoritative live catalog cache in `TrustedRuntimeWal`; cache update failures mark the catalog `NeedsRebuild` without turning successful WAL commits into failures.

## Scope

- [ ] Tests only
- [ ] Docs only
- [x] Runtime code

## Links

- Refs #521

## Checklist

- [ ] CI green (fmt, clippy, tests, rustdoc, audit/deny)
- [x] Kept PR small and focused (one thing)

## Local verification

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p warp-core --lib`
- [x] `cargo clippy -p warp-core --features "native_rule_bootstrap trusted_runtime host_test" --test trusted_runtime_host_loop_tests`
- [x] `cargo xtask test-slice runtime-wal-ack`
- [x] `cargo xtask test-slice durable-runtime-wal`

## Notes

- RED/GREEN was missed for this slice: the implementation landed before the focused witnesses were added. The added witnesses prove the current patched branch behavior, not that the tests failed before the implementation.
- The catalog is intentionally a derived read model. `RecoveryScanReport` remains the canonical rebuild seam, and live catalog updates are cache-only posture.
- No derived `WscBundle`, `CheckpointRange`, or `ZkWormhole` coverage is implemented in this PR; those segment kinds are reserved for later covering evidence.