### PR TITLE
Freeze Echo Edict provider semantic source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 
 ### Added
 
+- `echo-wesley-gen` now exposes a strict, versioned Echo Edict provider
+  semantic-source model and pure validator. The checked first-operation source
+  fixes `target.replace` authority, typed failure and obstruction schemas,
+  exhaustive source mapping, full optic profile, budget, native capability,
+  explicit semantic discharge, source-partitioned authority facts, complete
+  lawpack/target-profile resources, generated artifact roles, package ABI and
+  provider identity, and full invocation schema bindings. It deterministically
+  rejects recursive types, Edict Core ownership violations, byte-counted string
+  aliases, invalid failure identifiers, duplicate or dangling facts,
+  missing or ambiguous effect implementations, duplicate target-profile adapter
+  selectors, authority/profile/capability disagreement, self-referential
+  manifests, and incorrect generated contracts, invocation domains, or schema
+  roots while treating generated files and relocated SDL as non-authoritative.
+  Authority-facts outputs are bound to Edict's canonical ABI work in
+  `flyingrobots/edict#157` rather than defining an Echo-owned wire contract.
 - `warp-core` now exposes `RetainedEvidenceBoundaryPosture` with boundary
   layer, origin, proof strength, access, completeness, and obstruction axes so
   retained evidence refs can be projected without conflating citation, reveal

--- a/crates/echo-wesley-gen/README.md
+++ b/crates/echo-wesley-gen/README.md
@@ -17,6 +17,23 @@ The preferred input is GraphQL SDL lowered directly through the published
 fixtures and compatibility while consumers move off the historical JavaScript
 generator.
 
+Echo's external Edict provider uses a separate strict source contract:
+[`schemas/edict-provider/echo-provider-semantics-v1.json`](../../schemas/edict-provider/echo-provider-semantics-v1.json).
+`provider_semantics::parse_provider_semantic_source_v1(...)` validates explicit
+source bytes without filesystem discovery, normalizes set-like declarations,
+and rejects duplicate coordinates or dangling authority, type, failure,
+obstruction, profile, budget, capability, adapter, and schema references with
+stable error kinds. It also checks exhaustive obstruction mappings,
+bounded type closure, Edict Core alias ownership, failure identifiers, exact
+fact-domain/authority families, capability-owned write classes, explicit
+semantic discharge, and complete lawpack/target-profile/invocation/domain/root
+contracts. Every runtime effect resolves to exactly one native capability or
+direct adapter, and every lawpack adapter has a unique target-profile selector.
+Authority-facts outputs name Edict issue #157 as their canonical contract owner.
+The separately declared provider manifest pins the later package root's exact
+ABI and provider coordinate and cannot inventory itself.
+This source is not accepted through the tolerant historical `echo-ir/v1` path.
+
 ## Usage
 
 ```bash
@@ -74,3 +91,7 @@ cat ir.json | cargo run -p echo-wesley-gen -- --contract-host --out generated.rs
   requirement bytes, codec id, and digest directly from
   `OpticAdmissionRequirementsArtifact`; Echo stores them as opaque registry
   payload and does not reserialize Wesley requirement structs.
+- Edict provider lawpacks, profiles, source-partitioned authority facts,
+  generated-artifact profiles, schemas, provenance, review JSON, and the later
+  package manifest are generated projections of the checked Echo provider
+  semantic source. They are not alternate authored inputs.

--- a/crates/echo-wesley-gen/src/lib.rs
+++ b/crates/echo-wesley-gen/src/lib.rs
@@ -12,6 +12,9 @@
 //! requirement structs. Enforcement, grant validation, admission tickets,
 //! witnesses, and execution are intentionally out of scope for this adapter.
 
+/// Strict Echo-owned semantic source for generated Edict provider artifacts.
+pub mod provider_semantics;
+
 /// Imported Wesley runtime optic artifact ready for Echo registration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportedRuntimeOpticArtifact {

--- a/crates/echo-wesley-gen/src/provider_semantics.rs
+++ b/crates/echo-wesley-gen/src/provider_semantics.rs
@@ -1,0 +1,3431 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+//! Strict, deterministic semantic-source validation for the Echo Edict provider.
+//!
+//! This module is deliberately separate from the additive, tolerant Wesley IR
+//! compatibility model. Provider generation must fail closed when semantic
+//! declarations conflict or reference facts outside the explicit source graph.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Semantic-source API accepted by [`parse_provider_semantic_source_v1`].
+pub const ECHO_PROVIDER_SEMANTIC_SOURCE_API_V1: &str = "echo.edict-provider-semantics/v1";
+
+/// One strict Echo-owned semantic source for provider generation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProviderSemanticSourceV1 {
+    /// Exact semantic-source API version.
+    pub api_version: String,
+    /// Stable identity of these semantic source bytes.
+    pub coordinate: String,
+    /// Explicit artifacts that own declarations in this source graph.
+    pub authority_sources: Vec<AuthoritySourceDeclaration>,
+    /// Provider-facing type catalog.
+    pub types: Vec<SemanticTypeDeclaration>,
+    /// Write-class catalog.
+    pub write_classes: Vec<NamedSemanticFact>,
+    /// Obstruction taxonomy.
+    pub obstructions: Vec<ObstructionDeclaration>,
+    /// Semantic effect catalog.
+    pub effects: Vec<SemanticEffectDeclaration>,
+    /// Operation-profile catalog.
+    pub profiles: Vec<OperationProfileDeclaration>,
+    /// Compile-time budget catalog.
+    pub budgets: Vec<BudgetDeclaration>,
+    /// Native target capability catalog.
+    pub capabilities: Vec<TargetCapabilityDeclaration>,
+    /// Optional one-hop direct adapter catalog.
+    pub direct_adapters: Vec<DirectAdapterDeclaration>,
+    /// Provider operation catalog.
+    pub operations: Vec<ProviderOperationDeclaration>,
+    /// Digest-locked resources referenced by generated lawpack/profile manifests.
+    pub artifact_resources: Vec<ArtifactResourceDeclaration>,
+    /// Complete lawpack-manifest projection for the selected semantic closure.
+    pub lawpack_projection: LawpackProjectionDeclaration,
+    /// Complete target-profile projection for the selected target.
+    pub target_profile_projection: TargetProfileProjectionDeclaration,
+    /// Metadata artifacts generated from this source.
+    pub generated_artifacts: Vec<GeneratedArtifactDeclaration>,
+    /// Package-root provider manifest assembled after components exist.
+    pub package_manifest: PackageManifestProjectionDeclaration,
+    /// Host-owned input roles whose domains require immutable schema bindings.
+    pub invocation_inputs: Vec<InvocationInputDeclaration>,
+    /// Runtime component outputs authorized by the provider contract.
+    pub invocation_outputs: Vec<InvocationOutputDeclaration>,
+    /// Immutable schema-domain bindings for component inputs and outputs.
+    pub schema_bindings: Vec<ArtifactSchemaBindingDeclaration>,
+}
+
+/// One artifact that owns a family of semantic facts.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AuthoritySourceDeclaration {
+    /// Stable authority-source coordinate.
+    pub coordinate: String,
+    /// Kind of authored source.
+    pub kind: AuthoritySourceKind,
+    /// Repository-relative artifact locator, optionally with a fragment.
+    pub artifact: String,
+}
+
+/// Supported authority locations for provider semantic facts.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthoritySourceKind {
+    /// Echo-owned GraphQL/Wesley source.
+    Graphql,
+    /// Echo-owned non-GraphQL semantic declaration.
+    EchoSemanticDeclaration,
+    /// Echo-owned target metadata.
+    TargetMetadata,
+    /// Echo runtime implementation.
+    RuntimeImplementation,
+}
+
+/// Identity and ownership shared by every semantic fact.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SemanticFactIdentity {
+    /// Stable fact coordinate.
+    pub coordinate: String,
+    /// Canonical semantic domain for this fact.
+    pub domain: String,
+    /// Coordinate of the fact's one authoritative source artifact.
+    pub authority: String,
+}
+
+/// A fact whose complete declaration is its identity.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NamedSemanticFact {
+    /// Stable identity and authority.
+    pub identity: SemanticFactIdentity,
+}
+
+/// Edict authority classes for typed effect failures and obstructions.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthorityClass {
+    /// Source may map the failure into a typed domain obstruction.
+    DomainMappable,
+    /// Participant or admission policy owns the failure.
+    ParticipantOwned,
+    /// Integrity validation owns the failure.
+    IntegrityFault,
+    /// Resource accounting owns the failure.
+    ResourceFault,
+    /// Compiler, host, or component implementation owns the failure.
+    InternalFault,
+}
+
+/// One typed domain obstruction exported by the provider closure.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ObstructionDeclaration {
+    /// Stable identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Authority class governing the obstruction.
+    pub authority_class: AuthorityClass,
+    /// Bounded Core type coordinate for the obstruction payload.
+    pub payload_schema: String,
+}
+
+/// One provider-facing type declaration.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SemanticTypeDeclaration {
+    /// Stable identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Bounded type shape used by the first provider fixture.
+    pub shape: SemanticTypeShape,
+}
+
+/// Bounded provider-facing type shapes supported by the v1 source.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum SemanticTypeShape {
+    /// Echo-owned alias of one bounded Edict Core string type.
+    CoreStringAlias {
+        /// Maximum number of Unicode scalar values selected by the alias.
+        max_scalar_values: u64,
+        /// Edict Core string canonicalization selected by the alias.
+        canonical: CoreStringCanonicalization,
+    },
+    /// Record whose fields form a name-keyed set.
+    Record {
+        /// Record fields.
+        fields: Vec<SemanticFieldDeclaration>,
+    },
+}
+
+impl SemanticTypeShape {
+    /// Returns the canonical Edict Core type coordinate for an external alias.
+    #[must_use]
+    pub fn core_type_coordinate(&self) -> Option<String> {
+        match self {
+            Self::CoreStringAlias {
+                max_scalar_values,
+                canonical,
+            } => Some(format!(
+                "String<max={max_scalar_values},canonical={}>",
+                canonical.as_str()
+            )),
+            Self::Record { .. } => None,
+        }
+    }
+
+    /// Checks a raw Edict Core string value against this alias's scalar bound.
+    ///
+    /// Returns `None` for non-string shapes. The alpha source only admits
+    /// `raw-utf8`, so no normalization step is required before counting.
+    #[must_use]
+    pub fn accepts_raw_string(&self, value: &str) -> Option<bool> {
+        match self {
+            Self::CoreStringAlias {
+                max_scalar_values,
+                canonical: CoreStringCanonicalization::RawUtf8,
+            } => Some(
+                u64::try_from(value.chars().count()).is_ok_and(|count| count <= *max_scalar_values),
+            ),
+            Self::Record { .. } => None,
+        }
+    }
+}
+
+/// Edict Core canonicalization policies admitted by the alpha source.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum CoreStringCanonicalization {
+    /// Preserve the exact Unicode scalar sequence without normalization.
+    #[serde(rename = "raw-utf8")]
+    RawUtf8,
+}
+
+impl CoreStringCanonicalization {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::RawUtf8 => "raw-utf8",
+        }
+    }
+}
+
+/// One field in a provider-facing record type.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SemanticFieldDeclaration {
+    /// Field name.
+    pub name: String,
+    /// Referenced semantic type coordinate.
+    #[serde(rename = "type")]
+    pub type_coordinate: String,
+}
+
+/// One semantic effect and its target-independent obligations.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SemanticEffectDeclaration {
+    /// Stable identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Ordered parameter type coordinates.
+    pub parameter_types: Vec<String>,
+    /// Result type coordinate.
+    pub result_type: String,
+    /// Whether the effect is proof-only or touches runtime execution.
+    pub execution_class: ExecutionClass,
+    /// Advisory effect kind exported through the lawpack ABI.
+    pub effect_kind_hint: EffectKindHint,
+    /// Required guard kinds, treated as a set.
+    pub guard_kinds: Vec<String>,
+    /// Failure-key to obstruction mappings, treated as a key set.
+    pub failures: Vec<EffectFailureDeclaration>,
+    /// Required footprint obligation.
+    pub footprint_obligation: String,
+    /// Required cost obligation.
+    pub cost_obligation: String,
+    /// Whether the semantic effect can participate in a target guard.
+    pub guard_support: bool,
+}
+
+/// Runtime posture of a semantic effect.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExecutionClass {
+    /// The effect establishes a proof without runtime execution.
+    ProofOnly,
+    /// The effect requires runtime execution.
+    Runtime,
+}
+
+/// Closed Edict v1 effect-kind vocabulary.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum EffectKindHint {
+    /// Read existing target state.
+    Read,
+    /// Create a value that must be absent.
+    Create,
+    /// Ensure a value exists with the requested identity.
+    Ensure,
+    /// Replace a value that must be present.
+    Replace,
+    /// Delete a value that must be present.
+    Delete,
+    /// Append to target state.
+    Append,
+    /// Reduce target state.
+    Reduce,
+    /// Emit a portable semantic fact.
+    #[serde(rename = "semantic.emit")]
+    SemanticEmit,
+    /// Target- or lawpack-defined effect semantics.
+    Custom,
+}
+
+/// One failure key emitted by a semantic effect.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EffectFailureDeclaration {
+    /// Effect-local stable failure key.
+    pub key: String,
+    /// Canonical domain for the failure fact.
+    pub domain: String,
+    /// Coordinate of the failure taxonomy's authoritative source.
+    pub authority: String,
+    /// Authority class governing source mapping.
+    pub authority_class: AuthorityClass,
+    /// Bounded Core type coordinate for the failure payload.
+    pub payload_type: String,
+}
+
+/// One operation profile accepted by the provider target.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OperationProfileDeclaration {
+    /// Stable identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Source-level profile names that resolve to this canonical profile.
+    pub source_names: Vec<String>,
+    /// Allowed write-class coordinates, treated as a set.
+    pub allowed_write_classes: Vec<String>,
+    /// Supported guard kinds, treated as a set.
+    pub guard_kinds: Vec<String>,
+    /// Required atomicity posture.
+    pub atomicity: String,
+    /// Whether the target supports postcondition evaluation.
+    pub postcondition_support: bool,
+    /// Edict ABI optic template supplied by this operation profile.
+    pub optic_template: OpticTemplateDeclaration,
+    /// Target-owned operation-mode predicate coordinate.
+    pub effect_predicate: String,
+    /// Supported optic contract coordinate.
+    pub optic_contract: String,
+}
+
+/// Edict v1 optic kinds.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OpticKind {
+    /// Read-only projection.
+    Revelation,
+    /// Runtime affect followed by lawful reintegration.
+    AffectReintegration,
+}
+
+/// Edict v1 optic boundary kinds.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BoundaryKind {
+    /// Projection-only boundary.
+    Projection,
+    /// Runtime-affecting boundary.
+    Affect,
+}
+
+/// Typed aperture requirement supplied by an operation profile.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum ApertureRequirementDeclaration {
+    /// Exact target footprint ceiling.
+    FootprintCeiling {
+        /// Footprint ceiling coordinate.
+        #[serde(rename = "ref")]
+        reference: String,
+    },
+    /// Abstract semantic footprint obligation.
+    AbstractFootprintObligation {
+        /// Footprint obligation coordinate.
+        #[serde(rename = "ref")]
+        reference: String,
+    },
+}
+
+impl ApertureRequirementDeclaration {
+    fn reference(&self) -> &str {
+        match self {
+            Self::FootprintCeiling { reference }
+            | Self::AbstractFootprintObligation { reference } => reference,
+        }
+    }
+}
+
+/// Exact Edict operation-profile optic template.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OpticTemplateDeclaration {
+    /// Optic classification.
+    pub optic_kind: OpticKind,
+    /// Authority boundary classification.
+    pub boundary_kind: BoundaryKind,
+    /// Canonical support policy coordinate.
+    pub support_policy: String,
+    /// Canonical support-loss disposition coordinate.
+    pub loss_disposition: String,
+    /// Optional profile-owned basis template.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub basis_template: Option<String>,
+    /// Optional typed aperture requirement.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aperture_requirement: Option<ApertureRequirementDeclaration>,
+}
+
+/// One exact Core evaluation budget.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BudgetDeclaration {
+    /// Stable identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Maximum Core evaluation steps.
+    pub max_steps: u64,
+    /// Maximum allocated bytes.
+    pub max_allocated_bytes: u64,
+    /// Maximum output bytes.
+    pub max_output_bytes: u64,
+}
+
+/// One target-native capability exposed to lowerability and lowering.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TargetCapabilityDeclaration {
+    /// Stable target-intrinsic identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Semantic effect implemented natively by this capability.
+    pub effect: String,
+    /// Authoritative target effect kind.
+    pub effect_kind: EffectKindHint,
+    /// Authoritative target write class.
+    pub write_class: String,
+    /// Whether the target intrinsic supports guards.
+    pub guard_support: bool,
+    /// Target footprint template coordinate.
+    pub footprint_template: String,
+    /// Target cost template coordinate.
+    pub cost_template: String,
+    /// Explicit discharge of target-independent semantic obligations.
+    pub semantic_discharge: SemanticEffectDischargeDeclaration,
+    /// Whether the intrinsic can participate in an atomic guard.
+    pub can_participate_in_atomic_guard: bool,
+    /// Target profile that owns the capability.
+    pub target_profile: String,
+    /// Inner target IR domain produced by the capability's lowerer.
+    pub target_ir_domain: String,
+}
+
+/// Explicit mapping from one target capability to its semantic obligations.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SemanticEffectDischargeDeclaration {
+    /// Advisory effect-kind hint being discharged.
+    pub effect_kind_hint: EffectKindHint,
+    /// Abstract footprint obligation being discharged.
+    pub footprint_obligation: String,
+    /// Abstract cost obligation being discharged.
+    pub cost_obligation: String,
+}
+
+/// One optional one-hop direct adapter declaration.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DirectAdapterDeclaration {
+    /// Stable adapter identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Semantic effect consumed by the adapter.
+    pub consumes_effect: String,
+    /// Native capability used by the adapter.
+    pub capability: String,
+    /// Semantic effects emitted by the adapter, empty for v1 one-hop support.
+    pub emits_effects: Vec<String>,
+}
+
+/// One operation in the provider semantic closure.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProviderOperationDeclaration {
+    /// Stable operation identity and authority.
+    pub identity: SemanticFactIdentity,
+    /// Input type coordinate.
+    pub input_type: String,
+    /// Output type coordinate.
+    pub output_type: String,
+    /// Semantic effect coordinate.
+    pub effect: String,
+    /// Canonical operation-profile coordinate.
+    pub profile: String,
+    /// Budget coordinate.
+    pub budget: String,
+    /// Exhaustive source-level failure-to-obstruction mapping.
+    pub obstruction_mappings: Vec<ObstructionMappingDeclaration>,
+    /// Native or direct-adapter implementation selection.
+    pub implementation: OperationImplementation,
+}
+
+/// One source-level effect failure to domain obstruction mapping.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ObstructionMappingDeclaration {
+    /// Effect-local failure key.
+    pub failure: String,
+    /// Domain obstruction coordinate.
+    pub obstruction: String,
+}
+
+/// Implementation selected for one provider operation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum OperationImplementation {
+    /// Direct target-native capability.
+    Native {
+        /// Target capability coordinate.
+        capability: String,
+    },
+    /// Exactly one declared direct adapter.
+    DirectAdapter {
+        /// Direct adapter coordinate.
+        adapter: String,
+    },
+}
+
+/// One resource consumed or produced while generating a manifest closure.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArtifactResourceDeclaration {
+    /// Source-local role used by projection fields.
+    pub role: String,
+    /// Stable resource coordinate before its digest is known.
+    pub coordinate: String,
+    /// ABI or Echo-owned schema contract for the resource bytes.
+    pub schema_contract: String,
+    /// Whether generation emits the resource or requires it as an explicit input.
+    pub provision: ArtifactResourceProvision,
+}
+
+/// How one digest-locked manifest resource becomes available.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ArtifactResourceProvision {
+    /// The Echo provider generator emits the resource.
+    Generated,
+    /// The caller must supply and digest-lock the resource explicitly.
+    External,
+}
+
+/// Complete lawpack-manifest projection for the first provider closure.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LawpackProjectionDeclaration {
+    /// Authored source owning lawpack projection facts.
+    pub authority: String,
+    /// Generated lawpack artifact role.
+    pub artifact_role: String,
+    /// Lawpack identifier.
+    pub id: String,
+    /// Lawpack version.
+    pub version: String,
+    /// Accepted Edict Core ABI coordinates.
+    pub accepted_core_abis: Vec<String>,
+    /// Digest-locked lawpack dependency artifact roles.
+    pub dependencies: Vec<String>,
+    /// Resource role containing the lawpack export surface.
+    pub exports_resource: String,
+    /// Target adapters required by runtime semantic effects.
+    pub target_adapters: Vec<LawpackTargetAdapterDeclaration>,
+    /// Declarative or executable lawpack verifier contract.
+    pub verifier: LawpackVerifierDeclaration,
+    /// Resource role containing compatibility claims.
+    pub compatibility_resource: String,
+    /// Resource role containing the conformance corpus.
+    pub conformance_fixture_corpus_resource: String,
+}
+
+/// One target adapter emitted into the lawpack manifest.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LawpackTargetAdapterDeclaration {
+    /// Generated target-profile artifact role accepted by the adapter.
+    pub accepted_target_profile_role: String,
+    /// Resource role for the accepted inner Target IR contract.
+    pub accepted_target_ir_resource: String,
+    /// Resource role for the adapter declaration.
+    pub adapter_resource: String,
+    /// Runtime semantic effects discharged by this adapter.
+    pub effects: Vec<String>,
+}
+
+/// Lawpack verifier representation selected by the generator.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    tag = "class",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum LawpackVerifierDeclaration {
+    /// Generated declarative verifier ruleset.
+    Declarative {
+        /// Resource role containing the ruleset.
+        ruleset_resource: String,
+    },
+}
+
+/// Complete target-profile manifest projection for the first provider closure.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TargetProfileProjectionDeclaration {
+    /// Target metadata source owning profile projection facts.
+    pub authority: String,
+    /// Generated target-profile artifact role.
+    pub artifact_role: String,
+    /// Target-profile identifier.
+    pub id: String,
+    /// Target-profile version.
+    pub version: String,
+    /// Accepted Edict Core ABI coordinates.
+    pub accepted_core_abis: Vec<String>,
+    /// Namespace owning target intrinsics.
+    pub intrinsic_namespace: String,
+    /// Resource role for the intrinsic corpus.
+    pub intrinsics_resource: String,
+    /// Resource role for operation profiles.
+    pub operation_profiles_resource: String,
+    /// Resource role for footprint algebra.
+    pub footprint_algebra_resource: String,
+    /// Resource role for cost algebra.
+    pub cost_algebra_resource: String,
+    /// Resource role for the inner Target IR contract.
+    pub target_ir_resource: String,
+    /// Resource role for the target obstruction taxonomy.
+    pub obstruction_taxonomy_resource: String,
+    /// Resource role for the target verifier contract.
+    pub verifier_resource: String,
+    /// Resource role for the target lowerer contract.
+    pub lowerer_resource: String,
+    /// Explicit sandbox contract resource role.
+    pub sandbox_resource: String,
+    /// Explicit fuel-model resource role.
+    pub fuel_model_resource: String,
+    /// Resource role for contract-bundle policy.
+    pub bundle_profile_resource: String,
+    /// Generated-artifact-profile package roles.
+    pub generated_artifact_profile_roles: Vec<String>,
+    /// Resource role for canonical encoding rules.
+    pub canonical_encoding_rules_resource: String,
+    /// Reserved lawpack adapter ABI list; empty in Edict v1.
+    pub accepted_lawpack_adapter_abis: Vec<String>,
+    /// Resource role for the diagnostic ABI.
+    pub diagnostic_abi_resource: String,
+    /// Atomic application doctrine.
+    pub application_model: String,
+    /// Read-consistency doctrine.
+    pub read_consistency: String,
+    /// Guard-evaluation doctrine.
+    pub guard_evaluation: String,
+    /// Obstruction rollback doctrine.
+    pub obstruction_rollback: String,
+    /// Whether a single application may span targets.
+    pub multi_target: bool,
+    /// Whether precommit postconditions are supported.
+    pub postcondition_support: bool,
+    /// Resource role for deterministic execution policy.
+    pub deterministic_execution_resource: String,
+    /// Resource role for the target conformance corpus.
+    pub conformance_fixture_corpus_resource: String,
+}
+
+/// One metadata artifact generated from the semantic source.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GeneratedArtifactDeclaration {
+    /// Provider manifest role.
+    pub role: String,
+    /// Provider artifact kind.
+    pub kind: GeneratedArtifactKind,
+    /// Stable artifact coordinate before its generated digest is known.
+    pub coordinate: String,
+    /// Edict ABI or schema contract the generated value must satisfy.
+    pub schema_contract: String,
+    /// Source manifest projected by an authority-facts document.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority_fact_source: Option<AuthorityFactSourceDeclaration>,
+    /// Cross-repository owner of a generated document contract, when required.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_owner: Option<String>,
+}
+
+/// Package-root manifest projection assembled after components exist.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PackageManifestProjectionDeclaration {
+    /// Package-local manifest role.
+    pub role: String,
+    /// Stable manifest coordinate before its generated digest is known.
+    pub coordinate: String,
+    /// Edict provider-manifest schema contract.
+    pub schema_contract: String,
+    /// Exact frozen component world implemented by the provider.
+    pub provider_abi: String,
+    /// Digest-bound provider resource coordinate selected during assembly.
+    pub provider_coordinate: String,
+}
+
+/// Source identity bound by one generated authority-facts document.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AuthorityFactSourceDeclaration {
+    /// Edict authority-facts source class.
+    pub kind: AuthorityFactSourceKind,
+    /// Coordinate of the generated lawpack or target profile.
+    pub coordinate: String,
+}
+
+/// Source classes admitted by the Edict authority-facts v1 ABI.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthorityFactSourceKind {
+    /// Facts projected from one generated lawpack.
+    Lawpack,
+    /// Facts projected from one generated target profile.
+    TargetProfile,
+}
+
+/// Generated metadata artifact kinds used by the provider manifest.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GeneratedArtifactKind {
+    /// Edict lawpack.
+    Lawpack,
+    /// Edict target-profile manifest.
+    TargetProfile,
+    /// Edict authority-facts document.
+    AuthorityFacts,
+    /// Edict provider manifest.
+    ProviderManifest,
+    /// Non-authoritative deterministic generation review.
+    ReviewArtifact,
+    /// Profile for one provider-generated output family.
+    GeneratedArtifactProfile,
+    /// Deterministic provider-generation provenance document.
+    GenerationProvenance,
+    /// Self-contained provider artifact schema.
+    ArtifactSchema,
+}
+
+/// One host-bound artifact role supplied to a provider component.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InvocationInputDeclaration {
+    /// Stable invocation input role.
+    pub role: String,
+    /// Host routing class for the input.
+    pub kind: InvocationInputKind,
+    /// Canonical artifact digest domain.
+    pub domain: String,
+    /// Provider manifest schema role validating the domain.
+    pub schema_role: String,
+}
+
+/// Input classes represented by the first lowerer/verifier contract.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum InvocationInputKind {
+    /// Canonical Edict Core module.
+    Core,
+    /// Generated target-profile manifest.
+    TargetProfile,
+    /// Generated lawpack manifest.
+    Lawpack,
+    /// One source-partitioned authority-facts document.
+    AuthorityFacts,
+    /// Compiler-produced lowerability requirements.
+    LowerabilityFacts,
+    /// Target IR supplied to the verifier.
+    TargetIr,
+}
+
+/// One output role that a provider component may return.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InvocationOutputDeclaration {
+    /// Requested provider output role.
+    pub role: String,
+    /// WIT output authority kind.
+    pub kind: InvocationOutputKind,
+    /// Canonical returned artifact domain.
+    pub domain: String,
+    /// Provider manifest schema role that validates this domain.
+    pub schema_role: String,
+}
+
+/// Provider WIT output kinds represented by the first source closure.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum InvocationOutputKind {
+    /// Canonical target IR.
+    TargetIr,
+    /// Generated provider-owned auxiliary artifact.
+    GeneratedArtifact,
+    /// Non-authoritative review projection.
+    ReviewPayload,
+    /// Semantic verifier report.
+    VerifierReport,
+}
+
+/// One provider manifest schema-domain binding.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArtifactSchemaBindingDeclaration {
+    /// Canonical artifact domain.
+    pub domain: String,
+    /// Generated artifact role containing the schema.
+    pub schema_role: String,
+    /// Schema format accepted by the Edict provider host.
+    pub format: ArtifactSchemaFormat,
+    /// Root rule within the self-contained schema artifact.
+    pub root_rule: String,
+}
+
+/// Schema formats admitted by the Echo provider source.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ArtifactSchemaFormat {
+    /// Edict's self-contained CDDL v1 provider schema format.
+    SelfContainedCddlV1,
+}
+
+/// Opaque proof that a semantic source is internally complete and normalized.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidatedProviderSemanticSourceV1 {
+    source: ProviderSemanticSourceV1,
+}
+
+impl ValidatedProviderSemanticSourceV1 {
+    /// Returns the normalized source declaration.
+    #[must_use]
+    pub const fn source(&self) -> &ProviderSemanticSourceV1 {
+        &self.source
+    }
+}
+
+/// Stable failure categories returned by semantic-source parsing and validation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProviderSemanticSourceErrorKind {
+    /// JSON did not match the strict v1 source shape.
+    MalformedDocument,
+    /// The source named an unsupported API version.
+    UnsupportedApiVersion,
+    /// A required coordinate, domain, role, or artifact locator was empty.
+    MissingIdentity,
+    /// A semantic coordinate was declared more than once.
+    DuplicateCoordinate,
+    /// A name-keyed field, failure, role, or domain was declared more than once.
+    DuplicateKey,
+    /// A fact referenced an absent authority source.
+    UnknownAuthority,
+    /// A fact family used a domain outside its frozen Echo source contract.
+    FactDomainMismatch,
+    /// A fact family selected an authority source of the wrong kind.
+    FactAuthorityMismatch,
+    /// A type reference was absent.
+    UnknownType,
+    /// A record type graph was recursive and therefore not bounded.
+    UnboundedTypeGraph,
+    /// An Echo-owned type attempted to claim an Edict Core coordinate.
+    CoreTypeAuthorityMismatch,
+    /// A write-class reference was absent.
+    UnknownWriteClass,
+    /// A write-class coordinate was outside Edict's frozen v1 vocabulary.
+    InvalidWriteClass,
+    /// An obstruction reference was absent.
+    UnknownObstruction,
+    /// An operation obstruction mapping named an absent effect failure.
+    UnknownFailure,
+    /// An effect failure key was not an Edict v1 identifier.
+    InvalidFailureKey,
+    /// An effect reference was absent.
+    UnknownEffect,
+    /// An operation-profile reference was absent.
+    UnknownProfile,
+    /// A budget reference was absent.
+    UnknownBudget,
+    /// A native target capability reference was absent.
+    UnknownCapability,
+    /// A direct adapter reference was absent.
+    UnknownAdapter,
+    /// A schema role did not identify a generated artifact schema.
+    UnknownSchemaRole,
+    /// An invocation input or output domain had no schema binding.
+    MissingSchemaBinding,
+    /// An invocation value and domain binding selected different schema roles.
+    SchemaRoleMismatch,
+    /// A historical or relocated artifact was named as active authority.
+    NonAuthoritativeSource,
+    /// Capabilities under one target profile disagreed on the inner IR domain.
+    TargetIrDomainMismatch,
+    /// A direct adapter attempted to emit another semantic effect.
+    UnsupportedAdapterChain,
+    /// More than one native capability or adapter claimed one semantic effect.
+    AmbiguousEffectImplementation,
+    /// A runtime semantic effect had no native or direct-adapter implementation.
+    MissingEffectImplementation,
+    /// An operation selected an implementation for a different semantic effect.
+    ImplementationEffectMismatch,
+    /// An operation profile omitted its effect's write class or guard.
+    ProfileEffectMismatch,
+    /// A semantic effect cannot project to the frozen Edict v1 ABI shape.
+    UnsupportedEffectShape,
+    /// A source obstruction map was incomplete or mapped a forbidden failure.
+    ObstructionMappingMismatch,
+    /// The v1 source cannot translate non-empty failure or obstruction payloads.
+    UnsupportedObstructionPayloadMapping,
+    /// A generated artifact kind named the wrong Edict schema contract.
+    ArtifactSchemaContractMismatch,
+    /// A cross-repository artifact contract named the wrong owner.
+    ArtifactContractOwnerMismatch,
+    /// A provider manifest was included in its own package-member inventory.
+    SelfReferentialManifestInventory,
+    /// The package-root manifest projection selected the wrong v1 identity.
+    ProviderManifestProjectionMismatch,
+    /// An authority-facts artifact selected an incompatible source projection.
+    AuthorityFactProjectionMismatch,
+    /// A lawpack or target-profile projection was incomplete or contradictory.
+    ArtifactClosureMismatch,
+    /// The pending Wesley generation-provenance contract was misidentified.
+    GenerationProvenanceContractMismatch,
+    /// A WIT output kind named the wrong canonical artifact domain.
+    OutputDomainMismatch,
+    /// A provider input kind named the wrong canonical artifact domain.
+    InputDomainMismatch,
+    /// The first provider invocation-input family was missing or duplicated.
+    InvocationInputClosureMismatch,
+    /// The first provider invocation-output family was missing or duplicated.
+    InvocationOutputClosureMismatch,
+    /// A schema binding did not belong to any declared invocation value.
+    UnexpectedSchemaBinding,
+    /// A WIT output domain named the wrong schema root.
+    SchemaRootMismatch,
+}
+
+/// Structured semantic-source parsing or validation failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderSemanticSourceError {
+    kind: ProviderSemanticSourceErrorKind,
+    subject: String,
+    reference: String,
+}
+
+impl ProviderSemanticSourceError {
+    /// Returns the stable failure category.
+    #[must_use]
+    pub const fn kind(&self) -> ProviderSemanticSourceErrorKind {
+        self.kind
+    }
+
+    /// Returns the declaration or field being validated.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// Returns the conflicting, unresolved, or contract-expected value.
+    #[must_use]
+    pub fn reference(&self) -> &str {
+        &self.reference
+    }
+
+    fn new(
+        kind: ProviderSemanticSourceErrorKind,
+        subject: impl Into<String>,
+        reference: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            subject: subject.into(),
+            reference: reference.into(),
+        }
+    }
+}
+
+impl fmt::Display for ProviderSemanticSourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "provider semantic source {:?}: {} -> {}",
+            self.kind, self.subject, self.reference
+        )
+    }
+}
+
+impl std::error::Error for ProviderSemanticSourceError {}
+
+/// Parse, normalize, and validate one v1 Echo provider semantic source.
+///
+/// This function performs no source discovery or I/O. Callers must supply the
+/// exact source bytes whose authority they intend to use.
+///
+/// # Errors
+///
+/// Returns a stable structured error when the document is malformed,
+/// unsupported, incomplete, contradictory, unbounded, or ABI-incompatible.
+pub fn parse_provider_semantic_source_v1(
+    json: &str,
+) -> Result<ValidatedProviderSemanticSourceV1, ProviderSemanticSourceError> {
+    let source = serde_json::from_str::<ProviderSemanticSourceV1>(json).map_err(|_| {
+        ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::MalformedDocument,
+            "document",
+            ECHO_PROVIDER_SEMANTIC_SOURCE_API_V1,
+        )
+    })?;
+    validate_provider_semantic_source_v1(source)
+}
+
+/// Normalize and validate one already-decoded v1 semantic source.
+///
+/// # Errors
+///
+/// Returns a stable structured error when the source is incomplete,
+/// contradictory, or contains dangling references.
+pub fn validate_provider_semantic_source_v1(
+    mut source: ProviderSemanticSourceV1,
+) -> Result<ValidatedProviderSemanticSourceV1, ProviderSemanticSourceError> {
+    if source.api_version != ECHO_PROVIDER_SEMANTIC_SOURCE_API_V1 {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::UnsupportedApiVersion,
+            "apiVersion",
+            source.api_version,
+        ));
+    }
+
+    normalize_source(&mut source);
+    validate_identities(&source)?;
+    validate_authorities(&source)?;
+    validate_fact_contracts(&source)?;
+    validate_type_references(&source)?;
+    validate_obstruction_references(&source)?;
+    validate_profile_references(&source)?;
+    validate_effect_references(&source)?;
+    validate_capability_references(&source)?;
+    validate_adapter_references(&source)?;
+    validate_effect_implementation_closure(&source)?;
+    validate_operation_references(&source)?;
+    validate_generated_artifact_contracts(&source)?;
+    validate_artifact_closure(&source)?;
+    validate_invocation_schema_bindings(&source)?;
+
+    Ok(ValidatedProviderSemanticSourceV1 { source })
+}
+
+fn normalize_source(source: &mut ProviderSemanticSourceV1) {
+    source
+        .authority_sources
+        .sort_by(|left, right| left.coordinate.cmp(&right.coordinate));
+    source
+        .types
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    for declaration in &mut source.types {
+        if let SemanticTypeShape::Record { fields } = &mut declaration.shape {
+            fields.sort_by(|left, right| left.name.cmp(&right.name));
+        }
+    }
+    sort_named_facts(&mut source.write_classes);
+    source
+        .obstructions
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    source
+        .effects
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    for effect in &mut source.effects {
+        effect.guard_kinds.sort();
+        effect
+            .failures
+            .sort_by(|left, right| left.key.cmp(&right.key));
+    }
+    source
+        .profiles
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    for profile in &mut source.profiles {
+        profile.source_names.sort();
+        profile.allowed_write_classes.sort();
+        profile.guard_kinds.sort();
+    }
+    source
+        .budgets
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    source
+        .capabilities
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    source
+        .direct_adapters
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    for adapter in &mut source.direct_adapters {
+        adapter.emits_effects.sort();
+    }
+    source
+        .operations
+        .sort_by(|left, right| identity(left).cmp(identity(right)));
+    for operation in &mut source.operations {
+        operation
+            .obstruction_mappings
+            .sort_by(|left, right| left.failure.cmp(&right.failure));
+    }
+    source
+        .artifact_resources
+        .sort_by(|left, right| left.role.cmp(&right.role));
+    source.lawpack_projection.accepted_core_abis.sort();
+    source.lawpack_projection.dependencies.sort();
+    for adapter in &mut source.lawpack_projection.target_adapters {
+        adapter.effects.sort();
+    }
+    source
+        .lawpack_projection
+        .target_adapters
+        .sort_by(|left, right| {
+            left.accepted_target_profile_role
+                .cmp(&right.accepted_target_profile_role)
+                .then(
+                    left.accepted_target_ir_resource
+                        .cmp(&right.accepted_target_ir_resource),
+                )
+                .then(left.adapter_resource.cmp(&right.adapter_resource))
+                .then(left.effects.cmp(&right.effects))
+        });
+    source.target_profile_projection.accepted_core_abis.sort();
+    source
+        .target_profile_projection
+        .generated_artifact_profile_roles
+        .sort();
+    source
+        .target_profile_projection
+        .accepted_lawpack_adapter_abis
+        .sort();
+    source
+        .generated_artifacts
+        .sort_by(|left, right| left.role.cmp(&right.role));
+    source
+        .invocation_inputs
+        .sort_by(|left, right| left.role.cmp(&right.role));
+    source
+        .invocation_outputs
+        .sort_by(|left, right| left.role.cmp(&right.role));
+    source
+        .schema_bindings
+        .sort_by(|left, right| left.domain.cmp(&right.domain));
+}
+
+fn sort_named_facts(facts: &mut [NamedSemanticFact]) {
+    facts.sort_by(|left, right| identity(left).cmp(identity(right)));
+}
+
+trait HasIdentity {
+    fn identity(&self) -> &SemanticFactIdentity;
+}
+
+macro_rules! has_identity {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            impl HasIdentity for $type {
+                fn identity(&self) -> &SemanticFactIdentity {
+                    &self.identity
+                }
+            }
+        )+
+    };
+}
+
+has_identity!(
+    SemanticTypeDeclaration,
+    NamedSemanticFact,
+    ObstructionDeclaration,
+    SemanticEffectDeclaration,
+    OperationProfileDeclaration,
+    BudgetDeclaration,
+    TargetCapabilityDeclaration,
+    DirectAdapterDeclaration,
+    ProviderOperationDeclaration,
+);
+
+fn identity(value: &impl HasIdentity) -> &str {
+    &value.identity().coordinate
+}
+
+fn validate_identities(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    require_nonempty("source.coordinate", &source.coordinate)?;
+
+    let mut coordinates = vec![("source", source.coordinate.as_str())];
+    for authority in &source.authority_sources {
+        require_nonempty("authoritySources.coordinate", &authority.coordinate)?;
+        require_nonempty("authoritySources.artifact", &authority.artifact)?;
+        coordinates.push(("authoritySources", authority.coordinate.as_str()));
+    }
+    collect_fact_identities("types", &source.types, &mut coordinates)?;
+    collect_fact_identities("writeClasses", &source.write_classes, &mut coordinates)?;
+    collect_fact_identities("obstructions", &source.obstructions, &mut coordinates)?;
+    collect_fact_identities("effects", &source.effects, &mut coordinates)?;
+    collect_fact_identities("profiles", &source.profiles, &mut coordinates)?;
+    collect_fact_identities("budgets", &source.budgets, &mut coordinates)?;
+    collect_fact_identities("capabilities", &source.capabilities, &mut coordinates)?;
+    collect_fact_identities("directAdapters", &source.direct_adapters, &mut coordinates)?;
+    collect_fact_identities("operations", &source.operations, &mut coordinates)?;
+    for resource in &source.artifact_resources {
+        require_nonempty("artifactResources.role", &resource.role)?;
+        require_nonempty("artifactResources.coordinate", &resource.coordinate)?;
+        require_nonempty(
+            "artifactResources.schemaContract",
+            &resource.schema_contract,
+        )?;
+        coordinates.push(("artifactResources", resource.coordinate.as_str()));
+    }
+    for artifact in &source.generated_artifacts {
+        validate_artifact_identity("generatedArtifacts", artifact)?;
+        coordinates.push(("generatedArtifacts", artifact.coordinate.as_str()));
+    }
+    validate_package_manifest_identity(&source.package_manifest)?;
+    coordinates.push(("packageManifest", &source.package_manifest.coordinate));
+    coordinates.push((
+        "packageManifest.providerCoordinate",
+        &source.package_manifest.provider_coordinate,
+    ));
+    coordinates.sort_by(|left, right| left.1.cmp(right.1).then(left.0.cmp(right.0)));
+    if let Some(window) = coordinates
+        .windows(2)
+        .find(|window| window[0].1 == window[1].1)
+    {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::DuplicateCoordinate,
+            window[1].0,
+            window[1].1,
+        ));
+    }
+
+    ensure_unique_keys(
+        "generatedArtifacts.role",
+        source.generated_artifacts.iter().map(|item| &item.role),
+    )?;
+    ensure_unique_keys(
+        "artifactResources.role",
+        source.artifact_resources.iter().map(|item| &item.role),
+    )?;
+    ensure_unique_keys(
+        "artifactResources.coordinate",
+        source
+            .artifact_resources
+            .iter()
+            .map(|item| &item.coordinate),
+    )?;
+    let mut package_roles = source
+        .generated_artifacts
+        .iter()
+        .map(|item| &item.role)
+        .collect::<Vec<_>>();
+    package_roles.push(&source.package_manifest.role);
+    ensure_unique_keys("packageRoles", package_roles.into_iter())?;
+    ensure_unique_keys(
+        "invocationInputs.role",
+        source.invocation_inputs.iter().map(|item| &item.role),
+    )?;
+    ensure_unique_keys(
+        "invocationOutputs.role",
+        source.invocation_outputs.iter().map(|item| &item.role),
+    )?;
+    ensure_unique_keys(
+        "schemaBindings.domain",
+        source.schema_bindings.iter().map(|item| &item.domain),
+    )?;
+
+    for obstruction in &source.obstructions {
+        require_nonempty("obstructions.payloadSchema", &obstruction.payload_schema)?;
+    }
+    for effect in &source.effects {
+        require_nonempty("effects.resultType", &effect.result_type)?;
+        require_nonempty("effects.footprintObligation", &effect.footprint_obligation)?;
+        require_nonempty("effects.costObligation", &effect.cost_obligation)?;
+        for failure in &effect.failures {
+            require_nonempty("effects.failures.key", &failure.key)?;
+            require_nonempty("effects.failures.domain", &failure.domain)?;
+            require_nonempty("effects.failures.authority", &failure.authority)?;
+            require_nonempty("effects.failures.payloadType", &failure.payload_type)?;
+        }
+    }
+    for profile in &source.profiles {
+        require_nonempty("profiles.atomicity", &profile.atomicity)?;
+        require_nonempty("profiles.effectPredicate", &profile.effect_predicate)?;
+        require_nonempty("profiles.opticContract", &profile.optic_contract)?;
+        require_nonempty(
+            "profiles.opticTemplate.supportPolicy",
+            &profile.optic_template.support_policy,
+        )?;
+        require_nonempty(
+            "profiles.opticTemplate.lossDisposition",
+            &profile.optic_template.loss_disposition,
+        )?;
+        if let Some(basis) = &profile.optic_template.basis_template {
+            require_nonempty("profiles.opticTemplate.basisTemplate", basis)?;
+        }
+        if let Some(aperture) = &profile.optic_template.aperture_requirement {
+            require_nonempty(
+                "profiles.opticTemplate.apertureRequirement.ref",
+                aperture.reference(),
+            )?;
+        }
+    }
+    for capability in &source.capabilities {
+        require_nonempty("capabilities.effect", &capability.effect)?;
+        require_nonempty("capabilities.writeClass", &capability.write_class)?;
+        require_nonempty(
+            "capabilities.footprintTemplate",
+            &capability.footprint_template,
+        )?;
+        require_nonempty("capabilities.costTemplate", &capability.cost_template)?;
+        require_nonempty(
+            "capabilities.semanticDischarge.footprintObligation",
+            &capability.semantic_discharge.footprint_obligation,
+        )?;
+        require_nonempty(
+            "capabilities.semanticDischarge.costObligation",
+            &capability.semantic_discharge.cost_obligation,
+        )?;
+        require_nonempty("capabilities.targetProfile", &capability.target_profile)?;
+        require_nonempty("capabilities.targetIrDomain", &capability.target_ir_domain)?;
+    }
+    for operation in &source.operations {
+        for mapping in &operation.obstruction_mappings {
+            require_nonempty("operations.obstructionMappings.failure", &mapping.failure)?;
+            require_nonempty(
+                "operations.obstructionMappings.obstruction",
+                &mapping.obstruction,
+            )?;
+        }
+    }
+
+    for input in &source.invocation_inputs {
+        require_nonempty("invocationInputs.role", &input.role)?;
+        require_nonempty("invocationInputs.domain", &input.domain)?;
+        require_nonempty("invocationInputs.schemaRole", &input.schema_role)?;
+    }
+    for output in &source.invocation_outputs {
+        require_nonempty("invocationOutputs.role", &output.role)?;
+        require_nonempty("invocationOutputs.domain", &output.domain)?;
+        require_nonempty("invocationOutputs.schemaRole", &output.schema_role)?;
+    }
+    for binding in &source.schema_bindings {
+        require_nonempty("schemaBindings.domain", &binding.domain)?;
+        require_nonempty("schemaBindings.schemaRole", &binding.schema_role)?;
+        require_nonempty("schemaBindings.rootRule", &binding.root_rule)?;
+    }
+    validate_projection_identities(source)?;
+    Ok(())
+}
+
+fn validate_artifact_identity(
+    subject: &'static str,
+    artifact: &GeneratedArtifactDeclaration,
+) -> Result<(), ProviderSemanticSourceError> {
+    require_nonempty(subject, &artifact.role)?;
+    require_nonempty(subject, &artifact.coordinate)?;
+    require_nonempty(subject, &artifact.schema_contract)?;
+    if let Some(contract_owner) = &artifact.contract_owner {
+        require_nonempty(subject, contract_owner)?;
+    }
+    Ok(())
+}
+
+fn validate_package_manifest_identity(
+    manifest: &PackageManifestProjectionDeclaration,
+) -> Result<(), ProviderSemanticSourceError> {
+    require_nonempty("packageManifest.role", &manifest.role)?;
+    require_nonempty("packageManifest.coordinate", &manifest.coordinate)?;
+    require_nonempty("packageManifest.schemaContract", &manifest.schema_contract)?;
+    require_nonempty("packageManifest.providerAbi", &manifest.provider_abi)?;
+    require_nonempty(
+        "packageManifest.providerCoordinate",
+        &manifest.provider_coordinate,
+    )
+}
+
+fn collect_fact_identities<'a, T: HasIdentity>(
+    family: &'static str,
+    facts: &'a [T],
+    coordinates: &mut Vec<(&'static str, &'a str)>,
+) -> Result<(), ProviderSemanticSourceError> {
+    for fact in facts {
+        let identity = fact.identity();
+        require_nonempty(family, &identity.coordinate)?;
+        require_nonempty(family, &identity.domain)?;
+        require_nonempty(family, &identity.authority)?;
+        coordinates.push((family, identity.coordinate.as_str()));
+    }
+    Ok(())
+}
+
+fn require_nonempty(subject: &'static str, value: &str) -> Result<(), ProviderSemanticSourceError> {
+    if value.is_empty() {
+        Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::MissingIdentity,
+            subject,
+            value,
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_unique_keys<'a>(
+    subject: &'static str,
+    values: impl Iterator<Item = &'a String>,
+) -> Result<(), ProviderSemanticSourceError> {
+    let mut seen = BTreeSet::new();
+    for value in values {
+        if !seen.insert(value.as_str()) {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::DuplicateKey,
+                subject,
+                value,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_projection_identities(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let lawpack = &source.lawpack_projection;
+    for (field, value) in [
+        ("lawpackProjection.authority", lawpack.authority.as_str()),
+        (
+            "lawpackProjection.artifactRole",
+            lawpack.artifact_role.as_str(),
+        ),
+        ("lawpackProjection.id", lawpack.id.as_str()),
+        ("lawpackProjection.version", lawpack.version.as_str()),
+        (
+            "lawpackProjection.exportsResource",
+            lawpack.exports_resource.as_str(),
+        ),
+        (
+            "lawpackProjection.compatibilityResource",
+            lawpack.compatibility_resource.as_str(),
+        ),
+        (
+            "lawpackProjection.conformanceFixtureCorpusResource",
+            lawpack.conformance_fixture_corpus_resource.as_str(),
+        ),
+    ] {
+        require_nonempty(field, value)?;
+    }
+    ensure_unique_keys(
+        "lawpackProjection.acceptedCoreAbis",
+        lawpack.accepted_core_abis.iter(),
+    )?;
+    ensure_unique_keys(
+        "lawpackProjection.dependencies",
+        lawpack.dependencies.iter(),
+    )?;
+    ensure_unique_keys(
+        "lawpackProjection.targetAdapters.acceptedTargetProfileRole",
+        lawpack
+            .target_adapters
+            .iter()
+            .map(|adapter| &adapter.accepted_target_profile_role),
+    )?;
+    for abi in &lawpack.accepted_core_abis {
+        require_nonempty("lawpackProjection.acceptedCoreAbis", abi)?;
+    }
+    for adapter in &lawpack.target_adapters {
+        for (field, value) in [
+            (
+                "lawpackProjection.targetAdapters.acceptedTargetProfileRole",
+                adapter.accepted_target_profile_role.as_str(),
+            ),
+            (
+                "lawpackProjection.targetAdapters.acceptedTargetIrResource",
+                adapter.accepted_target_ir_resource.as_str(),
+            ),
+            (
+                "lawpackProjection.targetAdapters.adapterResource",
+                adapter.adapter_resource.as_str(),
+            ),
+        ] {
+            require_nonempty(field, value)?;
+        }
+        ensure_unique_keys(
+            "lawpackProjection.targetAdapters.effects",
+            adapter.effects.iter(),
+        )?;
+    }
+    let LawpackVerifierDeclaration::Declarative { ruleset_resource } = &lawpack.verifier;
+    require_nonempty(
+        "lawpackProjection.verifier.rulesetResource",
+        ruleset_resource,
+    )?;
+
+    let target = &source.target_profile_projection;
+    for (field, value) in [
+        (
+            "targetProfileProjection.authority",
+            target.authority.as_str(),
+        ),
+        (
+            "targetProfileProjection.artifactRole",
+            target.artifact_role.as_str(),
+        ),
+        ("targetProfileProjection.id", target.id.as_str()),
+        ("targetProfileProjection.version", target.version.as_str()),
+        (
+            "targetProfileProjection.intrinsicNamespace",
+            target.intrinsic_namespace.as_str(),
+        ),
+        (
+            "targetProfileProjection.intrinsicsResource",
+            target.intrinsics_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.operationProfilesResource",
+            target.operation_profiles_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.footprintAlgebraResource",
+            target.footprint_algebra_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.costAlgebraResource",
+            target.cost_algebra_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.targetIrResource",
+            target.target_ir_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.obstructionTaxonomyResource",
+            target.obstruction_taxonomy_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.verifierResource",
+            target.verifier_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.lowererResource",
+            target.lowerer_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.sandboxResource",
+            target.sandbox_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.fuelModelResource",
+            target.fuel_model_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.bundleProfileResource",
+            target.bundle_profile_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.canonicalEncodingRulesResource",
+            target.canonical_encoding_rules_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.diagnosticAbiResource",
+            target.diagnostic_abi_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.applicationModel",
+            target.application_model.as_str(),
+        ),
+        (
+            "targetProfileProjection.readConsistency",
+            target.read_consistency.as_str(),
+        ),
+        (
+            "targetProfileProjection.guardEvaluation",
+            target.guard_evaluation.as_str(),
+        ),
+        (
+            "targetProfileProjection.obstructionRollback",
+            target.obstruction_rollback.as_str(),
+        ),
+        (
+            "targetProfileProjection.deterministicExecutionResource",
+            target.deterministic_execution_resource.as_str(),
+        ),
+        (
+            "targetProfileProjection.conformanceFixtureCorpusResource",
+            target.conformance_fixture_corpus_resource.as_str(),
+        ),
+    ] {
+        require_nonempty(field, value)?;
+    }
+    ensure_unique_keys(
+        "targetProfileProjection.acceptedCoreAbis",
+        target.accepted_core_abis.iter(),
+    )?;
+    ensure_unique_keys(
+        "targetProfileProjection.generatedArtifactProfileRoles",
+        target.generated_artifact_profile_roles.iter(),
+    )?;
+    ensure_unique_keys(
+        "targetProfileProjection.acceptedLawpackAdapterAbis",
+        target.accepted_lawpack_adapter_abis.iter(),
+    )
+}
+
+fn validate_authorities(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    for authority in &source.authority_sources {
+        if !is_authoritative_locator(&authority.artifact) {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::NonAuthoritativeSource,
+                &authority.coordinate,
+                &authority.artifact,
+            ));
+        }
+    }
+    let authorities = source
+        .authority_sources
+        .iter()
+        .map(|authority| authority.coordinate.as_str())
+        .collect::<BTreeSet<_>>();
+
+    for identity in all_fact_identities(source) {
+        require_reference(
+            &authorities,
+            &identity.authority,
+            ProviderSemanticSourceErrorKind::UnknownAuthority,
+            &identity.coordinate,
+        )?;
+    }
+    for effect in &source.effects {
+        for failure in &effect.failures {
+            require_reference(
+                &authorities,
+                &failure.authority,
+                ProviderSemanticSourceErrorKind::UnknownAuthority,
+                &effect.identity.coordinate,
+            )?;
+        }
+    }
+    for (subject, authority) in [
+        ("lawpackProjection", &source.lawpack_projection.authority),
+        (
+            "targetProfileProjection",
+            &source.target_profile_projection.authority,
+        ),
+    ] {
+        require_reference(
+            &authorities,
+            authority,
+            ProviderSemanticSourceErrorKind::UnknownAuthority,
+            subject,
+        )?;
+    }
+    Ok(())
+}
+
+fn is_authoritative_locator(locator: &str) -> bool {
+    let mut fragments = locator.split('#');
+    let path = fragments.next().unwrap_or_default();
+    if path.is_empty()
+        || fragments.clone().count() > 1
+        || path.starts_with('/')
+        || path.contains('\\')
+        || path.contains(':')
+    {
+        return false;
+    }
+    let forbidden = [
+        "",
+        ".",
+        "..",
+        "build",
+        "dist",
+        "generated",
+        "out",
+        "target",
+        "wesley-relocated",
+    ];
+    !path
+        .split('/')
+        .any(|component| forbidden.contains(&component))
+}
+
+fn validate_fact_contracts(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let authorities = source
+        .authority_sources
+        .iter()
+        .map(|authority| (authority.coordinate.as_str(), authority.kind))
+        .collect::<BTreeMap<_, _>>();
+    validate_fact_family(
+        &source.types,
+        "echo.edict-provider/value/v1",
+        &[
+            AuthoritySourceKind::Graphql,
+            AuthoritySourceKind::EchoSemanticDeclaration,
+        ],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.write_classes,
+        "echo.edict-provider/write-class/v1",
+        &[AuthoritySourceKind::TargetMetadata],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.obstructions,
+        "echo.edict-provider/obstruction/v1",
+        &[AuthoritySourceKind::EchoSemanticDeclaration],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.effects,
+        "echo.edict-provider/semantic-effect/v1",
+        &[AuthoritySourceKind::EchoSemanticDeclaration],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.profiles,
+        "echo.edict-provider/operation-profile/v1",
+        &[AuthoritySourceKind::TargetMetadata],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.budgets,
+        "echo.edict-provider/core-budget/v1",
+        &[AuthoritySourceKind::EchoSemanticDeclaration],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.capabilities,
+        "echo.edict-provider/target-intrinsic/v1",
+        &[AuthoritySourceKind::TargetMetadata],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.direct_adapters,
+        "echo.edict-provider/direct-adapter/v1",
+        &[AuthoritySourceKind::TargetMetadata],
+        &authorities,
+    )?;
+    validate_fact_family(
+        &source.operations,
+        "echo.edict-provider/operation/v1",
+        &[AuthoritySourceKind::EchoSemanticDeclaration],
+        &authorities,
+    )?;
+    for effect in &source.effects {
+        for failure in &effect.failures {
+            if failure.domain != "echo.edict-provider/effect-failure/v1" {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::FactDomainMismatch,
+                    &effect.identity.coordinate,
+                    &failure.domain,
+                ));
+            }
+            let Some(kind) = authorities.get(failure.authority.as_str()).copied() else {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::UnknownAuthority,
+                    &effect.identity.coordinate,
+                    &failure.authority,
+                ));
+            };
+            if kind != AuthoritySourceKind::TargetMetadata {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+                    &effect.identity.coordinate,
+                    &failure.authority,
+                ));
+            }
+        }
+    }
+    validate_projection_authority(
+        "lawpackProjection",
+        &source.lawpack_projection.authority,
+        AuthoritySourceKind::EchoSemanticDeclaration,
+        &authorities,
+    )?;
+    validate_projection_authority(
+        "targetProfileProjection",
+        &source.target_profile_projection.authority,
+        AuthoritySourceKind::TargetMetadata,
+        &authorities,
+    )?;
+    Ok(())
+}
+
+fn validate_projection_authority(
+    subject: &str,
+    authority: &str,
+    expected: AuthoritySourceKind,
+    authorities: &BTreeMap<&str, AuthoritySourceKind>,
+) -> Result<(), ProviderSemanticSourceError> {
+    let Some(actual) = authorities.get(authority).copied() else {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::UnknownAuthority,
+            subject,
+            authority,
+        ));
+    };
+    if actual != expected {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+            subject,
+            authority,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_fact_family<T: HasIdentity>(
+    facts: &[T],
+    expected_domain: &str,
+    allowed_authorities: &[AuthoritySourceKind],
+    authorities: &BTreeMap<&str, AuthoritySourceKind>,
+) -> Result<(), ProviderSemanticSourceError> {
+    for fact in facts {
+        let identity = fact.identity();
+        if identity.domain != expected_domain {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::FactDomainMismatch,
+                &identity.coordinate,
+                &identity.domain,
+            ));
+        }
+        let Some(kind) = authorities.get(identity.authority.as_str()).copied() else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnknownAuthority,
+                &identity.coordinate,
+                &identity.authority,
+            ));
+        };
+        if !allowed_authorities.contains(&kind) {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+                &identity.coordinate,
+                &identity.authority,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn all_fact_identities(source: &ProviderSemanticSourceV1) -> Vec<&SemanticFactIdentity> {
+    let mut identities = Vec::new();
+    append_identities(&mut identities, &source.types);
+    append_identities(&mut identities, &source.write_classes);
+    append_identities(&mut identities, &source.obstructions);
+    append_identities(&mut identities, &source.effects);
+    append_identities(&mut identities, &source.profiles);
+    append_identities(&mut identities, &source.budgets);
+    append_identities(&mut identities, &source.capabilities);
+    append_identities(&mut identities, &source.direct_adapters);
+    append_identities(&mut identities, &source.operations);
+    identities
+}
+
+fn append_identities<'a, T: HasIdentity>(
+    identities: &mut Vec<&'a SemanticFactIdentity>,
+    facts: &'a [T],
+) {
+    identities.extend(facts.iter().map(HasIdentity::identity));
+}
+
+fn validate_type_references(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let types = coordinates(&source.types);
+    for declaration in &source.types {
+        if is_edict_core_coordinate(&declaration.identity.coordinate) {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::CoreTypeAuthorityMismatch,
+                &declaration.identity.coordinate,
+                "edict.core/v1",
+            ));
+        }
+        if let SemanticTypeShape::Record { fields } = &declaration.shape {
+            ensure_unique_keys("types.fields.name", fields.iter().map(|field| &field.name))?;
+            for field in fields {
+                require_nonempty("types.fields.name", &field.name)?;
+                require_reference(
+                    &types,
+                    &field.type_coordinate,
+                    ProviderSemanticSourceErrorKind::UnknownType,
+                    &declaration.identity.coordinate,
+                )?;
+            }
+        }
+    }
+    let mut bounded = source
+        .types
+        .iter()
+        .filter_map(|declaration| {
+            matches!(declaration.shape, SemanticTypeShape::CoreStringAlias { .. })
+                .then_some(declaration.identity.coordinate.as_str())
+        })
+        .collect::<BTreeSet<_>>();
+    loop {
+        let before = bounded.len();
+        for declaration in &source.types {
+            if let SemanticTypeShape::Record { fields } = &declaration.shape {
+                if fields
+                    .iter()
+                    .all(|field| bounded.contains(field.type_coordinate.as_str()))
+                {
+                    bounded.insert(&declaration.identity.coordinate);
+                }
+            }
+        }
+        if bounded.len() == before {
+            break;
+        }
+    }
+    if bounded.len() != source.types.len() {
+        if let Some(declaration) = source
+            .types
+            .iter()
+            .find(|declaration| !bounded.contains(declaration.identity.coordinate.as_str()))
+        {
+            let reference = match &declaration.shape {
+                SemanticTypeShape::Record { fields } => fields
+                    .iter()
+                    .find(|field| !bounded.contains(field.type_coordinate.as_str()))
+                    .map(|field| field.type_coordinate.as_str())
+                    .unwrap_or_default(),
+                SemanticTypeShape::CoreStringAlias { .. } => "",
+            };
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnboundedTypeGraph,
+                &declaration.identity.coordinate,
+                reference,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_edict_core_coordinate(value: &str) -> bool {
+    const SCALARS: [&str; 7] = ["Bool", "I32", "I64", "U32", "U64", "Digest", "Unit"];
+    const REFINED_OR_COMPOUND: [&str; 6] =
+        ["String", "Bytes", "Option", "List", "Map", "CapabilityRef"];
+
+    SCALARS.contains(&value)
+        || REFINED_OR_COMPOUND.iter().any(|name| {
+            value
+                .strip_prefix(name)
+                .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with('<'))
+        })
+}
+
+fn validate_obstruction_references(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let types = coordinates(&source.types);
+    for obstruction in &source.obstructions {
+        require_reference(
+            &types,
+            &obstruction.payload_schema,
+            ProviderSemanticSourceErrorKind::UnknownType,
+            &obstruction.identity.coordinate,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_profile_references(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let write_classes = coordinates(&source.write_classes);
+    for write_class in &source.write_classes {
+        if !is_abi_write_class(&write_class.identity.coordinate) {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::InvalidWriteClass,
+                "writeClasses",
+                &write_class.identity.coordinate,
+            ));
+        }
+    }
+    let mut profile_by_source_name = BTreeMap::new();
+    for profile in &source.profiles {
+        ensure_unique_keys("profiles.sourceNames", profile.source_names.iter())?;
+        ensure_unique_keys(
+            "profiles.allowedWriteClasses",
+            profile.allowed_write_classes.iter(),
+        )?;
+        ensure_unique_keys("profiles.guardKinds", profile.guard_kinds.iter())?;
+        for source_name in &profile.source_names {
+            if profile_by_source_name
+                .insert(source_name.as_str(), profile.identity.coordinate.as_str())
+                .is_some()
+            {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::DuplicateKey,
+                    "profiles.sourceNames",
+                    source_name,
+                ));
+            }
+        }
+        for write_class in &profile.allowed_write_classes {
+            require_reference(
+                &write_classes,
+                write_class,
+                ProviderSemanticSourceErrorKind::UnknownWriteClass,
+                &profile.identity.coordinate,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn is_abi_write_class(value: &str) -> bool {
+    matches!(
+        value,
+        "none" | "read" | "create" | "ensure" | "append" | "replace" | "delete" | "custom"
+    )
+}
+
+fn validate_effect_references(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let types = coordinates(&source.types);
+
+    for effect in &source.effects {
+        if effect.parameter_types.len() != 1 {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnsupportedEffectShape,
+                &effect.identity.coordinate,
+                effect.parameter_types.len().to_string(),
+            ));
+        }
+        ensure_unique_keys("effects.guardKinds", effect.guard_kinds.iter())?;
+        if !effect.guard_kinds.is_empty() && !effect.guard_support {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnsupportedEffectShape,
+                &effect.identity.coordinate,
+                "guardSupport",
+            ));
+        }
+        for parameter in &effect.parameter_types {
+            require_reference(
+                &types,
+                parameter,
+                ProviderSemanticSourceErrorKind::UnknownType,
+                &effect.identity.coordinate,
+            )?;
+        }
+        require_reference(
+            &types,
+            &effect.result_type,
+            ProviderSemanticSourceErrorKind::UnknownType,
+            &effect.identity.coordinate,
+        )?;
+        ensure_unique_keys(
+            "effects.failures.key",
+            effect.failures.iter().map(|failure| &failure.key),
+        )?;
+        for failure in &effect.failures {
+            if !is_edict_failure_identifier(&failure.key) {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::InvalidFailureKey,
+                    &effect.identity.coordinate,
+                    &failure.key,
+                ));
+            }
+            require_reference(
+                &types,
+                &failure.payload_type,
+                ProviderSemanticSourceErrorKind::UnknownType,
+                &effect.identity.coordinate,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn is_edict_failure_identifier(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == b'_')
+        || !bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return false;
+    }
+    !matches!(
+        value,
+        "package"
+            | "use"
+            | "type"
+            | "enum"
+            | "variant"
+            | "intent"
+            | "returns"
+            | "profile"
+            | "implements"
+            | "basis"
+            | "footprint"
+            | "budget"
+            | "where"
+            | "let"
+            | "return"
+            | "require"
+            | "guarantee"
+            | "assert"
+            | "if"
+            | "then"
+            | "else"
+            | "for"
+            | "in"
+            | "bounded"
+            | "yield"
+            | "match"
+            | "as"
+            | "digest"
+            | "fn"
+            | "const"
+            | "true"
+            | "false"
+    )
+}
+
+fn validate_adapter_references(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let effects = coordinates(&source.effects);
+    let capabilities = coordinates(&source.capabilities);
+    for adapter in &source.direct_adapters {
+        require_reference(
+            &effects,
+            &adapter.consumes_effect,
+            ProviderSemanticSourceErrorKind::UnknownEffect,
+            &adapter.identity.coordinate,
+        )?;
+        require_reference(
+            &capabilities,
+            &adapter.capability,
+            ProviderSemanticSourceErrorKind::UnknownCapability,
+            &adapter.identity.coordinate,
+        )?;
+        if !adapter.emits_effects.is_empty() {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnsupportedAdapterChain,
+                &adapter.identity.coordinate,
+                &adapter.emits_effects[0],
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_capability_references(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let write_classes = coordinates(&source.write_classes);
+    let target_profiles = source
+        .generated_artifacts
+        .iter()
+        .filter(|artifact| artifact.kind == GeneratedArtifactKind::TargetProfile)
+        .map(|artifact| artifact.coordinate.as_str())
+        .collect::<BTreeSet<_>>();
+    let effects = source
+        .effects
+        .iter()
+        .map(|effect| (effect.identity.coordinate.as_str(), effect))
+        .collect::<BTreeMap<_, _>>();
+    let mut target_ir_by_profile = BTreeMap::new();
+    for capability in &source.capabilities {
+        let Some(effect) = effects.get(capability.effect.as_str()) else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnknownEffect,
+                &capability.identity.coordinate,
+                &capability.effect,
+            ));
+        };
+        require_reference(
+            &target_profiles,
+            &capability.target_profile,
+            ProviderSemanticSourceErrorKind::UnknownProfile,
+            &capability.identity.coordinate,
+        )?;
+        require_reference(
+            &write_classes,
+            &capability.write_class,
+            ProviderSemanticSourceErrorKind::UnknownWriteClass,
+            &capability.identity.coordinate,
+        )?;
+        if capability.write_class == "none" {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+                &capability.identity.coordinate,
+                &capability.write_class,
+            ));
+        }
+        require_nonempty("capabilities.targetIrDomain", &capability.target_ir_domain)?;
+        if let Some(previous) = target_ir_by_profile.insert(
+            capability.target_profile.as_str(),
+            capability.target_ir_domain.as_str(),
+        ) {
+            if previous != capability.target_ir_domain {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::TargetIrDomainMismatch,
+                    &capability.target_profile,
+                    &capability.target_ir_domain,
+                ));
+            }
+        }
+        let expected_discharge = (
+            effect.effect_kind_hint,
+            effect.footprint_obligation.as_str(),
+            effect.cost_obligation.as_str(),
+        );
+        let actual_discharge = (
+            capability.semantic_discharge.effect_kind_hint,
+            capability.semantic_discharge.footprint_obligation.as_str(),
+            capability.semantic_discharge.cost_obligation.as_str(),
+        );
+        let missing_guard_support = effect.guard_support && !capability.guard_support;
+        let atomic_guard_mismatch = effect
+            .guard_kinds
+            .iter()
+            .any(|guard| guard == "precommit-atomic")
+            && !capability.can_participate_in_atomic_guard;
+        let proof_only_mutation = effect.execution_class == ExecutionClass::ProofOnly
+            && is_mutating_write_class(&capability.write_class);
+        if actual_discharge != expected_discharge
+            || missing_guard_support
+            || atomic_guard_mismatch
+            || proof_only_mutation
+        {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+                &capability.identity.coordinate,
+                &capability.effect,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_effect_implementation_closure(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let mut implementations = BTreeMap::new();
+    for (effect, implementation) in source
+        .capabilities
+        .iter()
+        .map(|capability| (&capability.effect, &capability.identity.coordinate))
+        .chain(
+            source
+                .direct_adapters
+                .iter()
+                .map(|adapter| (&adapter.consumes_effect, &adapter.identity.coordinate)),
+        )
+    {
+        if implementations
+            .insert(effect.as_str(), implementation)
+            .is_some()
+        {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::AmbiguousEffectImplementation,
+                "effectImplementations",
+                effect,
+            ));
+        }
+    }
+    if let Some(effect) = source.effects.iter().find(|effect| {
+        effect.execution_class == ExecutionClass::Runtime
+            && !implementations.contains_key(effect.identity.coordinate.as_str())
+    }) {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::MissingEffectImplementation,
+            "effectImplementations",
+            &effect.identity.coordinate,
+        ));
+    }
+    Ok(())
+}
+
+fn is_mutating_write_class(write_class: &str) -> bool {
+    !matches!(write_class, "none" | "read")
+}
+
+fn validate_operation_references(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let types = coordinates(&source.types);
+    let type_declarations = source
+        .types
+        .iter()
+        .map(|declaration| (declaration.identity.coordinate.as_str(), declaration))
+        .collect::<BTreeMap<_, _>>();
+    let effects = source
+        .effects
+        .iter()
+        .map(|effect| (effect.identity.coordinate.as_str(), effect))
+        .collect::<BTreeMap<_, _>>();
+    let profiles = source
+        .profiles
+        .iter()
+        .map(|profile| (profile.identity.coordinate.as_str(), profile))
+        .collect::<BTreeMap<_, _>>();
+    let budgets = coordinates(&source.budgets);
+    let capabilities = source
+        .capabilities
+        .iter()
+        .map(|capability| (capability.identity.coordinate.as_str(), capability))
+        .collect::<BTreeMap<_, _>>();
+    let adapters = source
+        .direct_adapters
+        .iter()
+        .map(|adapter| (adapter.identity.coordinate.as_str(), adapter))
+        .collect::<BTreeMap<_, _>>();
+    let obstructions = source
+        .obstructions
+        .iter()
+        .map(|obstruction| (obstruction.identity.coordinate.as_str(), obstruction))
+        .collect::<BTreeMap<_, _>>();
+
+    for operation in &source.operations {
+        let subject = &operation.identity.coordinate;
+        require_reference(
+            &types,
+            &operation.input_type,
+            ProviderSemanticSourceErrorKind::UnknownType,
+            subject,
+        )?;
+        require_reference(
+            &types,
+            &operation.output_type,
+            ProviderSemanticSourceErrorKind::UnknownType,
+            subject,
+        )?;
+        let Some(effect) = effects.get(operation.effect.as_str()) else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnknownEffect,
+                subject,
+                &operation.effect,
+            ));
+        };
+        let Some(profile) = profiles.get(operation.profile.as_str()) else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnknownProfile,
+                subject,
+                &operation.profile,
+            ));
+        };
+        require_reference(
+            &budgets,
+            &operation.budget,
+            ProviderSemanticSourceErrorKind::UnknownBudget,
+            subject,
+        )?;
+        let capability = match &operation.implementation {
+            OperationImplementation::Native {
+                capability: capability_coordinate,
+            } => {
+                let Some(capability) = capabilities.get(capability_coordinate.as_str()) else {
+                    return Err(ProviderSemanticSourceError::new(
+                        ProviderSemanticSourceErrorKind::UnknownCapability,
+                        subject,
+                        capability_coordinate,
+                    ));
+                };
+                if capability.effect != operation.effect {
+                    return Err(ProviderSemanticSourceError::new(
+                        ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+                        subject,
+                        &capability.effect,
+                    ));
+                }
+                *capability
+            }
+            OperationImplementation::DirectAdapter {
+                adapter: adapter_coordinate,
+            } => {
+                let Some(adapter) = adapters.get(adapter_coordinate.as_str()) else {
+                    return Err(ProviderSemanticSourceError::new(
+                        ProviderSemanticSourceErrorKind::UnknownAdapter,
+                        subject,
+                        adapter_coordinate,
+                    ));
+                };
+                if adapter.consumes_effect != operation.effect {
+                    return Err(ProviderSemanticSourceError::new(
+                        ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+                        subject,
+                        &adapter.consumes_effect,
+                    ));
+                }
+                let Some(capability) = capabilities.get(adapter.capability.as_str()) else {
+                    return Err(ProviderSemanticSourceError::new(
+                        ProviderSemanticSourceErrorKind::UnknownCapability,
+                        subject,
+                        &adapter.capability,
+                    ));
+                };
+                *capability
+            }
+        };
+        if !profile
+            .allowed_write_classes
+            .contains(&capability.write_class)
+        {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                subject,
+                &capability.write_class,
+            ));
+        }
+        if let Some(guard) = effect
+            .guard_kinds
+            .iter()
+            .find(|guard| !profile.guard_kinds.contains(guard))
+        {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                subject,
+                guard,
+            ));
+        }
+        match &profile.optic_template.aperture_requirement {
+            Some(ApertureRequirementDeclaration::AbstractFootprintObligation { reference })
+                if reference == &effect.footprint_obligation => {}
+            Some(aperture) => {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                    subject,
+                    aperture.reference(),
+                ));
+            }
+            None => {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                    subject,
+                    &effect.footprint_obligation,
+                ));
+            }
+        }
+        if is_mutating_write_class(&capability.write_class) {
+            if profile.optic_template.optic_kind != OpticKind::AffectReintegration {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                    subject,
+                    "revelation",
+                ));
+            }
+            if profile.optic_template.boundary_kind != BoundaryKind::Affect {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                    subject,
+                    "projection",
+                ));
+            }
+        }
+        if effect
+            .guard_kinds
+            .iter()
+            .any(|guard| guard == "precommit-atomic")
+        {
+            if profile.atomicity != "atomic" {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                    subject,
+                    &profile.atomicity,
+                ));
+            }
+            if !capability.can_participate_in_atomic_guard {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+                    &capability.identity.coordinate,
+                    &capability.effect,
+                ));
+            }
+        }
+        validate_operation_obstruction_mappings(
+            subject,
+            &operation.obstruction_mappings,
+            effect,
+            &obstructions,
+            &type_declarations,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_operation_obstruction_mappings(
+    subject: &str,
+    mappings: &[ObstructionMappingDeclaration],
+    effect: &SemanticEffectDeclaration,
+    obstructions: &BTreeMap<&str, &ObstructionDeclaration>,
+    types: &BTreeMap<&str, &SemanticTypeDeclaration>,
+) -> Result<(), ProviderSemanticSourceError> {
+    ensure_unique_keys(
+        "operations.obstructionMappings.failure",
+        mappings.iter().map(|mapping| &mapping.failure),
+    )?;
+    let failures = effect
+        .failures
+        .iter()
+        .map(|failure| (failure.key.as_str(), failure))
+        .collect::<BTreeMap<_, _>>();
+    let expected = effect
+        .failures
+        .iter()
+        .filter(|failure| failure.authority_class == AuthorityClass::DomainMappable)
+        .map(|failure| failure.key.as_str())
+        .collect::<BTreeSet<_>>();
+    let actual = mappings
+        .iter()
+        .map(|mapping| mapping.failure.as_str())
+        .collect::<BTreeSet<_>>();
+
+    for mapping in mappings {
+        let Some(failure) = failures.get(mapping.failure.as_str()) else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnknownFailure,
+                subject,
+                &mapping.failure,
+            ));
+        };
+        if failure.authority_class != AuthorityClass::DomainMappable {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ObstructionMappingMismatch,
+                subject,
+                &mapping.failure,
+            ));
+        }
+        let Some(obstruction) = obstructions.get(mapping.obstruction.as_str()) else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnknownObstruction,
+                subject,
+                &mapping.obstruction,
+            ));
+        };
+        if obstruction.authority_class != AuthorityClass::DomainMappable {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ObstructionMappingMismatch,
+                subject,
+                &mapping.obstruction,
+            ));
+        }
+        if !is_empty_record_type(types, &failure.payload_type)
+            || !is_empty_record_type(types, &obstruction.payload_schema)
+        {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnsupportedObstructionPayloadMapping,
+                subject,
+                &mapping.failure,
+            ));
+        }
+    }
+
+    if actual != expected {
+        let reference = expected
+            .symmetric_difference(&actual)
+            .next()
+            .copied()
+            .unwrap_or_default();
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ObstructionMappingMismatch,
+            subject,
+            reference,
+        ));
+    }
+    Ok(())
+}
+
+fn is_empty_record_type(
+    types: &BTreeMap<&str, &SemanticTypeDeclaration>,
+    coordinate: &str,
+) -> bool {
+    matches!(
+        types.get(coordinate).map(|declaration| &declaration.shape),
+        Some(SemanticTypeShape::Record { fields }) if fields.is_empty()
+    )
+}
+
+fn validate_generated_artifact_contracts(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    for artifact in &source.generated_artifacts {
+        if artifact.kind == GeneratedArtifactKind::ProviderManifest {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::SelfReferentialManifestInventory,
+                &artifact.role,
+                &artifact.coordinate,
+            ));
+        }
+        let expected = match artifact.kind {
+            GeneratedArtifactKind::Lawpack => "edict.lawpack/v1",
+            GeneratedArtifactKind::TargetProfile => "edict.target-profile/v1",
+            GeneratedArtifactKind::AuthorityFacts => "edict.authority-facts/v1",
+            GeneratedArtifactKind::ProviderManifest => "edict.provider-manifest/v1",
+            GeneratedArtifactKind::ReviewArtifact => "echo.edict-provider.generation-review/v1",
+            GeneratedArtifactKind::GeneratedArtifactProfile => "echo.generated-artifact-profile/v1",
+            GeneratedArtifactKind::GenerationProvenance => "wesley:GenerationProvenanceManifestV1",
+            GeneratedArtifactKind::ArtifactSchema => "selfContainedCddlV1",
+        };
+        if artifact.schema_contract != expected {
+            return Err(ProviderSemanticSourceError::new(
+                if artifact.kind == GeneratedArtifactKind::GenerationProvenance {
+                    ProviderSemanticSourceErrorKind::GenerationProvenanceContractMismatch
+                } else {
+                    ProviderSemanticSourceErrorKind::ArtifactSchemaContractMismatch
+                },
+                &artifact.role,
+                &artifact.schema_contract,
+            ));
+        }
+        let expected_contract_owner = match artifact.kind {
+            GeneratedArtifactKind::AuthorityFacts => Some("flyingrobots/edict#157"),
+            GeneratedArtifactKind::GenerationProvenance => Some("flyingrobots/wesley#728"),
+            _ => None,
+        };
+        if artifact.contract_owner.as_deref() != expected_contract_owner {
+            return Err(ProviderSemanticSourceError::new(
+                if artifact.kind == GeneratedArtifactKind::GenerationProvenance {
+                    ProviderSemanticSourceErrorKind::GenerationProvenanceContractMismatch
+                } else {
+                    ProviderSemanticSourceErrorKind::ArtifactContractOwnerMismatch
+                },
+                &artifact.role,
+                artifact.contract_owner.as_deref().unwrap_or_default(),
+            ));
+        }
+        validate_authority_fact_projection(source, artifact)?;
+    }
+    if source.package_manifest.schema_contract != "edict.provider-manifest/v1" {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactSchemaContractMismatch,
+            &source.package_manifest.role,
+            &source.package_manifest.schema_contract,
+        ));
+    }
+    for (actual, expected) in [
+        (
+            source.package_manifest.provider_abi.as_str(),
+            "edict:target-provider@1.0.0",
+        ),
+        (
+            source.package_manifest.provider_coordinate.as_str(),
+            "echo.edict-provider@1",
+        ),
+    ] {
+        if actual != expected {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ProviderManifestProjectionMismatch,
+                &source.package_manifest.role,
+                actual,
+            ));
+        }
+    }
+    if source.package_manifest.provider_coordinate == source.package_manifest.coordinate {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ProviderManifestProjectionMismatch,
+            &source.package_manifest.role,
+            &source.package_manifest.provider_coordinate,
+        ));
+    }
+    for (kind, expected_count) in [
+        (GeneratedArtifactKind::Lawpack, 1),
+        (GeneratedArtifactKind::TargetProfile, 1),
+        (GeneratedArtifactKind::AuthorityFacts, 2),
+        (GeneratedArtifactKind::ReviewArtifact, 1),
+        (GeneratedArtifactKind::GeneratedArtifactProfile, 1),
+        (GeneratedArtifactKind::GenerationProvenance, 1),
+        (GeneratedArtifactKind::ArtifactSchema, 1),
+    ] {
+        let actual = source
+            .generated_artifacts
+            .iter()
+            .filter(|artifact| artifact.kind == kind)
+            .count();
+        if actual != expected_count {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+                "generatedArtifacts",
+                format!("{}:{actual}", generated_artifact_kind_name(kind)),
+            ));
+        }
+    }
+    for source_kind in [
+        AuthorityFactSourceKind::Lawpack,
+        AuthorityFactSourceKind::TargetProfile,
+    ] {
+        let actual = source
+            .generated_artifacts
+            .iter()
+            .filter_map(|artifact| artifact.authority_fact_source.as_ref())
+            .filter(|fact_source| fact_source.kind == source_kind)
+            .count();
+        if actual != 1 {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+                "generatedArtifacts",
+                authority_fact_source_kind_name(source_kind),
+            ));
+        }
+    }
+    Ok(())
+}
+
+const fn generated_artifact_kind_name(kind: GeneratedArtifactKind) -> &'static str {
+    match kind {
+        GeneratedArtifactKind::Lawpack => "lawpack",
+        GeneratedArtifactKind::TargetProfile => "targetProfile",
+        GeneratedArtifactKind::AuthorityFacts => "authorityFacts",
+        GeneratedArtifactKind::ProviderManifest => "providerManifest",
+        GeneratedArtifactKind::ReviewArtifact => "reviewArtifact",
+        GeneratedArtifactKind::GeneratedArtifactProfile => "generatedArtifactProfile",
+        GeneratedArtifactKind::GenerationProvenance => "generationProvenance",
+        GeneratedArtifactKind::ArtifactSchema => "artifactSchema",
+    }
+}
+
+const fn authority_fact_source_kind_name(kind: AuthorityFactSourceKind) -> &'static str {
+    match kind {
+        AuthorityFactSourceKind::Lawpack => "lawpack",
+        AuthorityFactSourceKind::TargetProfile => "targetProfile",
+    }
+}
+
+fn validate_authority_fact_projection(
+    source: &ProviderSemanticSourceV1,
+    artifact: &GeneratedArtifactDeclaration,
+) -> Result<(), ProviderSemanticSourceError> {
+    let Some(fact_source) = &artifact.authority_fact_source else {
+        if artifact.kind == GeneratedArtifactKind::AuthorityFacts {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+                &artifact.role,
+                "authorityFactSource",
+            ));
+        }
+        return Ok(());
+    };
+    if artifact.kind != GeneratedArtifactKind::AuthorityFacts {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+            &artifact.role,
+            &fact_source.coordinate,
+        ));
+    }
+    let expected_kind = match fact_source.kind {
+        AuthorityFactSourceKind::Lawpack => GeneratedArtifactKind::Lawpack,
+        AuthorityFactSourceKind::TargetProfile => GeneratedArtifactKind::TargetProfile,
+    };
+    let valid = source.generated_artifacts.iter().any(|candidate| {
+        candidate.kind == expected_kind && candidate.coordinate == fact_source.coordinate
+    });
+    if !valid {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+            &artifact.role,
+            &fact_source.coordinate,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_artifact_closure(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    let artifacts = source
+        .generated_artifacts
+        .iter()
+        .map(|artifact| (artifact.role.as_str(), artifact))
+        .collect::<BTreeMap<_, _>>();
+    let resources = source
+        .artifact_resources
+        .iter()
+        .map(|resource| (resource.role.as_str(), resource))
+        .collect::<BTreeMap<_, _>>();
+    let lawpack = &source.lawpack_projection;
+    let lawpack_artifact = require_artifact_kind(
+        &artifacts,
+        &lawpack.artifact_role,
+        GeneratedArtifactKind::Lawpack,
+        "lawpackProjection.artifactRole",
+    )?;
+    if lawpack_artifact.coordinate != format!("{}@{}", lawpack.id, lawpack.version) {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &lawpack.artifact_role,
+            &lawpack_artifact.coordinate,
+        ));
+    }
+    if lawpack.accepted_core_abis != ["edict.core/v1"]
+        || !lawpack.dependencies.is_empty()
+        || lawpack.target_adapters.is_empty()
+    {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &lawpack.artifact_role,
+            "lawpackManifest",
+        ));
+    }
+    let mut used_resources = BTreeSet::new();
+    require_resource(
+        &resources,
+        &lawpack.exports_resource,
+        Some("edict.lawpack/v1#lawpack-exports"),
+        Some(ArtifactResourceProvision::Generated),
+        &lawpack.artifact_role,
+        &mut used_resources,
+    )?;
+    require_resource(
+        &resources,
+        &lawpack.compatibility_resource,
+        Some("echo.edict-provider.lawpack-compatibility/v1"),
+        Some(ArtifactResourceProvision::Generated),
+        &lawpack.artifact_role,
+        &mut used_resources,
+    )?;
+    require_resource(
+        &resources,
+        &lawpack.conformance_fixture_corpus_resource,
+        Some("echo.edict-provider.conformance-corpus/v1"),
+        Some(ArtifactResourceProvision::Generated),
+        &lawpack.artifact_role,
+        &mut used_resources,
+    )?;
+    let LawpackVerifierDeclaration::Declarative { ruleset_resource } = &lawpack.verifier;
+    require_resource(
+        &resources,
+        ruleset_resource,
+        Some("echo.edict-provider.lawpack-verifier/v1"),
+        Some(ArtifactResourceProvision::Generated),
+        &lawpack.artifact_role,
+        &mut used_resources,
+    )?;
+
+    let runtime_effects = source
+        .effects
+        .iter()
+        .filter(|effect| effect.execution_class == ExecutionClass::Runtime)
+        .map(|effect| effect.identity.coordinate.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut adapted_effects = BTreeSet::new();
+    for adapter in &lawpack.target_adapters {
+        require_artifact_kind(
+            &artifacts,
+            &adapter.accepted_target_profile_role,
+            GeneratedArtifactKind::TargetProfile,
+            &lawpack.artifact_role,
+        )?;
+        let target_ir = require_resource(
+            &resources,
+            &adapter.accepted_target_ir_resource,
+            Some("echo.span-ir/v1"),
+            Some(ArtifactResourceProvision::Generated),
+            &lawpack.artifact_role,
+            &mut used_resources,
+        )?;
+        require_resource(
+            &resources,
+            &adapter.adapter_resource,
+            Some("echo.edict-provider.lawpack-target-adapter/v1"),
+            Some(ArtifactResourceProvision::Generated),
+            &lawpack.artifact_role,
+            &mut used_resources,
+        )?;
+        if adapter.effects.is_empty() {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+                &lawpack.artifact_role,
+                &adapter.adapter_resource,
+            ));
+        }
+        for effect in &adapter.effects {
+            if !runtime_effects.contains(effect.as_str())
+                || !adapted_effects.insert(effect.as_str())
+            {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+                    &lawpack.artifact_role,
+                    effect,
+                ));
+            }
+        }
+        if !source
+            .capabilities
+            .iter()
+            .any(|capability| capability.target_ir_domain == target_ir.coordinate)
+        {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+                &lawpack.artifact_role,
+                &target_ir.coordinate,
+            ));
+        }
+    }
+    if adapted_effects != runtime_effects {
+        let reference = runtime_effects
+            .iter()
+            .find(|effect| !adapted_effects.contains(**effect))
+            .copied()
+            .unwrap_or_default();
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &lawpack.artifact_role,
+            reference,
+        ));
+    }
+
+    let target = &source.target_profile_projection;
+    let target_artifact = require_artifact_kind(
+        &artifacts,
+        &target.artifact_role,
+        GeneratedArtifactKind::TargetProfile,
+        "targetProfileProjection.artifactRole",
+    )?;
+    if target_artifact.coordinate != format!("{}@{}", target.id, target.version)
+        || target.intrinsic_namespace != target_artifact.coordinate
+        || source
+            .capabilities
+            .iter()
+            .any(|capability| capability.target_profile != target_artifact.coordinate)
+    {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &target.artifact_role,
+            &target_artifact.coordinate,
+        ));
+    }
+    if target.accepted_core_abis != ["edict.core/v1"]
+        || !target.accepted_lawpack_adapter_abis.is_empty()
+        || target.application_model != "atomic"
+        || target.read_consistency != "application-snapshot"
+        || target.guard_evaluation != "precommit-atomic"
+        || target.obstruction_rollback != "no-visible-effects"
+        || target.multi_target
+    {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &target.artifact_role,
+            "targetProfileManifest",
+        ));
+    }
+    for profile in &source.profiles {
+        if profile.postcondition_support != target.postcondition_support {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+                &target.artifact_role,
+                &profile.identity.coordinate,
+            ));
+        }
+    }
+    let target_slots = [
+        (
+            target.intrinsics_resource.as_str(),
+            Some("edict.target-profile.intrinsics/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.operation_profiles_resource.as_str(),
+            Some("edict.target-profile.operation-profiles/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.footprint_algebra_resource.as_str(),
+            Some("echo.dpo.footprint/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.cost_algebra_resource.as_str(),
+            Some("echo.dpo.cost/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.target_ir_resource.as_str(),
+            Some("echo.span-ir/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.obstruction_taxonomy_resource.as_str(),
+            Some("echo.dpo.obstructions/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.verifier_resource.as_str(),
+            Some("echo.dpo.verifier/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.lowerer_resource.as_str(),
+            Some("echo.dpo.lowerer/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.sandbox_resource.as_str(),
+            Some("edict.wasm-component/v1"),
+            ArtifactResourceProvision::External,
+        ),
+        (
+            target.fuel_model_resource.as_str(),
+            Some("edict.fuel/v1"),
+            ArtifactResourceProvision::External,
+        ),
+        (
+            target.bundle_profile_resource.as_str(),
+            Some("echo.dpo.bundle/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+        (
+            target.canonical_encoding_rules_resource.as_str(),
+            Some("edict.canonical-cbor/v1"),
+            ArtifactResourceProvision::External,
+        ),
+        (
+            target.diagnostic_abi_resource.as_str(),
+            Some("edict.diagnostics/v1"),
+            ArtifactResourceProvision::External,
+        ),
+        (
+            target.deterministic_execution_resource.as_str(),
+            Some("edict.determinism/v1"),
+            ArtifactResourceProvision::External,
+        ),
+        (
+            target.conformance_fixture_corpus_resource.as_str(),
+            Some("echo.edict-provider.conformance-corpus/v1"),
+            ArtifactResourceProvision::Generated,
+        ),
+    ];
+    let mut target_ir = None;
+    for (role, contract, provision) in target_slots {
+        let resource = require_resource(
+            &resources,
+            role,
+            contract,
+            Some(provision),
+            &target.artifact_role,
+            &mut used_resources,
+        )?;
+        if role == target.target_ir_resource {
+            target_ir = Some(resource.coordinate.as_str());
+        }
+    }
+    let Some(target_ir) = target_ir else {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &target.artifact_role,
+            &target.target_ir_resource,
+        ));
+    };
+    if source
+        .capabilities
+        .iter()
+        .any(|capability| capability.target_ir_domain != target_ir)
+    {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &target.artifact_role,
+            target_ir,
+        ));
+    }
+    for role in &target.generated_artifact_profile_roles {
+        require_artifact_kind(
+            &artifacts,
+            role,
+            GeneratedArtifactKind::GeneratedArtifactProfile,
+            &target.artifact_role,
+        )?;
+    }
+    let declared_profile_roles = source
+        .generated_artifacts
+        .iter()
+        .filter(|artifact| artifact.kind == GeneratedArtifactKind::GeneratedArtifactProfile)
+        .map(|artifact| artifact.role.as_str())
+        .collect::<BTreeSet<_>>();
+    let referenced_profile_roles = target
+        .generated_artifact_profile_roles
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    if declared_profile_roles != referenced_profile_roles {
+        let reference = declared_profile_roles
+            .symmetric_difference(&referenced_profile_roles)
+            .next()
+            .copied()
+            .unwrap_or_default();
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            &target.artifact_role,
+            reference,
+        ));
+    }
+    if used_resources.len() != resources.len() {
+        let unused = resources
+            .keys()
+            .find(|role| !used_resources.contains(**role))
+            .copied()
+            .unwrap_or_default();
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            "artifactResources",
+            unused,
+        ));
+    }
+    Ok(())
+}
+
+fn require_artifact_kind<'a>(
+    artifacts: &'a BTreeMap<&str, &'a GeneratedArtifactDeclaration>,
+    role: &str,
+    expected_kind: GeneratedArtifactKind,
+    subject: &str,
+) -> Result<&'a GeneratedArtifactDeclaration, ProviderSemanticSourceError> {
+    let Some(artifact) = artifacts.get(role).copied() else {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            subject,
+            role,
+        ));
+    };
+    if artifact.kind != expected_kind {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            subject,
+            role,
+        ));
+    }
+    Ok(artifact)
+}
+
+fn require_resource<'a>(
+    resources: &'a BTreeMap<&str, &'a ArtifactResourceDeclaration>,
+    role: &str,
+    expected_contract: Option<&str>,
+    expected_provision: Option<ArtifactResourceProvision>,
+    subject: &str,
+    used: &mut BTreeSet<&'a str>,
+) -> Result<&'a ArtifactResourceDeclaration, ProviderSemanticSourceError> {
+    let Some(resource) = resources.get(role).copied() else {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            subject,
+            role,
+        ));
+    };
+    if expected_contract.is_some_and(|contract| resource.schema_contract != contract)
+        || expected_provision.is_some_and(|provision| resource.provision != provision)
+    {
+        return Err(ProviderSemanticSourceError::new(
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+            subject,
+            role,
+        ));
+    }
+    used.insert(resource.role.as_str());
+    Ok(resource)
+}
+
+fn validate_invocation_schema_bindings(
+    source: &ProviderSemanticSourceV1,
+) -> Result<(), ProviderSemanticSourceError> {
+    for (kind, expected_count) in [
+        (InvocationInputKind::Core, 1),
+        (InvocationInputKind::TargetProfile, 1),
+        (InvocationInputKind::Lawpack, 1),
+        (InvocationInputKind::AuthorityFacts, 2),
+        (InvocationInputKind::LowerabilityFacts, 1),
+        (InvocationInputKind::TargetIr, 1),
+    ] {
+        let actual = source
+            .invocation_inputs
+            .iter()
+            .filter(|input| input.kind == kind)
+            .count();
+        if actual != expected_count {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::InvocationInputClosureMismatch,
+                "invocationInputs",
+                invocation_input_kind_name(kind),
+            ));
+        }
+    }
+    for input in &source.invocation_inputs {
+        let expected_domain = expected_input_domain(input.kind);
+        if input.domain != expected_domain {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::InputDomainMismatch,
+                &input.role,
+                &input.domain,
+            ));
+        }
+    }
+    for kind in [
+        InvocationOutputKind::TargetIr,
+        InvocationOutputKind::GeneratedArtifact,
+        InvocationOutputKind::ReviewPayload,
+        InvocationOutputKind::VerifierReport,
+    ] {
+        let actual = source
+            .invocation_outputs
+            .iter()
+            .filter(|output| output.kind == kind)
+            .count();
+        if actual != 1 {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::InvocationOutputClosureMismatch,
+                "invocationOutputs",
+                invocation_output_kind_name(kind),
+            ));
+        }
+    }
+    let schema_roles = source
+        .generated_artifacts
+        .iter()
+        .filter(|artifact| artifact.kind == GeneratedArtifactKind::ArtifactSchema)
+        .map(|artifact| artifact.role.as_str())
+        .collect::<BTreeSet<_>>();
+    let bindings = source
+        .schema_bindings
+        .iter()
+        .map(|binding| (binding.domain.as_str(), binding))
+        .collect::<BTreeMap<_, _>>();
+    let output_domains = source
+        .invocation_outputs
+        .iter()
+        .map(|output| output.domain.as_str())
+        .collect::<BTreeSet<_>>();
+    let input_domains = source
+        .invocation_inputs
+        .iter()
+        .map(|input| input.domain.as_str())
+        .collect::<BTreeSet<_>>();
+    for output in &source.invocation_outputs {
+        let (expected_domain, _) = expected_output_contract(output.kind);
+        if output.domain != expected_domain {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::OutputDomainMismatch,
+                &output.role,
+                &output.domain,
+            ));
+        }
+    }
+
+    for binding in &source.schema_bindings {
+        if !output_domains.contains(binding.domain.as_str())
+            && !input_domains.contains(binding.domain.as_str())
+        {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::UnexpectedSchemaBinding,
+                "schemaBindings",
+                &binding.domain,
+            ));
+        }
+        require_reference(
+            &schema_roles,
+            &binding.schema_role,
+            ProviderSemanticSourceErrorKind::UnknownSchemaRole,
+            &binding.domain,
+        )?;
+        let expected_root = expected_schema_root(&binding.domain);
+        if let Some(expected_root) = expected_root {
+            if binding.root_rule != expected_root {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::SchemaRootMismatch,
+                    &binding.domain,
+                    &binding.root_rule,
+                ));
+            }
+        }
+    }
+
+    let artifact_roles = source
+        .generated_artifacts
+        .iter()
+        .map(|artifact| (artifact.role.as_str(), artifact.kind))
+        .collect::<BTreeMap<_, _>>();
+    for input in &source.invocation_inputs {
+        require_reference(
+            &schema_roles,
+            &input.schema_role,
+            ProviderSemanticSourceErrorKind::UnknownSchemaRole,
+            &input.role,
+        )?;
+        if let Some(expected_kind) = input_artifact_kind(input.kind) {
+            if artifact_roles.get(input.role.as_str()) != Some(&expected_kind) {
+                return Err(ProviderSemanticSourceError::new(
+                    ProviderSemanticSourceErrorKind::InvocationInputClosureMismatch,
+                    &input.role,
+                    generated_artifact_kind_name(expected_kind),
+                ));
+            }
+        }
+        let Some(binding) = bindings.get(input.domain.as_str()) else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::MissingSchemaBinding,
+                &input.role,
+                &input.domain,
+            ));
+        };
+        if binding.schema_role != input.schema_role {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::SchemaRoleMismatch,
+                &input.role,
+                &input.schema_role,
+            ));
+        }
+    }
+
+    for output in &source.invocation_outputs {
+        require_reference(
+            &schema_roles,
+            &output.schema_role,
+            ProviderSemanticSourceErrorKind::UnknownSchemaRole,
+            &output.role,
+        )?;
+        let (_, expected_root) = expected_output_contract(output.kind);
+        let Some(binding) = bindings.get(output.domain.as_str()) else {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::MissingSchemaBinding,
+                &output.role,
+                &output.domain,
+            ));
+        };
+        if binding.schema_role != output.schema_role {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::SchemaRoleMismatch,
+                &output.role,
+                &output.schema_role,
+            ));
+        }
+        if binding.root_rule != expected_root {
+            return Err(ProviderSemanticSourceError::new(
+                ProviderSemanticSourceErrorKind::SchemaRootMismatch,
+                &output.role,
+                &binding.root_rule,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn expected_output_contract(kind: InvocationOutputKind) -> (&'static str, &'static str) {
+    match kind {
+        InvocationOutputKind::TargetIr => ("edict.target-ir.artifact/v1", "target-ir-artifact"),
+        InvocationOutputKind::GeneratedArtifact => {
+            ("echo.generated-artifact/v1", "generated-artifact")
+        }
+        InvocationOutputKind::ReviewPayload => ("echo.review-payload/v1", "review-payload"),
+        InvocationOutputKind::VerifierReport => ("echo.verifier-report/v1", "verifier-report"),
+    }
+}
+
+const fn expected_input_domain(kind: InvocationInputKind) -> &'static str {
+    match kind {
+        InvocationInputKind::Core => "edict.core.module/v1",
+        InvocationInputKind::TargetProfile => "edict.target-profile/v1",
+        InvocationInputKind::Lawpack => "edict.lawpack/v1",
+        InvocationInputKind::AuthorityFacts => "edict.authority-facts/v1",
+        InvocationInputKind::LowerabilityFacts => "edict.lowering-requirements/v1",
+        InvocationInputKind::TargetIr => "edict.target-ir.artifact/v1",
+    }
+}
+
+const fn invocation_input_kind_name(kind: InvocationInputKind) -> &'static str {
+    match kind {
+        InvocationInputKind::Core => "core",
+        InvocationInputKind::TargetProfile => "targetProfile",
+        InvocationInputKind::Lawpack => "lawpack",
+        InvocationInputKind::AuthorityFacts => "authorityFacts",
+        InvocationInputKind::LowerabilityFacts => "lowerabilityFacts",
+        InvocationInputKind::TargetIr => "targetIr",
+    }
+}
+
+const fn input_artifact_kind(kind: InvocationInputKind) -> Option<GeneratedArtifactKind> {
+    match kind {
+        InvocationInputKind::TargetProfile => Some(GeneratedArtifactKind::TargetProfile),
+        InvocationInputKind::Lawpack => Some(GeneratedArtifactKind::Lawpack),
+        InvocationInputKind::AuthorityFacts => Some(GeneratedArtifactKind::AuthorityFacts),
+        InvocationInputKind::Core
+        | InvocationInputKind::LowerabilityFacts
+        | InvocationInputKind::TargetIr => None,
+    }
+}
+
+const fn invocation_output_kind_name(kind: InvocationOutputKind) -> &'static str {
+    match kind {
+        InvocationOutputKind::TargetIr => "targetIr",
+        InvocationOutputKind::GeneratedArtifact => "generatedArtifact",
+        InvocationOutputKind::ReviewPayload => "reviewPayload",
+        InvocationOutputKind::VerifierReport => "verifierReport",
+    }
+}
+
+fn expected_schema_root(domain: &str) -> Option<&'static str> {
+    match domain {
+        "edict.authority-facts/v1" => Some("authority-facts"),
+        "edict.core.module/v1" => Some("core-module"),
+        "edict.lawpack/v1" => Some("lawpack-manifest"),
+        "edict.lowering-requirements/v1" => Some("lowering-requirements"),
+        "edict.target-profile/v1" => Some("target-profile-manifest"),
+        "edict.target-ir.artifact/v1" => Some("target-ir-artifact"),
+        "echo.generated-artifact/v1" => Some("generated-artifact"),
+        "echo.review-payload/v1" => Some("review-payload"),
+        "echo.verifier-report/v1" => Some("verifier-report"),
+        _ => None,
+    }
+}
+
+fn coordinates<T: HasIdentity>(facts: &[T]) -> BTreeSet<&str> {
+    facts
+        .iter()
+        .map(|fact| fact.identity().coordinate.as_str())
+        .collect()
+}
+
+fn require_reference(
+    known: &BTreeSet<&str>,
+    reference: &str,
+    kind: ProviderSemanticSourceErrorKind,
+    subject: &str,
+) -> Result<(), ProviderSemanticSourceError> {
+    if known.contains(reference) {
+        Ok(())
+    } else {
+        Err(ProviderSemanticSourceError::new(kind, subject, reference))
+    }
+}

--- a/crates/echo-wesley-gen/tests/provider_semantic_source.rs
+++ b/crates/echo-wesley-gen/tests/provider_semantic_source.rs
@@ -1,0 +1,1743 @@
+// SPDX-License-Identifier: Apache-2.0
+// © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots>
+#![allow(clippy::expect_used, clippy::panic)]
+//! Integration tests for the strict Echo Edict provider semantic source.
+
+use echo_wesley_gen::provider_semantics::{
+    parse_provider_semantic_source_v1, ApertureRequirementDeclaration, ArtifactResourceProvision,
+    AuthorityClass, AuthorityFactSourceKind, AuthoritySourceKind, BoundaryKind,
+    CoreStringCanonicalization, EffectKindHint, ExecutionClass, GeneratedArtifactKind,
+    InvocationInputKind, InvocationOutputKind, OpticKind, ProviderSemanticSourceErrorKind,
+    SemanticTypeShape, ECHO_PROVIDER_SEMANTIC_SOURCE_API_V1,
+};
+use serde_json::{json, Value};
+
+const SOURCE: &str =
+    include_str!("../../../schemas/edict-provider/echo-provider-semantics-v1.json");
+
+fn source_value() -> Value {
+    serde_json::from_str(SOURCE).expect("checked source fixture is JSON")
+}
+
+fn assert_failure(mutate: impl FnOnce(&mut Value), expected: ProviderSemanticSourceErrorKind) {
+    let mut source = source_value();
+    mutate(&mut source);
+    let text = serde_json::to_string(&source).expect("mutated source serializes");
+    let error =
+        parse_provider_semantic_source_v1(&text).expect_err("invalid semantic source must fail");
+    assert_eq!(error.kind(), expected);
+}
+
+fn assert_failure_tuple(
+    mutate: impl FnOnce(&mut Value),
+    expected: (ProviderSemanticSourceErrorKind, &str, &str),
+) {
+    let mut source = source_value();
+    mutate(&mut source);
+    assert_source_failure_tuple(&source, expected);
+}
+
+fn assert_source_failure_tuple(
+    source: &Value,
+    expected: (ProviderSemanticSourceErrorKind, &str, &str),
+) {
+    let text = serde_json::to_string(source).expect("mutated source serializes");
+    let error =
+        parse_provider_semantic_source_v1(&text).expect_err("invalid semantic source must fail");
+    assert_eq!((error.kind(), error.subject(), error.reference()), expected);
+}
+
+#[test]
+fn checked_echo_provider_semantic_source_validates() {
+    let validated = parse_provider_semantic_source_v1(SOURCE)
+        .expect("checked Echo provider semantic source validates");
+    let source = validated.source();
+
+    assert_eq!(source.api_version, ECHO_PROVIDER_SEMANTIC_SOURCE_API_V1);
+    assert_eq!(source.coordinate, "echo.semantic-schema@1");
+    assert_eq!(source.operations.len(), 1);
+    assert_eq!(source.operations[0].identity.coordinate, "a.b@1.t");
+    assert_eq!(source.operations[0].effect, "target.replace");
+    assert_eq!(source.types.len(), 6);
+    assert_eq!(
+        source
+            .types
+            .iter()
+            .map(|declaration| declaration.identity.coordinate.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "a.b@1.Id",
+            "a.b@1.Input",
+            "a.b@1.Output",
+            "a.b@1.Receipt",
+            "domain.WriteRejected.Payload",
+            "target.replace.rejected",
+        ]
+    );
+    assert!(matches!(
+        &source.types[0].shape,
+        SemanticTypeShape::CoreStringAlias {
+            max_scalar_values: 16,
+            canonical: CoreStringCanonicalization::RawUtf8,
+        }
+    ));
+    assert_eq!(
+        source.types[0].shape.core_type_coordinate().as_deref(),
+        Some("String<max=16,canonical=raw-utf8>")
+    );
+    assert_eq!(
+        source.types[0].shape.accepts_raw_string(&"é".repeat(16)),
+        Some(true)
+    );
+    assert_eq!(
+        source.types[0].shape.accepts_raw_string(&"é".repeat(17)),
+        Some(false)
+    );
+    for coordinate in ["domain.WriteRejected.Payload", "target.replace.rejected"] {
+        let declaration = source
+            .types
+            .iter()
+            .find(|declaration| declaration.identity.coordinate == coordinate)
+            .expect("empty payload type is declared");
+        assert!(matches!(
+            &declaration.shape,
+            SemanticTypeShape::Record { fields } if fields.is_empty()
+        ));
+    }
+    assert_eq!(source.write_classes[0].identity.coordinate, "replace");
+    assert!(source
+        .generated_artifacts
+        .iter()
+        .filter(|artifact| artifact.kind == GeneratedArtifactKind::AuthorityFacts)
+        .all(|artifact| artifact.contract_owner.as_deref() == Some("flyingrobots/edict#157")));
+    assert_eq!(
+        source.obstructions[0].identity.coordinate,
+        "domain.WriteRejected"
+    );
+    assert_eq!(
+        source.obstructions[0].authority_class,
+        AuthorityClass::DomainMappable
+    );
+    assert_eq!(
+        source.obstructions[0].payload_schema,
+        "domain.WriteRejected.Payload"
+    );
+
+    let effect = &source.effects[0];
+    assert_eq!(effect.identity.coordinate, "target.replace");
+    assert_eq!(effect.parameter_types, ["a.b@1.Id"]);
+    assert_eq!(effect.result_type, "a.b@1.Receipt");
+    assert_eq!(effect.execution_class, ExecutionClass::Runtime);
+    assert_eq!(effect.effect_kind_hint, EffectKindHint::Replace);
+    assert_eq!(effect.guard_kinds, ["precommit-atomic"]);
+    assert!(effect.guard_support);
+    assert_eq!(effect.footprint_obligation, "target.replace.footprint");
+    assert_eq!(effect.cost_obligation, "target.replace.cost");
+    assert_eq!(effect.failures[0].key, "rejected");
+    assert_eq!(
+        effect.failures[0].domain,
+        "echo.edict-provider/effect-failure/v1"
+    );
+    assert_eq!(
+        effect.failures[0].authority,
+        "echo.provider-target-metadata@1"
+    );
+    assert_eq!(
+        effect.failures[0].authority_class,
+        AuthorityClass::DomainMappable
+    );
+    assert_eq!(effect.failures[0].payload_type, "target.replace.rejected");
+
+    let profile = &source.profiles[0];
+    assert_eq!(profile.identity.coordinate, "continuum.profile.write/v1");
+    assert_eq!(profile.source_names, ["p.effectful"]);
+    assert_eq!(profile.allowed_write_classes, ["replace"]);
+    assert_eq!(profile.guard_kinds, ["precommit-atomic"]);
+    assert_eq!(profile.atomicity, "atomic");
+    assert!(profile.postcondition_support);
+    assert_eq!(
+        profile.optic_template.optic_kind,
+        OpticKind::AffectReintegration
+    );
+    assert_eq!(profile.optic_template.boundary_kind, BoundaryKind::Affect);
+    assert_eq!(
+        profile.optic_template.support_policy,
+        "continuum.support.carry-or-obstruct/v1"
+    );
+    assert_eq!(
+        profile.optic_template.loss_disposition,
+        "continuum.support.reject-on-loss/v1"
+    );
+    assert_eq!(
+        profile.optic_template.aperture_requirement,
+        Some(
+            ApertureRequirementDeclaration::AbstractFootprintObligation {
+                reference: "target.replace.footprint".to_owned(),
+            }
+        )
+    );
+    assert_eq!(
+        profile.effect_predicate,
+        "echo.dpo.operation-mode.replace-only/v1"
+    );
+    assert_eq!(profile.optic_contract, "replace-point");
+    assert!(source.direct_adapters.is_empty());
+    assert_eq!(source.budgets[0].max_steps, 8);
+    assert_eq!(source.budgets[0].max_allocated_bytes, 1024);
+    assert_eq!(source.budgets[0].max_output_bytes, 256);
+    assert_eq!(source.capabilities[0].effect, "target.replace");
+    assert_eq!(source.capabilities[0].effect_kind, EffectKindHint::Replace);
+    assert_eq!(source.capabilities[0].write_class, "replace");
+    assert!(source.capabilities[0].guard_support);
+    assert_eq!(
+        source.capabilities[0].footprint_template,
+        "target.replace.footprint"
+    );
+    assert_eq!(source.capabilities[0].cost_template, "target.replace.cost");
+    assert_eq!(
+        source.capabilities[0].semantic_discharge.effect_kind_hint,
+        EffectKindHint::Replace
+    );
+    assert_eq!(
+        source.capabilities[0]
+            .semantic_discharge
+            .footprint_obligation,
+        "target.replace.footprint"
+    );
+    assert_eq!(
+        source.capabilities[0].semantic_discharge.cost_obligation,
+        "target.replace.cost"
+    );
+    assert!(source.capabilities[0].can_participate_in_atomic_guard);
+    assert_eq!(source.capabilities[0].target_profile, "echo.dpo@1");
+    assert_eq!(source.capabilities[0].target_ir_domain, "echo.span-ir/v1");
+    assert_eq!(source.operations[0].obstruction_mappings.len(), 1);
+    assert_eq!(
+        source.operations[0].obstruction_mappings[0].failure,
+        "rejected"
+    );
+    assert_eq!(
+        source.operations[0].obstruction_mappings[0].obstruction,
+        "domain.WriteRejected"
+    );
+
+    let authority_kind = |coordinate: &str| {
+        source
+            .authority_sources
+            .iter()
+            .find(|authority| authority.coordinate == coordinate)
+            .map(|authority| authority.kind)
+            .expect("fact authority is declared")
+    };
+    let fact_contracts = [
+        (
+            &source.types[0].identity,
+            "echo.edict-provider/value/v1",
+            AuthoritySourceKind::EchoSemanticDeclaration,
+        ),
+        (
+            &source.write_classes[0].identity,
+            "echo.edict-provider/write-class/v1",
+            AuthoritySourceKind::TargetMetadata,
+        ),
+        (
+            &source.obstructions[0].identity,
+            "echo.edict-provider/obstruction/v1",
+            AuthoritySourceKind::EchoSemanticDeclaration,
+        ),
+        (
+            &source.effects[0].identity,
+            "echo.edict-provider/semantic-effect/v1",
+            AuthoritySourceKind::EchoSemanticDeclaration,
+        ),
+        (
+            &source.profiles[0].identity,
+            "echo.edict-provider/operation-profile/v1",
+            AuthoritySourceKind::TargetMetadata,
+        ),
+        (
+            &source.budgets[0].identity,
+            "echo.edict-provider/core-budget/v1",
+            AuthoritySourceKind::EchoSemanticDeclaration,
+        ),
+        (
+            &source.capabilities[0].identity,
+            "echo.edict-provider/target-intrinsic/v1",
+            AuthoritySourceKind::TargetMetadata,
+        ),
+        (
+            &source.operations[0].identity,
+            "echo.edict-provider/operation/v1",
+            AuthoritySourceKind::EchoSemanticDeclaration,
+        ),
+    ];
+    for (identity, domain, kind) in fact_contracts {
+        assert_eq!(identity.domain, domain);
+        assert_eq!(authority_kind(&identity.authority), kind);
+    }
+    assert_eq!(
+        authority_kind(&effect.failures[0].authority),
+        AuthoritySourceKind::TargetMetadata
+    );
+    assert_eq!(
+        authority_kind(&source.lawpack_projection.authority),
+        AuthoritySourceKind::EchoSemanticDeclaration
+    );
+    assert_eq!(
+        authority_kind(&source.target_profile_projection.authority),
+        AuthoritySourceKind::TargetMetadata
+    );
+
+    let generated = source
+        .generated_artifacts
+        .iter()
+        .map(|artifact| {
+            (
+                artifact.role.as_str(),
+                artifact.kind,
+                artifact.coordinate.as_str(),
+                artifact.schema_contract.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        generated,
+        vec![
+            (
+                "authority-facts.echo-dpo",
+                GeneratedArtifactKind::AuthorityFacts,
+                "echo.dpo-authority-facts@1",
+                "edict.authority-facts/v1",
+            ),
+            (
+                "authority-facts.echo-lawpack",
+                GeneratedArtifactKind::AuthorityFacts,
+                "echo.dpo-lawpack-authority-facts@1",
+                "edict.authority-facts/v1",
+            ),
+            (
+                "generated-artifact-profile.echo-dpo-registration",
+                GeneratedArtifactKind::GeneratedArtifactProfile,
+                "echo.dpo.registration/v1",
+                "echo.generated-artifact-profile/v1",
+            ),
+            (
+                "lawpack.echo-dpo",
+                GeneratedArtifactKind::Lawpack,
+                "echo.dpo-lawpack@1",
+                "edict.lawpack/v1",
+            ),
+            (
+                "provenance.provider-generation",
+                GeneratedArtifactKind::GenerationProvenance,
+                "echo.edict-provider-generation-provenance@1",
+                "wesley:GenerationProvenanceManifestV1",
+            ),
+            (
+                "review.provider-generation",
+                GeneratedArtifactKind::ReviewArtifact,
+                "echo.edict-provider-generation-review@1",
+                "echo.edict-provider.generation-review/v1",
+            ),
+            (
+                "schema.echo-provider-artifacts",
+                GeneratedArtifactKind::ArtifactSchema,
+                "echo.provider-artifacts.cddl@1",
+                "selfContainedCddlV1",
+            ),
+            (
+                "target-profile.echo-dpo",
+                GeneratedArtifactKind::TargetProfile,
+                "echo.dpo@1",
+                "edict.target-profile/v1",
+            ),
+        ]
+    );
+    let authority_fact_sources = source
+        .generated_artifacts
+        .iter()
+        .filter_map(|artifact| {
+            artifact.authority_fact_source.as_ref().map(|fact_source| {
+                (
+                    artifact.role.as_str(),
+                    fact_source.kind,
+                    fact_source.coordinate.as_str(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        authority_fact_sources,
+        vec![
+            (
+                "authority-facts.echo-dpo",
+                AuthorityFactSourceKind::TargetProfile,
+                "echo.dpo@1",
+            ),
+            (
+                "authority-facts.echo-lawpack",
+                AuthorityFactSourceKind::Lawpack,
+                "echo.dpo-lawpack@1",
+            ),
+        ]
+    );
+    assert_eq!(
+        (
+            source.package_manifest.role.as_str(),
+            source.package_manifest.coordinate.as_str(),
+            source.package_manifest.schema_contract.as_str(),
+            source.package_manifest.provider_abi.as_str(),
+            source.package_manifest.provider_coordinate.as_str(),
+        ),
+        (
+            "provider-manifest.echo",
+            "echo.edict-provider-manifest@1",
+            "edict.provider-manifest/v1",
+            "edict:target-provider@1.0.0",
+            "echo.edict-provider@1",
+        )
+    );
+    let generation_provenance = source
+        .generated_artifacts
+        .iter()
+        .find(|artifact| artifact.kind == GeneratedArtifactKind::GenerationProvenance)
+        .expect("generation provenance is a generated package member");
+    assert_eq!(
+        generation_provenance.contract_owner.as_deref(),
+        Some("flyingrobots/wesley#728")
+    );
+    assert_eq!(source.artifact_resources.len(), 19);
+    assert_eq!(
+        source
+            .artifact_resources
+            .iter()
+            .filter(|resource| resource.provision == ArtifactResourceProvision::External)
+            .map(|resource| resource.coordinate.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "edict.canonical-cbor/v1",
+            "edict.determinism/v1",
+            "edict.diagnostics/v1",
+            "edict.fuel/v1",
+            "edict.wasm-component/v1",
+        ]
+    );
+    assert_eq!(source.lawpack_projection.artifact_role, "lawpack.echo-dpo");
+    assert_eq!(source.lawpack_projection.target_adapters.len(), 1);
+    assert_eq!(
+        source.lawpack_projection.target_adapters[0].effects,
+        ["target.replace"]
+    );
+    assert_eq!(
+        source.target_profile_projection.artifact_role,
+        "target-profile.echo-dpo"
+    );
+    assert_eq!(
+        source
+            .target_profile_projection
+            .generated_artifact_profile_roles,
+        ["generated-artifact-profile.echo-dpo-registration"]
+    );
+
+    let outputs = source
+        .invocation_outputs
+        .iter()
+        .map(|output| (output.role.as_str(), output.kind, output.domain.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outputs,
+        vec![
+            (
+                "generated.echo-dpo",
+                InvocationOutputKind::GeneratedArtifact,
+                "echo.generated-artifact/v1",
+            ),
+            (
+                "review.echo-dpo",
+                InvocationOutputKind::ReviewPayload,
+                "echo.review-payload/v1",
+            ),
+            (
+                "target-ir.echo-dpo",
+                InvocationOutputKind::TargetIr,
+                "edict.target-ir.artifact/v1",
+            ),
+            (
+                "verifier-report.echo-dpo",
+                InvocationOutputKind::VerifierReport,
+                "echo.verifier-report/v1",
+            ),
+        ]
+    );
+    assert_eq!(
+        source
+            .invocation_inputs
+            .iter()
+            .map(|input| (input.role.as_str(), input.kind, input.domain.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "authority-facts.echo-dpo",
+                InvocationInputKind::AuthorityFacts,
+                "edict.authority-facts/v1",
+            ),
+            (
+                "authority-facts.echo-lawpack",
+                InvocationInputKind::AuthorityFacts,
+                "edict.authority-facts/v1",
+            ),
+            (
+                "core.echo-provider",
+                InvocationInputKind::Core,
+                "edict.core.module/v1",
+            ),
+            (
+                "lawpack.echo-dpo",
+                InvocationInputKind::Lawpack,
+                "edict.lawpack/v1",
+            ),
+            (
+                "lowerability.echo-dpo",
+                InvocationInputKind::LowerabilityFacts,
+                "edict.lowering-requirements/v1",
+            ),
+            (
+                "target-ir.echo-dpo",
+                InvocationInputKind::TargetIr,
+                "edict.target-ir.artifact/v1",
+            ),
+            (
+                "target-profile.echo-dpo",
+                InvocationInputKind::TargetProfile,
+                "edict.target-profile/v1",
+            ),
+        ]
+    );
+    assert_eq!(
+        source
+            .schema_bindings
+            .iter()
+            .map(|binding| (binding.domain.as_str(), binding.root_rule.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("echo.generated-artifact/v1", "generated-artifact"),
+            ("echo.review-payload/v1", "review-payload"),
+            ("echo.verifier-report/v1", "verifier-report"),
+            ("edict.authority-facts/v1", "authority-facts"),
+            ("edict.core.module/v1", "core-module"),
+            ("edict.lawpack/v1", "lawpack-manifest"),
+            ("edict.lowering-requirements/v1", "lowering-requirements"),
+            ("edict.target-ir.artifact/v1", "target-ir-artifact"),
+            ("edict.target-profile/v1", "target-profile-manifest"),
+        ]
+    );
+}
+
+#[test]
+fn set_like_source_reordering_preserves_validated_semantics() {
+    let mut ordered = source_value();
+    ordered["types"][0]["shape"]["fields"]
+        .as_array_mut()
+        .expect("record fields are a set")
+        .push(json!({"name": "alternate", "type": "a.b@1.Id"}));
+    ordered["writeClasses"]
+        .as_array_mut()
+        .expect("write classes are a set")
+        .push(json!({
+            "identity": {
+                "coordinate": "read",
+                "domain": "echo.edict-provider/write-class/v1",
+                "authority": "echo.provider-target-metadata@1"
+            }
+        }));
+    ordered["obstructions"]
+        .as_array_mut()
+        .expect("obstructions are a set")
+        .push(json!({
+            "identity": {
+                "coordinate": "domain.OtherRejection",
+                "domain": "echo.edict-provider/obstruction/v1",
+                "authority": "echo.provider-semantic-declaration@1"
+            },
+            "authorityClass": "domainMappable",
+            "payloadSchema": "domain.WriteRejected.Payload"
+        }));
+    ordered["effects"][0]["guardKinds"]
+        .as_array_mut()
+        .expect("effect guards are a set")
+        .push(Value::String("preflight".to_owned()));
+    ordered["effects"][0]["failures"]
+        .as_array_mut()
+        .expect("effect failures are a set")
+        .push(json!({
+            "key": "other",
+            "domain": "echo.edict-provider/effect-failure/v1",
+            "authority": "echo.provider-target-metadata@1",
+            "authorityClass": "domainMappable",
+            "payloadType": "target.replace.rejected"
+        }));
+    ordered["profiles"][0]["sourceNames"]
+        .as_array_mut()
+        .expect("profile source names are a set")
+        .push(Value::String("p.write".to_owned()));
+    ordered["profiles"][0]["allowedWriteClasses"]
+        .as_array_mut()
+        .expect("allowed write classes are a set")
+        .push(Value::String("read".to_owned()));
+    ordered["profiles"][0]["guardKinds"]
+        .as_array_mut()
+        .expect("profile guards are a set")
+        .push(Value::String("preflight".to_owned()));
+    ordered["operations"][0]["obstructionMappings"]
+        .as_array_mut()
+        .expect("obstruction mappings are a key set")
+        .push(json!({
+            "failure": "other",
+            "obstruction": "domain.OtherRejection"
+        }));
+    let mut second_effect = ordered["effects"][0].clone();
+    second_effect["identity"]["coordinate"] = Value::String("target.ensure".to_owned());
+    second_effect["effectKindHint"] = Value::String("ensure".to_owned());
+    second_effect["footprintObligation"] = Value::String("target.ensure.footprint".to_owned());
+    second_effect["costObligation"] = Value::String("target.ensure.cost".to_owned());
+    ordered["effects"]
+        .as_array_mut()
+        .expect("effects")
+        .push(second_effect);
+    let mut second_capability = ordered["capabilities"][0].clone();
+    second_capability["identity"]["coordinate"] = Value::String("echo.dpo@1.ensure".to_owned());
+    second_capability["effect"] = Value::String("target.ensure".to_owned());
+    second_capability["effectKind"] = Value::String("ensure".to_owned());
+    second_capability["footprintTemplate"] =
+        Value::String("echo.dpo.ensure-footprint/v1".to_owned());
+    second_capability["costTemplate"] = Value::String("echo.dpo.ensure-cost/v1".to_owned());
+    second_capability["semanticDischarge"]["effectKindHint"] = Value::String("ensure".to_owned());
+    second_capability["semanticDischarge"]["footprintObligation"] =
+        Value::String("target.ensure.footprint".to_owned());
+    second_capability["semanticDischarge"]["costObligation"] =
+        Value::String("target.ensure.cost".to_owned());
+    ordered["capabilities"]
+        .as_array_mut()
+        .expect("capabilities")
+        .push(second_capability);
+    ordered["lawpackProjection"]["targetAdapters"][0]["effects"]
+        .as_array_mut()
+        .expect("adapter effects")
+        .push(Value::String("target.ensure".to_owned()));
+
+    let ordered_text = serde_json::to_string(&ordered).expect("ordered source serializes");
+    let baseline = parse_provider_semantic_source_v1(&ordered_text)
+        .expect("expanded baseline semantic source validates");
+    let mut reordered = ordered;
+
+    for pointer in [
+        "/types/0/shape/fields",
+        "/effects/0/guardKinds",
+        "/effects/0/failures",
+        "/profiles/0/sourceNames",
+        "/profiles/0/allowedWriteClasses",
+        "/profiles/0/guardKinds",
+        "/operations/0/obstructionMappings",
+        "/lawpackProjection/acceptedCoreAbis",
+        "/lawpackProjection/dependencies",
+        "/lawpackProjection/targetAdapters",
+        "/lawpackProjection/targetAdapters/0/effects",
+        "/targetProfileProjection/acceptedCoreAbis",
+        "/targetProfileProjection/generatedArtifactProfileRoles",
+        "/targetProfileProjection/acceptedLawpackAdapterAbis",
+    ] {
+        reordered
+            .pointer_mut(pointer)
+            .and_then(Value::as_array_mut)
+            .expect("nested set-like field is an array")
+            .reverse();
+    }
+
+    for key in [
+        "authoritySources",
+        "types",
+        "writeClasses",
+        "obstructions",
+        "effects",
+        "profiles",
+        "budgets",
+        "capabilities",
+        "directAdapters",
+        "operations",
+        "artifactResources",
+        "generatedArtifacts",
+        "invocationInputs",
+        "invocationOutputs",
+        "schemaBindings",
+    ] {
+        reordered[key]
+            .as_array_mut()
+            .expect("set-like declaration family is an array")
+            .reverse();
+    }
+
+    let text = serde_json::to_string(&reordered).expect("reordered source serializes");
+    let normalized =
+        parse_provider_semantic_source_v1(&text).expect("reordered semantic source validates");
+    assert_eq!(baseline, normalized);
+}
+
+#[test]
+fn conflicting_duplicate_coordinate_fails_deterministically() {
+    let mut source = source_value();
+    let mut duplicate = source["effects"][0].clone();
+    duplicate["resultType"] = Value::String("echo.unknown.Result@1".to_owned());
+    source["effects"]
+        .as_array_mut()
+        .expect("effects array")
+        .push(duplicate);
+    let expected = (
+        ProviderSemanticSourceErrorKind::DuplicateCoordinate,
+        "effects",
+        "target.replace",
+    );
+    assert_source_failure_tuple(&source, expected);
+    source["effects"]
+        .as_array_mut()
+        .expect("effects array")
+        .reverse();
+    assert_source_failure_tuple(&source, expected);
+}
+
+#[test]
+fn recursive_type_graphs_fail_with_deterministic_edges() {
+    assert_failure_tuple(
+        |source| {
+            source["types"][0]["shape"]["fields"][0]["type"] =
+                Value::String("a.b@1.Input".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::UnboundedTypeGraph,
+            "a.b@1.Input",
+            "a.b@1.Input",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["types"][0]["shape"]["fields"][0]["type"] =
+                Value::String("a.b@1.Output".to_owned());
+            source["types"][2]["shape"]["fields"][0]["type"] =
+                Value::String("a.b@1.Input".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::UnboundedTypeGraph,
+            "a.b@1.Input",
+            "a.b@1.Output",
+        ),
+    );
+
+    let mut source = source_value();
+    for index in [0, 2] {
+        let coordinate = source["types"][index]["identity"]["coordinate"]
+            .as_str()
+            .expect("type coordinate")
+            .to_owned();
+        source["types"][index]["shape"]["fields"][0]["type"] = Value::String(coordinate);
+    }
+    let expected = (
+        ProviderSemanticSourceErrorKind::UnboundedTypeGraph,
+        "a.b@1.Input",
+        "a.b@1.Input",
+    );
+    assert_source_failure_tuple(&source, expected);
+    source["types"]
+        .as_array_mut()
+        .expect("types array")
+        .reverse();
+    assert_source_failure_tuple(&source, expected);
+}
+
+#[test]
+fn core_string_alias_keeps_edict_core_authority() {
+    assert_failure(
+        |source| {
+            source["types"][3]["shape"]["maxBytes"] = json!(16);
+        },
+        ProviderSemanticSourceErrorKind::MalformedDocument,
+    );
+    assert_failure(
+        |source| {
+            source["types"][3]["shape"]
+                .as_object_mut()
+                .expect("core alias shape")
+                .remove("canonical");
+        },
+        ProviderSemanticSourceErrorKind::MalformedDocument,
+    );
+    assert_failure(
+        |source| {
+            source["types"][3]["shape"]["canonical"] = Value::String("unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::MalformedDocument,
+    );
+    for coordinate in ["String<max=16>", "Bool", "List<a.b@1.Id,max=1>"] {
+        assert_failure_tuple(
+            |source| {
+                source["types"][3]["identity"]["coordinate"] = Value::String(coordinate.to_owned());
+            },
+            (
+                ProviderSemanticSourceErrorKind::CoreTypeAuthorityMismatch,
+                coordinate,
+                "edict.core/v1",
+            ),
+        );
+    }
+}
+
+#[test]
+fn stale_relocated_sdl_cannot_override_declared_coordinate() {
+    assert_failure(
+        |source| {
+            source["authoritySources"]
+                .as_array_mut()
+                .expect("authority source array")
+                .push(json!({
+                        "coordinate": "echo.stale-relocated-sdl@1",
+                        "kind": "graphql",
+                        "artifact": "schemas/wesley-relocated/echo.graphql"
+                }));
+            source["types"][0]["identity"]["authority"] =
+                Value::String("echo.stale-relocated-sdl@1".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::NonAuthoritativeSource,
+    );
+}
+
+#[test]
+fn authority_locators_must_be_authored_repository_paths() {
+    for locator in [
+        "/tmp/semantic.json",
+        "../semantic.json",
+        "https://example.com/semantic.json",
+        "schemas\\semantic.json",
+        "target/generated/semantic.json",
+    ] {
+        assert_failure_tuple(
+            |source| {
+                source["authoritySources"][0]["artifact"] = Value::String(locator.to_owned());
+            },
+            (
+                ProviderSemanticSourceErrorKind::NonAuthoritativeSource,
+                "echo.provider-semantic-declaration@1",
+                locator,
+            ),
+        );
+    }
+}
+
+#[test]
+fn fact_domains_and_authority_families_fail_closed() {
+    let wrong_domain = "echo.edict-provider/wrong/v1";
+    for (pointer, coordinate) in [
+        ("/types/0/identity", "a.b@1.Input"),
+        ("/writeClasses/0/identity", "replace"),
+        ("/obstructions/0/identity", "domain.WriteRejected"),
+        ("/effects/0/identity", "target.replace"),
+        ("/profiles/0/identity", "continuum.profile.write/v1"),
+        ("/budgets/0/identity", "p.tiny"),
+        ("/capabilities/0/identity", "echo.dpo@1.replace"),
+        ("/operations/0/identity", "a.b@1.t"),
+    ] {
+        assert_failure_tuple(
+            |source| {
+                source.pointer_mut(pointer).expect("fact identity")["domain"] =
+                    Value::String(wrong_domain.to_owned());
+            },
+            (
+                ProviderSemanticSourceErrorKind::FactDomainMismatch,
+                coordinate,
+                wrong_domain,
+            ),
+        );
+    }
+    assert_failure_tuple(
+        |source| {
+            source["effects"][0]["failures"][0]["domain"] = Value::String(wrong_domain.to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::FactDomainMismatch,
+            "target.replace",
+            wrong_domain,
+        ),
+    );
+
+    for (pointer, coordinate, authority) in [
+        (
+            "/types/0/identity",
+            "a.b@1.Input",
+            "echo.provider-target-metadata@1",
+        ),
+        (
+            "/writeClasses/0/identity",
+            "replace",
+            "echo.provider-semantic-declaration@1",
+        ),
+        (
+            "/obstructions/0/identity",
+            "domain.WriteRejected",
+            "echo.provider-target-metadata@1",
+        ),
+        (
+            "/effects/0/identity",
+            "target.replace",
+            "echo.provider-target-metadata@1",
+        ),
+        (
+            "/profiles/0/identity",
+            "continuum.profile.write/v1",
+            "echo.provider-semantic-declaration@1",
+        ),
+        (
+            "/budgets/0/identity",
+            "p.tiny",
+            "echo.provider-target-metadata@1",
+        ),
+        (
+            "/capabilities/0/identity",
+            "echo.dpo@1.replace",
+            "echo.provider-semantic-declaration@1",
+        ),
+        (
+            "/operations/0/identity",
+            "a.b@1.t",
+            "echo.provider-target-metadata@1",
+        ),
+    ] {
+        assert_failure_tuple(
+            |source| {
+                source.pointer_mut(pointer).expect("fact identity")["authority"] =
+                    Value::String(authority.to_owned());
+            },
+            (
+                ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+                coordinate,
+                authority,
+            ),
+        );
+    }
+    assert_failure_tuple(
+        |source| {
+            source["effects"][0]["failures"][0]["authority"] =
+                Value::String("echo.provider-semantic-declaration@1".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+            "target.replace",
+            "echo.provider-semantic-declaration@1",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["lawpackProjection"]["authority"] =
+                Value::String("echo.provider-target-metadata@1".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+            "lawpackProjection",
+            "echo.provider-target-metadata@1",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["targetProfileProjection"]["authority"] =
+                Value::String("echo.provider-semantic-declaration@1".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+            "targetProfileProjection",
+            "echo.provider-semantic-declaration@1",
+        ),
+    );
+
+    let adapter = json!({
+        "identity": {
+            "coordinate": "echo.dpo@1.replace-adapter",
+            "domain": "echo.edict-provider/direct-adapter/v1",
+            "authority": "echo.provider-target-metadata@1"
+        },
+        "consumesEffect": "target.replace",
+        "capability": "echo.dpo@1.replace",
+        "emitsEffects": []
+    });
+    assert_failure_tuple(
+        |source| {
+            source["directAdapters"] = json!([adapter.clone()]);
+            source["directAdapters"][0]["identity"]["domain"] =
+                Value::String(wrong_domain.to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::FactDomainMismatch,
+            "echo.dpo@1.replace-adapter",
+            wrong_domain,
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["directAdapters"] = json!([adapter.clone()]);
+            source["directAdapters"][0]["identity"]["authority"] =
+                Value::String("echo.provider-semantic-declaration@1".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::FactAuthorityMismatch,
+            "echo.dpo@1.replace-adapter",
+            "echo.provider-semantic-declaration@1",
+        ),
+    );
+}
+
+#[test]
+fn unknown_semantic_references_fail_with_stable_kinds() {
+    assert_failure(
+        |source| {
+            source["operations"][0]["inputType"] = Value::String("type.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownType,
+    );
+    assert_failure(
+        |source| {
+            source["operations"][0]["obstructionMappings"][0]["obstruction"] =
+                Value::String("obstruction.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownObstruction,
+    );
+    assert_failure(
+        |source| {
+            source["operations"][0]["obstructionMappings"][0]["failure"] =
+                Value::String("failure_unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownFailure,
+    );
+    assert_failure(
+        |source| {
+            source["operations"][0]["profile"] = Value::String("profile.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownProfile,
+    );
+    assert_failure(
+        |source| {
+            source["capabilities"][0]["effect"] = Value::String("effect.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownEffect,
+    );
+    assert_failure(
+        |source| {
+            source["capabilities"][0]["targetProfile"] =
+                Value::String("target-profile.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownProfile,
+    );
+    assert_failure(
+        |source| {
+            source["operations"][0]["budget"] = Value::String("budget.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownBudget,
+    );
+    assert_failure(
+        |source| {
+            source["operations"][0]["implementation"]["capability"] =
+                Value::String("capability.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownCapability,
+    );
+    assert_failure(
+        |source| {
+            source["operations"][0]["implementation"] = json!({
+                "kind": "directAdapter",
+                "adapter": "adapter.unknown"
+            });
+        },
+        ProviderSemanticSourceErrorKind::UnknownAdapter,
+    );
+}
+
+#[test]
+fn strict_shape_and_set_duplicates_fail_deterministically() {
+    assert_failure(
+        |source| {
+            source["unexpected"] = Value::Bool(true);
+        },
+        ProviderSemanticSourceErrorKind::MalformedDocument,
+    );
+    for pointer in [
+        "/effects/0/guardKinds",
+        "/profiles/0/sourceNames",
+        "/profiles/0/allowedWriteClasses",
+        "/profiles/0/guardKinds",
+    ] {
+        assert_failure(
+            |source| {
+                let values = source
+                    .pointer_mut(pointer)
+                    .and_then(Value::as_array_mut)
+                    .expect("set field is an array");
+                values.push(values[0].clone());
+            },
+            ProviderSemanticSourceErrorKind::DuplicateKey,
+        );
+    }
+    for pointer in ["/effects/0/failures", "/operations/0/obstructionMappings"] {
+        assert_failure(
+            |source| {
+                let values = source
+                    .pointer_mut(pointer)
+                    .and_then(Value::as_array_mut)
+                    .expect("keyed declaration field is an array");
+                values.push(values[0].clone());
+            },
+            ProviderSemanticSourceErrorKind::DuplicateKey,
+        );
+    }
+}
+
+#[test]
+fn profile_source_names_are_globally_unique() {
+    assert_failure_tuple(
+        |source| {
+            let mut profile = source["profiles"][0].clone();
+            profile["identity"]["coordinate"] =
+                Value::String("continuum.profile.write-secondary/v1".to_owned());
+            source["profiles"]
+                .as_array_mut()
+                .expect("profiles")
+                .push(profile);
+        },
+        (
+            ProviderSemanticSourceErrorKind::DuplicateKey,
+            "profiles.sourceNames",
+            "p.effectful",
+        ),
+    );
+}
+
+#[test]
+fn typed_failure_and_mapping_closure_fails_closed() {
+    for key in ["bad-name", "1bad", "else"] {
+        assert_failure_tuple(
+            |source| {
+                source["effects"][0]["failures"][0]["key"] = Value::String(key.to_owned());
+                source["operations"][0]["obstructionMappings"][0]["failure"] =
+                    Value::String(key.to_owned());
+            },
+            (
+                ProviderSemanticSourceErrorKind::InvalidFailureKey,
+                "target.replace",
+                key,
+            ),
+        );
+    }
+    assert_failure(
+        |source| {
+            source["effects"][0]["failures"][0]["payloadType"] =
+                Value::String("type.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownType,
+    );
+    assert_failure(
+        |source| {
+            source["obstructions"][0]["payloadSchema"] = Value::String("type.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownType,
+    );
+    assert_failure(
+        |source| {
+            source["effects"][0]["failures"][0]["authorityClass"] =
+                Value::String("participantOwned".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::ObstructionMappingMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["operations"][0]["obstructionMappings"] = json!([]);
+        },
+        ProviderSemanticSourceErrorKind::ObstructionMappingMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["effects"][0]["failures"][0]["payloadType"] =
+                Value::String("a.b@1.Input".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnsupportedObstructionPayloadMapping,
+    );
+    assert_failure(
+        |source| {
+            source["obstructions"][0]["payloadSchema"] = Value::String("a.b@1.Input".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnsupportedObstructionPayloadMapping,
+    );
+}
+
+#[test]
+fn effect_profile_and_implementation_joins_fail_closed() {
+    assert_failure(
+        |source| {
+            source["effects"][0]["parameterTypes"] = json!([]);
+        },
+        ProviderSemanticSourceErrorKind::UnsupportedEffectShape,
+    );
+    assert_failure(
+        |source| {
+            source["profiles"][0]["allowedWriteClasses"] = json!([]);
+        },
+        ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["profiles"][0]["guardKinds"] = json!([]);
+        },
+        ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+    );
+    let mut independent_target_authority = source_value();
+    independent_target_authority["capabilities"][0]["effectKind"] =
+        Value::String("custom".to_owned());
+    independent_target_authority["capabilities"][0]["footprintTemplate"] =
+        Value::String("echo.dpo.replace-footprint/v1".to_owned());
+    independent_target_authority["capabilities"][0]["costTemplate"] =
+        Value::String("echo.dpo.replace-cost/v1".to_owned());
+    let text = serde_json::to_string(&independent_target_authority)
+        .expect("independent target authority serializes");
+    parse_provider_semantic_source_v1(&text)
+        .expect("target-authoritative facts need not equal advisory lawpack facts");
+    assert_failure_tuple(
+        |source| {
+            source["capabilities"][0]["writeClass"] = Value::String("changed".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::UnknownWriteClass,
+            "echo.dpo@1.replace",
+            "changed",
+        ),
+    );
+    for (field, value) in [
+        ("effectKindHint", "create"),
+        ("footprintObligation", "changed"),
+        ("costObligation", "changed"),
+    ] {
+        assert_failure(
+            |source| {
+                source["capabilities"][0]["semanticDischarge"][field] =
+                    Value::String(value.to_owned());
+            },
+            ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+        );
+    }
+    assert_failure_tuple(
+        |source| {
+            source["effects"][0]["executionClass"] = Value::String("proofOnly".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+            "echo.dpo@1.replace",
+            "target.replace",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["capabilities"][0]["canParticipateInAtomicGuard"] = Value::Bool(false);
+        },
+        (
+            ProviderSemanticSourceErrorKind::ImplementationEffectMismatch,
+            "echo.dpo@1.replace",
+            "target.replace",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["profiles"][0]["opticTemplate"]
+                .as_object_mut()
+                .expect("optic template")
+                .remove("apertureRequirement");
+        },
+        (
+            ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+            "a.b@1.t",
+            "target.replace.footprint",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["profiles"][0]["opticTemplate"]["apertureRequirement"] = json!({
+                "kind": "footprintCeiling",
+                "ref": "target.replace.footprint"
+            });
+        },
+        (
+            ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+            "a.b@1.t",
+            "target.replace.footprint",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["profiles"][0]["opticTemplate"]["apertureRequirement"]["ref"] =
+                Value::String("changed".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+            "a.b@1.t",
+            "changed",
+        ),
+    );
+    for (field, value, reference) in [
+        ("opticKind", "revelation", "revelation"),
+        ("boundaryKind", "projection", "projection"),
+    ] {
+        assert_failure_tuple(
+            |source| {
+                source["profiles"][0]["opticTemplate"][field] = Value::String(value.to_owned());
+            },
+            (
+                ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+                "a.b@1.t",
+                reference,
+            ),
+        );
+    }
+    assert_failure_tuple(
+        |source| {
+            source["profiles"][0]["atomicity"] = Value::String("non-atomic".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+            "a.b@1.t",
+            "non-atomic",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["writeClasses"]
+                .as_array_mut()
+                .expect("write classes")
+                .push(json!({
+                    "identity": {
+                        "coordinate": "read",
+                        "domain": "echo.edict-provider/write-class/v1",
+                        "authority": "echo.provider-target-metadata@1"
+                    }
+                }));
+            source["capabilities"][0]["writeClass"] = Value::String("read".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+            "a.b@1.t",
+            "read",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["writeClasses"]
+                .as_array_mut()
+                .expect("write classes")
+                .push(json!({
+                    "identity": {
+                        "coordinate": "read",
+                        "domain": "echo.edict-provider/write-class/v1",
+                        "authority": "echo.provider-target-metadata@1"
+                    }
+                }));
+            let mut target_effect = source["effects"][0].clone();
+            target_effect["identity"]["coordinate"] = Value::String("target.read".to_owned());
+            target_effect["effectKindHint"] = Value::String("read".to_owned());
+            target_effect["footprintObligation"] =
+                Value::String("target.read.footprint".to_owned());
+            target_effect["costObligation"] = Value::String("target.read.cost".to_owned());
+            source["effects"]
+                .as_array_mut()
+                .expect("effects")
+                .push(target_effect);
+            source["capabilities"][0]["identity"]["coordinate"] =
+                Value::String("echo.dpo@1.read".to_owned());
+            source["capabilities"][0]["effect"] = Value::String("target.read".to_owned());
+            source["capabilities"][0]["effectKind"] = Value::String("read".to_owned());
+            source["capabilities"][0]["writeClass"] = Value::String("read".to_owned());
+            source["capabilities"][0]["footprintTemplate"] =
+                Value::String("target.read.footprint".to_owned());
+            source["capabilities"][0]["costTemplate"] =
+                Value::String("target.read.cost".to_owned());
+            source["capabilities"][0]["semanticDischarge"]["effectKindHint"] =
+                Value::String("read".to_owned());
+            source["capabilities"][0]["semanticDischarge"]["footprintObligation"] =
+                Value::String("target.read.footprint".to_owned());
+            source["capabilities"][0]["semanticDischarge"]["costObligation"] =
+                Value::String("target.read.cost".to_owned());
+            source["directAdapters"] = json!([{
+                "identity": {
+                    "coordinate": "echo.dpo@1.replace-adapter",
+                    "domain": "echo.edict-provider/direct-adapter/v1",
+                    "authority": "echo.provider-target-metadata@1"
+                },
+                "consumesEffect": "target.replace",
+                "capability": "echo.dpo@1.read",
+                "emitsEffects": []
+            }]);
+            source["operations"][0]["implementation"] = json!({
+                "kind": "directAdapter",
+                "adapter": "echo.dpo@1.replace-adapter"
+            });
+        },
+        (
+            ProviderSemanticSourceErrorKind::ProfileEffectMismatch,
+            "a.b@1.t",
+            "read",
+        ),
+    );
+    assert_failure(
+        |source| {
+            let mut duplicate = source["capabilities"][0].clone();
+            duplicate["identity"]["coordinate"] =
+                Value::String("echo.dpo@1.replace-again".to_owned());
+            source["capabilities"]
+                .as_array_mut()
+                .expect("capabilities array")
+                .push(duplicate);
+        },
+        ProviderSemanticSourceErrorKind::AmbiguousEffectImplementation,
+    );
+    assert_failure_tuple(
+        |source| {
+            source["directAdapters"] = json!([{
+                "identity": {
+                    "coordinate": "echo.dpo@1.replace-adapter",
+                    "domain": "echo.edict-provider/direct-adapter/v1",
+                    "authority": "echo.provider-target-metadata@1"
+                },
+                "consumesEffect": "target.replace",
+                "capability": "echo.dpo@1.replace",
+                "emitsEffects": []
+            }]);
+        },
+        (
+            ProviderSemanticSourceErrorKind::AmbiguousEffectImplementation,
+            "effectImplementations",
+            "target.replace",
+        ),
+    );
+    assert_failure(
+        |source| {
+            source["directAdapters"] = json!([{
+                "identity": {
+                    "coordinate": "echo.dpo@1.replace-adapter",
+                    "domain": "echo.edict-provider/direct-adapter/v1",
+                    "authority": "echo.provider-target-metadata@1"
+                },
+                "consumesEffect": "target.replace",
+                "capability": "echo.dpo@1.replace",
+                "emitsEffects": ["target.replace"]
+            }]);
+        },
+        ProviderSemanticSourceErrorKind::UnsupportedAdapterChain,
+    );
+}
+
+#[test]
+fn every_runtime_effect_requires_exactly_one_implementation() {
+    assert_failure_tuple(
+        |source| {
+            let mut effect = source["effects"][0].clone();
+            effect["identity"]["coordinate"] = Value::String("target.unimplemented".to_owned());
+            effect["effectKindHint"] = Value::String("ensure".to_owned());
+            effect["footprintObligation"] =
+                Value::String("target.unimplemented.footprint".to_owned());
+            effect["costObligation"] = Value::String("target.unimplemented.cost".to_owned());
+            source["effects"]
+                .as_array_mut()
+                .expect("effects")
+                .push(effect);
+            source["lawpackProjection"]["targetAdapters"][0]["effects"]
+                .as_array_mut()
+                .expect("adapter effects")
+                .push(Value::String("target.unimplemented".to_owned()));
+        },
+        (
+            ProviderSemanticSourceErrorKind::MissingEffectImplementation,
+            "effectImplementations",
+            "target.unimplemented",
+        ),
+    );
+}
+
+#[test]
+fn lawpack_target_profile_selector_is_unique_and_order_independent() {
+    let mut source = source_value();
+    let mut duplicate = source["lawpackProjection"]["targetAdapters"][0].clone();
+    duplicate["adapterResource"] = Value::String("resource.lawpack-target-adapter-copy".to_owned());
+    source["lawpackProjection"]["targetAdapters"]
+        .as_array_mut()
+        .expect("target adapters")
+        .push(duplicate);
+
+    let expected = (
+        ProviderSemanticSourceErrorKind::DuplicateKey,
+        "lawpackProjection.targetAdapters.acceptedTargetProfileRole",
+        "target-profile.echo-dpo",
+    );
+    assert_source_failure_tuple(&source, expected);
+    source["lawpackProjection"]["targetAdapters"]
+        .as_array_mut()
+        .expect("target adapters")
+        .reverse();
+    assert_source_failure_tuple(&source, expected);
+}
+
+#[test]
+fn one_target_profile_cannot_mix_inner_target_ir_domains() {
+    assert_failure_tuple(
+        |source| {
+            let mut capability = source["capabilities"][0].clone();
+            capability["identity"]["coordinate"] =
+                Value::String("echo.dpo@1.replace-other".to_owned());
+            capability["targetIrDomain"] = Value::String("echo.other-ir/v1".to_owned());
+            source["capabilities"]
+                .as_array_mut()
+                .expect("capabilities")
+                .push(capability);
+        },
+        (
+            ProviderSemanticSourceErrorKind::TargetIrDomainMismatch,
+            "echo.dpo@1",
+            "echo.other-ir/v1",
+        ),
+    );
+}
+
+#[test]
+fn generated_artifact_and_output_contracts_are_exact() {
+    assert_failure(
+        |source| {
+            source["generatedArtifacts"][0]["schemaContract"] =
+                Value::String("edict.wrong/v1".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::ArtifactSchemaContractMismatch,
+    );
+    assert_failure_tuple(
+        |source| {
+            source["generatedArtifacts"]
+                .as_array_mut()
+                .expect("generated artifacts")
+                .push(json!({
+                    "role": "provider-manifest.echo-copy",
+                    "kind": "providerManifest",
+                    "coordinate": "echo.edict-provider-manifest-copy@1",
+                    "schemaContract": "edict.provider-manifest/v1"
+                }));
+        },
+        (
+            ProviderSemanticSourceErrorKind::SelfReferentialManifestInventory,
+            "provider-manifest.echo-copy",
+            "echo.edict-provider-manifest-copy@1",
+        ),
+    );
+    for field in ["providerAbi", "providerCoordinate"] {
+        assert_failure_tuple(
+            |source| {
+                source["packageManifest"][field] = Value::String("wrong@1".to_owned());
+            },
+            (
+                ProviderSemanticSourceErrorKind::ProviderManifestProjectionMismatch,
+                "provider-manifest.echo",
+                "wrong@1",
+            ),
+        );
+    }
+    assert_failure_tuple(
+        |source| {
+            source["generatedArtifacts"][0]
+                .as_object_mut()
+                .expect("authority facts")
+                .remove("authorityFactSource");
+        },
+        (
+            ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+            "authority-facts.echo-dpo",
+            "authorityFactSource",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["generatedArtifacts"][0]["contractOwner"] =
+                Value::String("flyingrobots/echo#651".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::ArtifactContractOwnerMismatch,
+            "authority-facts.echo-dpo",
+            "flyingrobots/echo#651",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["generatedArtifacts"][0]["authorityFactSource"]["coordinate"] =
+                Value::String("echo.dpo-lawpack@1".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+            "authority-facts.echo-dpo",
+            "echo.dpo-lawpack@1",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["generatedArtifacts"][1]["authorityFactSource"] = json!({
+                "kind": "targetProfile",
+                "coordinate": "echo.dpo@1"
+            });
+        },
+        (
+            ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+            "generatedArtifacts",
+            "lawpack",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["generatedArtifacts"][3]["authorityFactSource"] = json!({
+                "kind": "lawpack",
+                "coordinate": "echo.dpo-lawpack@1"
+            });
+        },
+        (
+            ProviderSemanticSourceErrorKind::AuthorityFactProjectionMismatch,
+            "lawpack.echo-dpo",
+            "echo.dpo-lawpack@1",
+        ),
+    );
+    assert_failure(
+        |source| {
+            source["generatedArtifacts"][4]["schemaContract"] =
+                Value::String("wesley:Unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::GenerationProvenanceContractMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["generatedArtifacts"][4]["contractOwner"] =
+                Value::String("flyingrobots/echo#651".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::GenerationProvenanceContractMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["lawpackProjection"]["targetAdapters"] = json!([]);
+        },
+        ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["targetProfileProjection"]["intrinsicsResource"] =
+                Value::String("resource.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["targetProfileProjection"]["generatedArtifactProfileRoles"] = json!([]);
+        },
+        ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+    );
+    for index in 0..19 {
+        assert_failure(
+            |source| {
+                source["artifactResources"][index]["schemaContract"] =
+                    Value::String("echo.wrong/v1".to_owned());
+            },
+            ProviderSemanticSourceErrorKind::ArtifactClosureMismatch,
+        );
+    }
+    assert_failure(
+        |source| {
+            source["invocationOutputs"][0]["domain"] =
+                Value::String("echo.review-payload/v1".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::OutputDomainMismatch,
+    );
+    assert_failure(
+        |source| {
+            source["schemaBindings"][2]["rootRule"] = Value::String("wrong-root".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::SchemaRootMismatch,
+    );
+}
+
+#[test]
+fn invocation_inputs_and_outputs_require_declared_schema_roles_and_domains() {
+    assert_failure_tuple(
+        |source| {
+            source["invocationInputs"]
+                .as_array_mut()
+                .expect("invocation inputs")
+                .remove(2);
+        },
+        (
+            ProviderSemanticSourceErrorKind::InvocationInputClosureMismatch,
+            "invocationInputs",
+            "core",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["invocationInputs"][2]["domain"] = Value::String("edict.wrong/v1".to_owned());
+        },
+        (
+            ProviderSemanticSourceErrorKind::InputDomainMismatch,
+            "core.echo-provider",
+            "edict.wrong/v1",
+        ),
+    );
+    assert_failure(
+        |source| {
+            source["invocationInputs"][0]["schemaRole"] =
+                Value::String("schema.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownSchemaRole,
+    );
+    assert_failure(
+        |source| {
+            source["invocationOutputs"][0]["schemaRole"] =
+                Value::String("schema.unknown".to_owned());
+        },
+        ProviderSemanticSourceErrorKind::UnknownSchemaRole,
+    );
+    assert_failure(
+        |source| {
+            source["schemaBindings"]
+                .as_array_mut()
+                .expect("schema bindings array")
+                .remove(0);
+        },
+        ProviderSemanticSourceErrorKind::MissingSchemaBinding,
+    );
+    assert_failure_tuple(
+        |source| {
+            source["invocationOutputs"]
+                .as_array_mut()
+                .expect("invocation outputs")
+                .remove(0);
+        },
+        (
+            ProviderSemanticSourceErrorKind::InvocationOutputClosureMismatch,
+            "invocationOutputs",
+            "generatedArtifact",
+        ),
+    );
+    assert_failure_tuple(
+        |source| {
+            source["schemaBindings"]
+                .as_array_mut()
+                .expect("schema bindings")
+                .push(json!({
+                    "domain": "echo.unused/v1",
+                    "schemaRole": "schema.echo-provider-artifacts",
+                    "format": "selfContainedCddlV1",
+                    "rootRule": "unused"
+                }));
+        },
+        (
+            ProviderSemanticSourceErrorKind::UnexpectedSchemaBinding,
+            "schemaBindings",
+            "echo.unused/v1",
+        ),
+    );
+}

--- a/docs/architecture/application-contract-hosting.md
+++ b/docs/architecture/application-contract-hosting.md
@@ -60,6 +60,7 @@ The design evidence for this boundary lives in these repo-local packets:
 - `docs/design/0015-registry-provider-host-boundary-decision/design.md`
 - `docs/design/0016-wesley-to-echo-toy-contract-proof/design.md`
 - `docs/design/0017-authenticated-wesley-intent-admission-posture/design.md`
+- `docs/design/echo-edict-provider-semantic-source.md`
 
 ## Ownership Split
 
@@ -114,6 +115,87 @@ Echo's generic runtime surfaces. That bridge has two separate faces:
 | :-------------------- | :---------------------------------------------------------------------- |
 | Application helpers   | Build canonical EINT intent bytes and `ObservationRequest` values.      |
 | Contract-host helpers | Install generated mutation handler rules and read-only query observers. |
+
+## External Edict Provider Artifacts
+
+Echo also owns the runtime-specific semantics supplied to Edict's generic
+external provider host. That pipeline has a separate source and output boundary:
+
+```text
+Echo GraphQL and checked semantic declarations
+  -> Echo-Wesley generators
+  -> generated lawpack, target profile, split authority facts, schemas,
+     review projection, generated-artifact profile, and provenance
+  -> provider-owned lowerer and verifier components
+  -> #655 generated provider manifest and digest-locked Echo provider package
+  -> Edict's runtime-neutral provider host
+```
+
+The first checked non-GraphQL source is
+[`schemas/edict-provider/echo-provider-semantics-v1.json`](../../schemas/edict-provider/echo-provider-semantics-v1.json).
+Its executable schema and pure validator live in
+`echo_wesley_gen::provider_semantics`. The source fixes one reviewed
+compatibility operation and explicitly records its type family, effect
+signature and execution class, typed failure and obstruction
+schemas, exhaustive obstruction mapping, full Edict optic profile, budget,
+target-owned write-class/native capability, complete manifest resources,
+artifact roles, invocation domains, and CDDL roots. Package records use an
+Echo-owned alias over the exact Edict Core string coordinate rather than
+redefining Core string semantics.
+
+The provider source follows three authority rules:
+
+1. A semantic fact has one stable coordinate, one named authority artifact, and
+   one canonical domain.
+2. Generated files are projections. A lawpack, profile, facts file, manifest,
+   schema, provenance record, or review rendering cannot become input authority.
+3. There is no directory or registry search. Runtime SDL and historical
+   relocated Wesley SDL do not become fallback authority merely because they
+   contain a matching name.
+
+The authority split is structural. The semantic declaration owns the portable
+effect, domain obstruction, source mapping, budget, and operation. Target
+metadata owns the operation profile and optic template, low-level failure
+taxonomy, write-class resolution, native capability, and inner Target IR
+selection. An explicit discharge mapping joins target authority to the
+lawpack's advisory hint and abstract footprint/cost obligations without making
+the two vocabularies identical. The semantic source's invocation/schema
+inventory owns the outer provider artifact domain. The validator checks the
+joins between those facts and rejects missing mappings, incompatible profiles,
+capability/effect disagreement, missing or ambiguous implementations, duplicate
+target-profile adapter selectors, recursive types, Core ownership violations,
+invalid failure identifiers, incomplete artifact closure, and non-empty payload
+mappings that would require generator-authored semantics.
+
+The provider manifest is a #655 package-root output, not a #652 member of its
+own artifact list. Two authority-facts documents preserve Edict's one-source
+rule: lawpack facts carry budgets, while target-profile facts carry operation
+profiles and resolved effect write classes. Their canonical byte contract is
+Edict-owned and landed under Edict #157 in Edict PR #159. Generated resource
+declarations carry no output digests. Standard Edict resources are explicit
+trusted inputs whose canonical publication is tracked by Edict #158.
+
+The target-profile lowerer and verifier resources are generated declarative
+contract documents. They do not select executable implementations. The package
+manifest separately binds the exact provider-owned components and their frozen
+WIT world attestations, preserving independent lowerers and component upgrades
+without target-profile semantic churn.
+
+The package-root projection pins `echo.edict-provider@1` to exact component
+world `edict:target-provider@1.0.0`. Generated provenance is a generic Edict
+`generationProvenance` package member whose document contract remains owned by
+Wesley #728.
+
+The first capability distinguishes two nested domains. `echo.span-ir/v1` is
+the inner Echo target IR domain selected by `echo.dpo@1.replace`.
+`edict.target-ir.artifact/v1` is the outer canonical artifact domain that
+crosses the Edict provider WIT boundary and is validated through the declared
+`target-ir-artifact` schema root.
+
+This source contract does not claim that Echo currently executes the declared
+replace operation. Runtime mutation, admission, receipts, and presence-sensitive
+replace enforcement remain runtime implementation authority and must be proven
+by the lowerer, verifier, and admitted-execution slices.
 
 Applications own:
 

--- a/docs/design/echo-edict-provider-semantic-source.md
+++ b/docs/design/echo-edict-provider-semantic-source.md
@@ -1,0 +1,554 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+---
+title: "PLATFORM-651 - Echo Edict Provider Semantic Source"
+legend: "PLATFORM"
+lane: "design"
+issue: "https://github.com/flyingrobots/echo/issues/651"
+status: "absorbed"
+owners:
+  - "@flyingrobots"
+created: "2026-07-13"
+updated: "2026-07-13"
+---
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+# PLATFORM-651 - Echo Edict Provider Semantic Source
+
+Status: absorbed
+Domain: contract hosting
+Canonical output: docs/architecture/application-contract-hosting.md
+Supersedes: none
+Superseded by: none
+Evidence: cargo +1.90.0 test -p echo-wesley-gen --test provider_semantic_source
+
+## Linked Issue
+
+- [Issue #651](https://github.com/flyingrobots/echo/issues/651)
+
+## Decision Summary
+
+Echo will own one strict, versioned JSON semantic declaration for the first
+Edict provider operation. `echo-wesley-gen` will parse it into an opaque
+validated value only after deterministic coordinate, authority, and reference
+checks. The declaration is source truth; future lawpack, target-profile,
+authority-fact, schema, provenance, and review files are generated projections.
+The semantic declaration owns portable facts, source mappings, output/schema
+bindings, and the generated metadata closure. Target metadata owns
+operation-profile doctrine, write-class resolution, the low-level failure
+taxonomy, and the native capability.
+
+## Sponsored Human
+
+An Echo maintainer wants one inspectable authority for the provider vocabulary
+so that Echo and Edict can evolve without copying semantic facts between
+repositories or treating generated JSON as authored truth.
+
+## Sponsored Agent
+
+An integration agent needs a checked source graph with stable failure kinds so
+it can generate provider artifacts without inferring facts from tests, stale
+SDL, or private runtime implementation details.
+
+## Hill
+
+By the end of this cycle, an agent can load the checked first-operation source
+through `echo-wesley-gen`, obtain the same validated graph after set-like source
+reordering, and receive a stable structural failure for every dangling or
+duplicate reference.
+
+## Current Truth
+
+- `WesleyIR` currently models types, operations, codec identity, and registry
+  identity, but not provider effects, write classes, obstructions, profiles,
+  budgets, target capabilities, adapters, or artifact schemas
+  ([crates/echo-wesley-gen/src/ir.rs#11:ebe8b6f73e1eb46439e07c73e1584875bc2929ad](https://github.com/flyingrobots/echo/blob/ebe8b6f73e1eb46439e07c73e1584875bc2929ad/crates/echo-wesley-gen/src/ir.rs#L11)).
+- The existing runtime GraphQL fragments are a narrow ADR-0008 runtime freeze;
+  they explicitly do not replace current WASM DTOs or describe every runtime
+  fact
+  ([schemas/runtime/README.md#6:ebe8b6f73e1eb46439e07c73e1584875bc2929ad](https://github.com/flyingrobots/echo/blob/ebe8b6f73e1eb46439e07c73e1584875bc2929ad/schemas/runtime/README.md#L6)).
+- Echo's existing Edict bridge accepts only a narrow `echo.span-ir/v1`
+  obstruction-receipt fixture and explicitly is not general provider dispatch
+  ([crates/warp-core/src/edict_target_ir.rs#3:ebe8b6f73e1eb46439e07c73e1584875bc2929ad](https://github.com/flyingrobots/echo/blob/ebe8b6f73e1eb46439e07c73e1584875bc2929ad/crates/warp-core/src/edict_target_ir.rs#L3)).
+- Edict's reviewed compatibility baseline already fixes the first target
+  operation as `target.replace`, native intrinsic `echo.dpo@1.replace`, profile
+  `continuum.profile.write/v1`, budget `p.tiny`, and failure key `rejected`
+  ([crates/edict-syntax/tests/target_ir.rs#21:6e3a862a7c54f22de81c01aaeb8bd786ad32bdfd](https://github.com/flyingrobots/edict/blob/6e3a862a7c54f22de81c01aaeb8bd786ad32bdfd/crates/edict-syntax/tests/target_ir.rs#L21)).
+
+## Problem
+
+The first Echo provider artifacts cannot be generated honestly while their
+semantic facts live only as hand-built test context across repositories. A
+generator could otherwise select whichever SDL, test constant, or runtime name
+it encountered first, making source ordering and stale relocated SDL an
+authority mechanism.
+
+## Scope
+
+This cycle includes:
+
+- the `echo.edict-provider-semantics/v1` declaration shape;
+- one compatibility operation around Edict's reviewed `target.replace` slice;
+- explicit authority, Core-alias, effect, write-class, obstruction, profile,
+  budget, capability, adapter, generated-artifact, invocation-role, and
+  schema-binding
+  declarations;
+- complete lawpack and target-profile resource projections, including explicit
+  generated versus external resource provision;
+- a separate package-root manifest projection and generated provenance member;
+- deterministic validation and normalized set ordering;
+- stable structural error kinds for duplicate and unknown references; and
+- an explicit decision that relocated Wesley Echo SDL is not active authority.
+
+## Non-Goals
+
+This cycle does not include:
+
+- generating lawpacks, target profiles, authority facts, CDDL, or provenance;
+- implementing the WIT lowerer or verifier;
+- admitting or executing Target IR in Echo;
+- changing Edict syntax or Core semantics;
+- generalizing the existing runtime GraphQL schema family; or
+- restoring `schemas/wesley-relocated/`.
+
+## User Experience / Product Shape
+
+Not applicable. This is a machine-readable generator input and Rust API, not a
+rendered product surface.
+
+### Accessibility Considerations
+
+The complete source graph and every failure category are available as typed
+data. No fact is visible only through formatting or diagnostic prose.
+
+## Runtime / API Contract
+
+`echo-wesley-gen` exports:
+
+```rust
+pub fn parse_provider_semantic_source_v1(
+    json: &str,
+) -> Result<ValidatedProviderSemanticSourceV1, ProviderSemanticSourceError>;
+```
+
+The public declaration structs are strict serde shapes with unknown fields
+rejected. Successful validation returns an opaque wrapper around a normalized
+source. The wrapper exposes the normalized declaration for later generation,
+but callers cannot construct a validated value directly.
+
+The declaration carries:
+
+- source identity and explicit authority-source references;
+- provider-facing record shapes and Echo-owned aliases over Edict Core types;
+- semantic effects with Edict execution/effect classification and typed
+  failures;
+- write classes, typed domain obstructions, exhaustive source mappings,
+  operation profiles with full optic templates, and budgets;
+- target capabilities, explicit semantic-obligation discharge, and optional
+  direct adapters;
+- one operation binding those references;
+- generated package-member role, coordinate, Edict kind, authority-fact source,
+  and schema contracts;
+- package-root manifest identity, exact provider ABI and provider coordinate,
+  lawpack/target-profile resource closure, and the Wesley #728
+  generation-provenance contract; and
+- complete provider invocation input/output roles plus immutable
+  schema-domain/root bindings.
+
+The target capability names the inner target-specific domain
+`echo.span-ir/v1`. The WIT output is independently schema-bound under Edict's
+outer canonical artifact domain `edict.target-ir.artifact/v1`, using the Echo
+schema root `target-ir-artifact`. These identities are not interchangeable.
+
+The first operation is the exact reviewed compatibility intent `a.b@1.t`, with
+package-local `Input`, `Receipt`, and `Output` records over the Echo-owned alias
+`a.b@1.Id`. That alias selects Edict's canonical Core coordinate
+`String<max=16,canonical=raw-utf8>`; Edict owns string semantics, while Echo owns
+the package alias and its 16-Unicode-scalar bound. The runtime `target.replace`
+effect declares
+`executionClass: runtime`, `effectKindHint: replace`, one target-owned typed
+`rejected` failure, and singular footprint/cost obligations matching the Edict
+v1 lawpack ABI. Its domain obstruction and source mapping are semantic-source
+facts. Both payload schemas are empty bounded records because the v1 mapping
+carries no payload transform. It uses native support. `directAdapters` is
+explicitly empty, matching Edict's reviewed native lowerability baseline. The
+schema still models direct-adapter selection, and an operation naming an absent
+adapter fails with `UnknownAdapter`.
+
+The target capability owns its resolved effect kind, write class, footprint
+template, and cost template. Those target facts are not required to equal the
+lawpack's advisory hint or abstract obligations. `semanticDischarge` explicitly
+records which effect-kind hint and footprint/cost obligations the capability
+discharges, and validation joins that mapping to the semantic effect.
+
+The empty semantic `directAdapters` catalog does not remove the lawpack ABI's
+target-adapter requirement. The lawpack projection carries one distinct
+digest-locked adapter resource binding `target.replace` to generated target
+profile `echo.dpo@1` and inner Target IR `echo.span-ir/v1`. Its verifier is a
+generated declarative ruleset, avoiding a dependency cycle with the later
+executable verifier component.
+
+The target-owned `continuum.profile.write/v1` profile supplies an
+`affectReintegration`/`affect` optic template, the abstract
+`target.replace.footprint` aperture, carry-or-obstruct support, reject-on-loss
+disposition, and the narrow
+`echo.dpo.operation-mode.replace-only/v1` effect predicate. These are explicit
+Echo target-metadata decisions; a generator does not infer them from the profile
+name.
+
+## Generated Artifact Closure
+
+`generatedArtifacts` is the future provider manifest's generated
+package-member inventory, not the manifest preimage itself. It contains:
+
+- `lawpack.echo-dpo` (`lawpack`) from `echo.dpo-lawpack@1`;
+- `target-profile.echo-dpo` (`targetProfile`) from `echo.dpo@1`;
+- two `authorityFacts` roles, one for the lawpack and one for the target profile;
+- `generated-artifact-profile.echo-dpo-registration` for helper output;
+- `provenance.provider-generation` using Wesley's provenance document;
+- `schema.echo-provider-artifacts` containing self-contained CDDL; and
+- `review.provider-generation`, a non-authoritative review projection.
+
+`packageManifest` separately declares
+`provider-manifest.echo:echo.edict-provider-manifest@1`, the exact component
+world `edict:target-provider@1.0.0`, and provider coordinate
+`echo.edict-provider@1`. It is assembled in #655 after #653 and #654 provide
+component bytes; it is not generated by #652 and cannot list itself as a
+digest-locked member.
+
+Authority facts are split because `edict.authority-facts/v1` binds exactly one
+lawpack or target-profile source. The lawpack projection supplies the budget
+facts. The target-profile projection supplies operation-profile and resolved
+effect write-class facts.
+
+The lawpack projection freezes its export corpus, native target adapter,
+declarative verifier, compatibility document, and conformance corpus. The
+target-profile projection freezes all mandatory v1 resource slots:
+intrinsics, operation profiles, footprint and cost algebra, Target IR,
+obstruction taxonomy, lowerer and verifier contracts, sandbox, fuel model,
+bundle profile, generated-artifact profiles, encoding rules, diagnostic ABI,
+determinism policy, and conformance corpus.
+
+Each resource is either `generated` by #652 or `external`. Generated lowerer and
+verifier resources are declarative target-profile contract documents, never
+component bytes. The package manifest assembled by #655 separately selects the
+exact executable components and their frozen WIT world attestations.
+
+An external declaration selects a required Edict contract but does not bless
+arbitrary caller bytes. #652 must receive trusted, digest-locked inputs whose
+publication and authority are tracked by
+[Edict #158](https://github.com/flyingrobots/edict/issues/158). The source
+carries no placeholder or hand-authored output digest.
+
+The two authority-facts artifacts bind `contractOwner` to
+[Edict #157](https://github.com/flyingrobots/edict/issues/157). Its canonical
+CBOR/CDDL contract and Edict consumer compatibility landed in
+[Edict PR #159](https://github.com/flyingrobots/edict/pull/159); Echo does not
+mint a second wire schema under `edict.authority-facts/v1`.
+
+The `generationProvenance` member requests Wesley's public
+`GenerationProvenanceManifestV1` owned by
+[Wesley #728](https://github.com/flyingrobots/wesley/issues/728). Edict
+[issue #155](https://github.com/flyingrobots/edict/issues/155) landed the generic
+provider artifact category, so the evidence is packageable without being
+mislabeled as review, generated-artifact-profile, or executable metadata. Edict
+routes the generated provenance envelope; Wesley owns its document schema.
+
+## Lower Modes
+
+The lower mode is direct in-memory JSON parsing. It requires no filesystem,
+network, environment, registry, clock, or Echo runtime.
+
+## Data / State Model
+
+- **Source of truth:**
+  `schemas/edict-provider/echo-provider-semantics-v1.json`.
+- **Derived state:** a normalized validated Rust value, followed later by
+  generated artifacts.
+- **Invalid states:** wrong versions, duplicate identities or keys, Edict Core
+  ownership claims, unbounded types, invalid failure keys, wrong authority
+  families, dangling references, incomplete projections, missing semantic
+  discharge, ambiguous implementations, wrong package identity, or wrong
+  invocation schema bindings.
+- **Reset behavior:** reparse the explicit source bytes.
+- **Serialization:** strict JSON source; #652 owns canonical artifact encoding.
+- **Determinism:** declaration arrays and declared sets normalize by exact UTF-8
+  ordering.
+
+```mermaid
+flowchart TD
+  Source[Echo semantic source JSON] --> Parse[Strict serde parse]
+  Parse --> Normalize[Normalize declared sets]
+  Normalize --> Validate[Validate identity and references]
+  Validate --> Checked[Opaque validated source]
+  Checked --> Generator[Future #652 generator]
+  Generator --> Artifacts[Lawpack, profile, facts, schemas, review, provenance]
+  Artifacts --> Assembly[Future #655 package assembly]
+  Assembly --> Manifest[Provider manifest plus components]
+```
+
+## Echo Authority Boundary
+
+The checked file contains two explicit authority families. The Echo semantic
+declaration owns provider records and Core aliases, the portable effect, domain
+obstruction and mapping, budget, operation, generated metadata closure, and
+outer invocation/schema binding. Edict retains authority over Core string
+semantics. Echo target metadata owns the operation profile and optic template,
+write class, low-level failure taxonomy, native capability, and inner
+`echo.span-ir/v1` selection. GraphQL remains authoritative only for types
+actually authored there; none are imported into this minimal fixture. Runtime
+implementation remains authoritative for execution and receipts, but it does
+not retroactively define provider metadata. Edict owns its source language,
+Core, provider ABI, and generic validation rules.
+
+Generated artifacts have no independent authority. A stale relocated SDL
+cannot override a declaration because validation has no search path or source
+precedence: every fact names exactly one authority, and duplicate coordinates
+fail before reference resolution.
+
+## Relocated SDL Reconciliation
+
+This design resolves #461 without restoring old Wesley-owned Echo SDL:
+
+- old `@wes_codec` and `@wes_version` annotations are not current policy; a
+  useful concept must be re-authored in an Echo-owned schema before Wesley may
+  compile it;
+- CAS, runtime, and worldline shapes remain owned by their current Echo Rust and
+  runtime-schema surfaces rather than copied from relocated SDL;
+- `echo-wasm-abi` remains the authority for its hand-authored Rust DTO and spec
+  surface; this slice creates no duplicate GraphQL authority;
+- `echo_registry_api::RegistryInfo::registry_version` remains the canonical
+  numeric `u32` registry-layout version;
+- `echo_wasm_abi::kernel_port::RegistryInfo::registry_version` remains an
+  `Option<String>` browser/kernel transport field containing the decimal
+  rendering when a registry is installed; this transport representation is not
+  provider semantic authority, and this slice changes no existing ABI shape;
+- relocated SDL stays in Git history only. It is neither archived under an
+  active schema path nor consulted by the provider validator.
+
+## Determinism / DIND Posture
+
+Top-level declaration families and explicitly set-like nested fields normalize
+by exact string order before reference validation. Target adapters use a total
+tuple order over profile role, Target IR role, adapter resource, and effects.
+Duplicate target-profile selectors reject before artifact generation. Positional
+effect parameters retain source order. No map iteration, clock, randomness,
+filesystem state, or environment state affects validation. Full DIND execution
+is not required because this slice is a pure parser/validator; focused reorder
+tests are the determinism witness.
+
+## WAL / WSC / Retention Posture
+
+Not applicable. No causal history, receipt, retained material, recovery state,
+WAL, WSC, or CAS behavior changes.
+
+## Accessibility Posture
+
+- Semantic labels and facts use typed declarations and stable coordinates.
+- Focus order, keyboard behavior, and visual-only information are not involved.
+- The source contains no secrets or ambient host data.
+
+## Localization / Directionality Posture
+
+Not applicable. No user-visible strings or locale-dependent ordering are added.
+
+## Agent Inspectability / Explainability Posture
+
+An agent can inspect the checked JSON fixture, the normalized public Rust value,
+and stable `ProviderSemanticSourceErrorKind` values. It never needs diagnostic
+text, a runtime trace, or a generated review file to determine authority.
+
+## App-Noun Boundary
+
+The selected names are Echo/Edict compatibility vocabulary. No Jedit, Graft,
+editor, filesystem, or product nouns enter production Echo core. The semantic
+source remains in `echo-wesley-gen`, outside `warp-core` execution machinery.
+
+## Linked Invariants
+
+- Tests are executable specification.
+- Runtime truth beats type theater.
+- Design becomes repository truth.
+- Echo owns runtime semantics; Edict remains runtime-neutral.
+- Generated files are projections, never semantic authority.
+- Determinism is binary.
+
+## Design Alternatives Considered
+
+### Option A: Extend the ADR-0008 GraphQL fragments
+
+Pros:
+
+- reuses an existing authored schema language.
+
+Cons:
+
+- the fragments do not own target capabilities, budgets, write classes,
+  provider roles, or schema roots;
+- adding unrelated directives would make GraphQL appear authoritative for facts
+  it cannot express honestly.
+
+### Option B: Infer facts from runtime Rust and Edict fixtures
+
+Pros:
+
+- avoids a new source artifact.
+
+Cons:
+
+- creates hidden filesystem discovery and source precedence;
+- makes refactors semantic changes;
+- permits stale or duplicate artifacts to win by traversal order.
+
+### Option C: Add one explicit Echo semantic declaration
+
+Pros:
+
+- gives every non-GraphQL fact one checked owner;
+- supports deterministic generation without coupling Echo to Edict internals;
+- leaves runtime execution authority in runtime code.
+
+Cons:
+
+- introduces a small versioned schema that Echo must maintain.
+
+## Decision
+
+Choose Option C. The first file is deliberately narrow and compatibility-fixture
+shaped. New operations expand the checked source in later slices; they do not
+weaken validation or create fallback source discovery.
+
+## Implementation Slices
+
+- [x] Slice 1: add RED semantic-source validation tests and fixture.
+- [x] Slice 2: implement strict normalized parsing and structural validation.
+- [x] Slice 3: publish source ownership docs and close relocated-SDL ambiguity.
+
+## Tests To Write First
+
+Behavior tests required:
+
+- [x] checked first-operation source validates;
+- [x] top-level and nested set reordering produces an equal validated value;
+- [x] conflicting duplicate coordinates fail with `DuplicateCoordinate`;
+- [x] stale relocated SDL cannot override an existing coordinate;
+- [x] unknown type, failure, obstruction, profile, budget, capability, and adapter
+      references fail with their exact stable kinds; and
+- [x] every invocation input and output resolves one declared schema
+      role/domain/root;
+- [x] typed payload, exhaustive mapping, profile/effect, capability/effect,
+      generated-contract, output-domain, and schema-root mismatches fail closed.
+- [x] recursive type graphs and invalid Edict failure identifiers fail with
+      stable full error tuples;
+- [x] wrong family domains, authority kinds, and non-authoritative source paths
+      fail before generation;
+- [x] capability-owned write classes, aperture/optic/atomic joins, and inner
+      Target IR coherence fail closed;
+- [x] Echo Core aliases derive exact Edict coordinates and count Unicode scalar
+      values rather than UTF-8 bytes;
+- [x] target-authoritative capability facts remain independent while explicit
+      semantic-discharge mappings fail closed;
+- [x] every runtime effect resolves exactly one native or direct-adapter
+      implementation;
+- [x] profile source aliases and lawpack target-profile selectors are unique,
+      while target-adapter ordering remains total;
+- [x] provider-manifest self-inventory and invalid authority-fact source
+      partitions or contract owners fail structurally; and
+- [x] lawpack, target-profile, review, schema, generated-profile, exact external
+      resources, package ABI/coordinate, invocation inputs, and generic
+      generation-provenance closure is complete.
+
+## Acceptance Criteria
+
+The work is done when:
+
+- [x] the behavior tests above are green;
+- [x] the checked source names one authority and domain for each fact;
+- [x] every generated artifact, manifest resource, provenance output, and
+      invocation input/output maps to its owning contract;
+- [x] docs state that runtime GraphQL and relocated SDL are not fallback sources;
+- [x] issue #461 is reconciled without restoring stale SDL; and
+- [ ] CI and local validation are green.
+
+## Validation Plan
+
+```bash
+cargo +1.90.0 test -p echo-wesley-gen --test provider_semantic_source
+cargo +1.90.0 clippy -p echo-wesley-gen \
+  --lib --test provider_semantic_source -- -D warnings -D missing-docs
+cargo +1.90.0 xtask pr-preflight
+git diff --check
+```
+
+## Playback / Witness
+
+```bash
+cargo +1.90.0 test -p echo-wesley-gen --test provider_semantic_source
+```
+
+The checked source is
+`schemas/edict-provider/echo-provider-semantics-v1.json`.
+
+## Risks
+
+- The first source could accidentally claim runtime behavior not yet present.
+  Mitigation: its operation is explicitly compatibility-fixture scoped, and the
+  design separates target metadata from runtime execution authority.
+- The new declaration could duplicate GraphQL later. Mitigation: every fact has
+  an explicit authority reference, and duplicate coordinates are invalid.
+- The shape could pre-empt generic Wesley design. Mitigation: this schema is
+  Echo-owned; Wesley #728 supplies only domain-neutral generation input and
+  provenance contracts.
+
+## Follow-On Debt
+
+- #652 generates the declared artifacts.
+- #653 implements the lowerer component.
+- #654 implements the verifier component.
+- Wesley #728 supplies canonical extension-generation input and provenance.
+
+## Retrospective
+
+What changed from the design:
+
+- The final source carries the exact effect/failure/obstruction and optic fields
+  needed by Edict's v1 ABIs. The obstruction mapping moved from the target-owned
+  failure declaration onto the semantic operation so the authority split is
+  explicit. Footprint and cost obligations became singular to match the lawpack
+  ABI instead of forcing generation to choose from a list.
+- Write-class authority moved entirely to target metadata and the selected
+  native capability. The source now separates the #655 package-root manifest
+  from #652 package members, partitions authority facts by Edict source kind,
+  and freezes every mandatory lawpack and target-profile resource.
+
+What the tests proved:
+
+- The checked source validates and normalizes independently of declared set
+  order. Strict parsing, duplicate keys, dangling references, stale authority,
+  incomplete mappings, non-empty payload mappings, profile/capability drift,
+  missing or ambiguous implementations, duplicate target-profile selectors,
+  and incorrect output contracts all fail with stable structured kinds.
+- Bounded type closure, identifier validity, authority family, target IR
+  coherence, manifest self-reference, authority-fact projection, and complete
+  artifact-resource closure have deterministic negative witnesses.
+
+What remains open:
+
+- #652 generates and validates the canonical provider artifacts. #653 and #654
+  implement the lowerer and verifier. Runtime presence-sensitive replace remains
+  deliberately unclaimed until those components and admitted execution land.
+- Wesley #728 must publish the provenance document type before #652 can emit
+  final bytes. Edict #155 already supplies the packageable
+  `generationProvenance` artifact category, so #655 can include that generated
+  member directly.
+- Edict #158 must publish trusted canonical resources before #652 accepts the
+  external target-profile contract inputs. The authority-facts ABI and consumer
+  bridge previously tracked by Edict #157 landed in Edict PR #159.
+
+PR:
+
+- Pending.

--- a/schemas/edict-provider/README.md
+++ b/schemas/edict-provider/README.md
@@ -1,0 +1,117 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR LicenseRef-MIND-UCAL-1.0 -->
+<!-- © James Ross Ω FLYING•ROBOTS <https://github.com/flyingrobots> -->
+
+# Echo Edict Provider Semantic Source
+
+This directory contains Echo-authored semantic input for the external Edict
+provider pipeline. It does not contain generated lawpacks, target profiles,
+authority facts, provider manifests, schemas, or review projections.
+
+The current source is
+[`echo-provider-semantics-v1.json`](echo-provider-semantics-v1.json). Its API is
+`echo.edict-provider-semantics/v1`, and its semantic-source coordinate is
+`echo.semantic-schema@1`.
+
+## Authority
+
+The checked source names one authority artifact and one canonical domain for
+each semantic fact. In the first compatibility closure:
+
+- the Echo semantic declaration owns the package-local records and Core aliases,
+  semantic effect, domain obstruction and source mapping, budget, operation,
+  generated package-member inventory, and outer invocation/schema inventory;
+- Edict owns Core string semantics; `a.b@1.Id` only selects the exact
+  `String<max=16,canonical=raw-utf8>` Core coordinate;
+- Echo target metadata owns the operation profile and optic template, the
+  low-level `rejected` failure taxonomy, write-class resolution, native
+  `echo.dpo@1.replace` capability, and its inner `echo.span-ir/v1` domain;
+- the semantic declaration's invocation/schema inventory independently owns the
+  outer `edict.target-ir.artifact/v1` provider domain and
+  `target-ir-artifact` root;
+- runtime GraphQL owns none of these first-operation facts; and
+- runtime implementation authority for actual replace execution remains
+  unresolved until the lowerer and verifier slices prove presence-sensitive
+  replace behavior.
+
+The source deliberately selects native lowerability and declares no semantic
+effect-to-effect direct adapter. Its lawpack projection separately declares the
+digest-locked target adapter required to discharge the runtime
+`target.replace` effect for `echo.dpo@1`; those are different contracts.
+
+## Executable Schema
+
+The strict Rust model and validator in
+`crates/echo-wesley-gen/src/provider_semantics.rs` are the executable schema for
+this source version. Every serialized object rejects unknown fields. Validation
+normalizes declared sets, rejects duplicate coordinates and keys, resolves every
+typed reference, checks effect/profile/capability and explicit semantic-discharge
+joins, requires exhaustive
+failure-to-obstruction mappings, and requires every generated artifact and
+invocation input/output to have its exact Edict contract, domain, format, and
+root rule. Every runtime effect must have exactly one native or direct-adapter
+implementation, and each lawpack adapter must select a unique target profile.
+The validator also rejects recursive type graphs, Echo claims over Edict Core
+coordinates, byte-counted string aliases, invalid Edict failure identifiers,
+duplicate profile aliases, wrong fact domains or authority kinds, conflicting
+inner Target IR domains, wrong package ABI/provider identity, self-referential
+provider inventories, incomplete authority-fact projections, and incomplete
+lawpack/target-profile resource closure.
+
+The v1 mapping shape intentionally supports only empty bounded failure and
+obstruction payloads because it carries no payload transform. A non-empty
+payload fails structurally instead of asking a future generator to invent a
+field mapping.
+
+There is no hand-maintained JSON Schema snapshot. Adding one without generating
+and checking it from the executable model would create a second shape authority.
+
+Run:
+
+```bash
+cargo +1.90.0 test -p echo-wesley-gen --test provider_semantic_source
+```
+
+## No Discovery
+
+The validator receives explicit source bytes and performs no filesystem,
+registry, environment, clock, or network discovery. Nothing under
+`schemas/wesley-relocated/` is active authority. A stale declaration supplied
+alongside the current source cannot override it: duplicate coordinates fail
+before references are resolved. Old relocated SDL remains historical Git
+evidence only.
+
+## Generated Outputs
+
+Issue #652 will compile this source into the declared Edict lawpack, target
+profile, two source-partitioned authority-facts documents, generated-artifact
+profile, self-contained CDDL schema, deterministic review artifact, manifest
+subresources, and Wesley-owned `generationProvenance` metadata. Resources marked
+`external` are explicit digest-locked generator inputs; placeholder digests
+are forbidden.
+
+The two authority-facts outputs use Edict's `edict.authority-facts/v1` domain
+and bind their contract owner to
+[Edict #157](https://github.com/flyingrobots/edict/issues/157). Echo does not
+define a second authority-facts wire schema. That Edict-owned canonical
+CBOR/CDDL contract and its compiler-consumer bridge landed in
+[Edict PR #159](https://github.com/flyingrobots/edict/pull/159).
+
+The generated target-profile lowerer and verifier resources are declarative
+contract documents. They are not executable component bytes. Issue #655 binds
+the exact lowerer and verifier components, including their frozen WIT world
+attestations, when it assembles the provider manifest.
+
+External Edict contract inputs require the trusted artifact publication model
+tracked by [Edict #158](https://github.com/flyingrobots/edict/issues/158).
+The semantic source selects their contracts but does not authenticate arbitrary
+caller bytes under those coordinates.
+
+Issue #655, after the lowerer and verifier components exist, assembles those
+outputs and generates the package-root `edict.provider-manifest/v1` for
+`echo.edict-provider@1`, implementing exact world
+`edict:target-provider@1.0.0`. The manifest is declared separately and is never
+listed inside its own artifact inventory. Runtime `reviewPayload` invocation
+output is distinct from #652's build-time `reviewArtifact`.
+
+All generated files are derived artifacts. Their digests and review renderings
+must never be copied back into this file as authored semantic facts.

--- a/schemas/edict-provider/echo-provider-semantics-v1.json
+++ b/schemas/edict-provider/echo-provider-semantics-v1.json
@@ -1,0 +1,598 @@
+{
+  "apiVersion": "echo.edict-provider-semantics/v1",
+  "coordinate": "echo.semantic-schema@1",
+  "authoritySources": [
+    {
+      "coordinate": "echo.provider-semantic-declaration@1",
+      "kind": "echoSemanticDeclaration",
+      "artifact": "schemas/edict-provider/echo-provider-semantics-v1.json"
+    },
+    {
+      "coordinate": "echo.provider-target-metadata@1",
+      "kind": "targetMetadata",
+      "artifact": "schemas/edict-provider/echo-provider-semantics-v1.json"
+    }
+  ],
+  "types": [
+    {
+      "identity": {
+        "coordinate": "a.b@1.Input",
+        "domain": "echo.edict-provider/value/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "shape": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "a.b@1.Id"
+          }
+        ]
+      }
+    },
+    {
+      "identity": {
+        "coordinate": "a.b@1.Receipt",
+        "domain": "echo.edict-provider/value/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "shape": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "a.b@1.Id"
+          }
+        ]
+      }
+    },
+    {
+      "identity": {
+        "coordinate": "a.b@1.Output",
+        "domain": "echo.edict-provider/value/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "shape": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "a.b@1.Id"
+          }
+        ]
+      }
+    },
+    {
+      "identity": {
+        "coordinate": "a.b@1.Id",
+        "domain": "echo.edict-provider/value/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "shape": {
+        "kind": "coreStringAlias",
+        "maxScalarValues": 16,
+        "canonical": "raw-utf8"
+      }
+    },
+    {
+      "identity": {
+        "coordinate": "domain.WriteRejected.Payload",
+        "domain": "echo.edict-provider/value/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "shape": {
+        "kind": "record",
+        "fields": []
+      }
+    },
+    {
+      "identity": {
+        "coordinate": "target.replace.rejected",
+        "domain": "echo.edict-provider/value/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "shape": {
+        "kind": "record",
+        "fields": []
+      }
+    }
+  ],
+  "writeClasses": [
+    {
+      "identity": {
+        "coordinate": "replace",
+        "domain": "echo.edict-provider/write-class/v1",
+        "authority": "echo.provider-target-metadata@1"
+      }
+    }
+  ],
+  "obstructions": [
+    {
+      "identity": {
+        "coordinate": "domain.WriteRejected",
+        "domain": "echo.edict-provider/obstruction/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "authorityClass": "domainMappable",
+      "payloadSchema": "domain.WriteRejected.Payload"
+    }
+  ],
+  "effects": [
+    {
+      "identity": {
+        "coordinate": "target.replace",
+        "domain": "echo.edict-provider/semantic-effect/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "parameterTypes": ["a.b@1.Id"],
+      "resultType": "a.b@1.Receipt",
+      "executionClass": "runtime",
+      "effectKindHint": "replace",
+      "guardKinds": ["precommit-atomic"],
+      "failures": [
+        {
+          "key": "rejected",
+          "domain": "echo.edict-provider/effect-failure/v1",
+          "authority": "echo.provider-target-metadata@1",
+          "authorityClass": "domainMappable",
+          "payloadType": "target.replace.rejected"
+        }
+      ],
+      "footprintObligation": "target.replace.footprint",
+      "costObligation": "target.replace.cost",
+      "guardSupport": true
+    }
+  ],
+  "profiles": [
+    {
+      "identity": {
+        "coordinate": "continuum.profile.write/v1",
+        "domain": "echo.edict-provider/operation-profile/v1",
+        "authority": "echo.provider-target-metadata@1"
+      },
+      "sourceNames": ["p.effectful"],
+      "allowedWriteClasses": ["replace"],
+      "guardKinds": ["precommit-atomic"],
+      "atomicity": "atomic",
+      "postconditionSupport": true,
+      "opticTemplate": {
+        "opticKind": "affectReintegration",
+        "boundaryKind": "affect",
+        "supportPolicy": "continuum.support.carry-or-obstruct/v1",
+        "lossDisposition": "continuum.support.reject-on-loss/v1",
+        "apertureRequirement": {
+          "kind": "abstractFootprintObligation",
+          "ref": "target.replace.footprint"
+        }
+      },
+      "effectPredicate": "echo.dpo.operation-mode.replace-only/v1",
+      "opticContract": "replace-point"
+    }
+  ],
+  "budgets": [
+    {
+      "identity": {
+        "coordinate": "p.tiny",
+        "domain": "echo.edict-provider/core-budget/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "maxSteps": 8,
+      "maxAllocatedBytes": 1024,
+      "maxOutputBytes": 256
+    }
+  ],
+  "capabilities": [
+    {
+      "identity": {
+        "coordinate": "echo.dpo@1.replace",
+        "domain": "echo.edict-provider/target-intrinsic/v1",
+        "authority": "echo.provider-target-metadata@1"
+      },
+      "effect": "target.replace",
+      "effectKind": "replace",
+      "writeClass": "replace",
+      "guardSupport": true,
+      "footprintTemplate": "target.replace.footprint",
+      "costTemplate": "target.replace.cost",
+      "semanticDischarge": {
+        "effectKindHint": "replace",
+        "footprintObligation": "target.replace.footprint",
+        "costObligation": "target.replace.cost"
+      },
+      "canParticipateInAtomicGuard": true,
+      "targetProfile": "echo.dpo@1",
+      "targetIrDomain": "echo.span-ir/v1"
+    }
+  ],
+  "directAdapters": [],
+  "operations": [
+    {
+      "identity": {
+        "coordinate": "a.b@1.t",
+        "domain": "echo.edict-provider/operation/v1",
+        "authority": "echo.provider-semantic-declaration@1"
+      },
+      "inputType": "a.b@1.Input",
+      "outputType": "a.b@1.Output",
+      "effect": "target.replace",
+      "profile": "continuum.profile.write/v1",
+      "budget": "p.tiny",
+      "obstructionMappings": [
+        {
+          "failure": "rejected",
+          "obstruction": "domain.WriteRejected"
+        }
+      ],
+      "implementation": {
+        "kind": "native",
+        "capability": "echo.dpo@1.replace"
+      }
+    }
+  ],
+  "artifactResources": [
+    {
+      "role": "resource.canonical-encoding",
+      "coordinate": "edict.canonical-cbor/v1",
+      "schemaContract": "edict.canonical-cbor/v1",
+      "provision": "external"
+    },
+    {
+      "role": "resource.conformance-corpus",
+      "coordinate": "echo.dpo.fixtures/v1",
+      "schemaContract": "echo.edict-provider.conformance-corpus/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.diagnostic-abi",
+      "coordinate": "edict.diagnostics/v1",
+      "schemaContract": "edict.diagnostics/v1",
+      "provision": "external"
+    },
+    {
+      "role": "resource.deterministic-execution",
+      "coordinate": "edict.determinism/v1",
+      "schemaContract": "edict.determinism/v1",
+      "provision": "external"
+    },
+    {
+      "role": "resource.fuel-model",
+      "coordinate": "edict.fuel/v1",
+      "schemaContract": "edict.fuel/v1",
+      "provision": "external"
+    },
+    {
+      "role": "resource.lawpack-compatibility",
+      "coordinate": "echo.dpo-lawpack.compatibility@1",
+      "schemaContract": "echo.edict-provider.lawpack-compatibility/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.lawpack-exports",
+      "coordinate": "echo.dpo-lawpack.exports@1",
+      "schemaContract": "edict.lawpack/v1#lawpack-exports",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.lawpack-target-adapter",
+      "coordinate": "echo.dpo-lawpack.adapter.echo-dpo@1",
+      "schemaContract": "echo.edict-provider.lawpack-target-adapter/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.lawpack-verifier",
+      "coordinate": "echo.dpo-lawpack.verifier@1",
+      "schemaContract": "echo.edict-provider.lawpack-verifier/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.sandbox",
+      "coordinate": "edict.wasm-component/v1",
+      "schemaContract": "edict.wasm-component/v1",
+      "provision": "external"
+    },
+    {
+      "role": "resource.target-bundle-profile",
+      "coordinate": "echo.dpo.bundle/v1",
+      "schemaContract": "echo.dpo.bundle/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-cost-algebra",
+      "coordinate": "echo.dpo.cost/v1",
+      "schemaContract": "echo.dpo.cost/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-footprint-algebra",
+      "coordinate": "echo.dpo.footprint/v1",
+      "schemaContract": "echo.dpo.footprint/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-intrinsics",
+      "coordinate": "echo.dpo.intrinsics/v1",
+      "schemaContract": "edict.target-profile.intrinsics/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-ir",
+      "coordinate": "echo.span-ir/v1",
+      "schemaContract": "echo.span-ir/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-lowerer-contract",
+      "coordinate": "echo.dpo.lowerer/v1",
+      "schemaContract": "echo.dpo.lowerer/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-obstruction-taxonomy",
+      "coordinate": "echo.dpo.obstructions/v1",
+      "schemaContract": "echo.dpo.obstructions/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-operation-profiles",
+      "coordinate": "echo.dpo.operation-profiles/v1",
+      "schemaContract": "edict.target-profile.operation-profiles/v1",
+      "provision": "generated"
+    },
+    {
+      "role": "resource.target-verifier-contract",
+      "coordinate": "echo.dpo.verifier/v1",
+      "schemaContract": "echo.dpo.verifier/v1",
+      "provision": "generated"
+    }
+  ],
+  "lawpackProjection": {
+    "authority": "echo.provider-semantic-declaration@1",
+    "artifactRole": "lawpack.echo-dpo",
+    "id": "echo.dpo-lawpack",
+    "version": "1",
+    "acceptedCoreAbis": ["edict.core/v1"],
+    "dependencies": [],
+    "exportsResource": "resource.lawpack-exports",
+    "targetAdapters": [
+      {
+        "acceptedTargetProfileRole": "target-profile.echo-dpo",
+        "acceptedTargetIrResource": "resource.target-ir",
+        "adapterResource": "resource.lawpack-target-adapter",
+        "effects": ["target.replace"]
+      }
+    ],
+    "verifier": {
+      "class": "declarative",
+      "rulesetResource": "resource.lawpack-verifier"
+    },
+    "compatibilityResource": "resource.lawpack-compatibility",
+    "conformanceFixtureCorpusResource": "resource.conformance-corpus"
+  },
+  "targetProfileProjection": {
+    "authority": "echo.provider-target-metadata@1",
+    "artifactRole": "target-profile.echo-dpo",
+    "id": "echo.dpo",
+    "version": "1",
+    "acceptedCoreAbis": ["edict.core/v1"],
+    "intrinsicNamespace": "echo.dpo@1",
+    "intrinsicsResource": "resource.target-intrinsics",
+    "operationProfilesResource": "resource.target-operation-profiles",
+    "footprintAlgebraResource": "resource.target-footprint-algebra",
+    "costAlgebraResource": "resource.target-cost-algebra",
+    "targetIrResource": "resource.target-ir",
+    "obstructionTaxonomyResource": "resource.target-obstruction-taxonomy",
+    "verifierResource": "resource.target-verifier-contract",
+    "lowererResource": "resource.target-lowerer-contract",
+    "sandboxResource": "resource.sandbox",
+    "fuelModelResource": "resource.fuel-model",
+    "bundleProfileResource": "resource.target-bundle-profile",
+    "generatedArtifactProfileRoles": [
+      "generated-artifact-profile.echo-dpo-registration"
+    ],
+    "canonicalEncodingRulesResource": "resource.canonical-encoding",
+    "acceptedLawpackAdapterAbis": [],
+    "diagnosticAbiResource": "resource.diagnostic-abi",
+    "applicationModel": "atomic",
+    "readConsistency": "application-snapshot",
+    "guardEvaluation": "precommit-atomic",
+    "obstructionRollback": "no-visible-effects",
+    "multiTarget": false,
+    "postconditionSupport": true,
+    "deterministicExecutionResource": "resource.deterministic-execution",
+    "conformanceFixtureCorpusResource": "resource.conformance-corpus"
+  },
+  "generatedArtifacts": [
+    {
+      "role": "authority-facts.echo-dpo",
+      "kind": "authorityFacts",
+      "coordinate": "echo.dpo-authority-facts@1",
+      "schemaContract": "edict.authority-facts/v1",
+      "contractOwner": "flyingrobots/edict#157",
+      "authorityFactSource": {
+        "kind": "targetProfile",
+        "coordinate": "echo.dpo@1"
+      }
+    },
+    {
+      "role": "authority-facts.echo-lawpack",
+      "kind": "authorityFacts",
+      "coordinate": "echo.dpo-lawpack-authority-facts@1",
+      "schemaContract": "edict.authority-facts/v1",
+      "contractOwner": "flyingrobots/edict#157",
+      "authorityFactSource": {
+        "kind": "lawpack",
+        "coordinate": "echo.dpo-lawpack@1"
+      }
+    },
+    {
+      "role": "generated-artifact-profile.echo-dpo-registration",
+      "kind": "generatedArtifactProfile",
+      "coordinate": "echo.dpo.registration/v1",
+      "schemaContract": "echo.generated-artifact-profile/v1"
+    },
+    {
+      "role": "lawpack.echo-dpo",
+      "kind": "lawpack",
+      "coordinate": "echo.dpo-lawpack@1",
+      "schemaContract": "edict.lawpack/v1"
+    },
+    {
+      "role": "provenance.provider-generation",
+      "kind": "generationProvenance",
+      "coordinate": "echo.edict-provider-generation-provenance@1",
+      "schemaContract": "wesley:GenerationProvenanceManifestV1",
+      "contractOwner": "flyingrobots/wesley#728"
+    },
+    {
+      "role": "review.provider-generation",
+      "kind": "reviewArtifact",
+      "coordinate": "echo.edict-provider-generation-review@1",
+      "schemaContract": "echo.edict-provider.generation-review/v1"
+    },
+    {
+      "role": "schema.echo-provider-artifacts",
+      "kind": "artifactSchema",
+      "coordinate": "echo.provider-artifacts.cddl@1",
+      "schemaContract": "selfContainedCddlV1"
+    },
+    {
+      "role": "target-profile.echo-dpo",
+      "kind": "targetProfile",
+      "coordinate": "echo.dpo@1",
+      "schemaContract": "edict.target-profile/v1"
+    }
+  ],
+  "packageManifest": {
+    "role": "provider-manifest.echo",
+    "coordinate": "echo.edict-provider-manifest@1",
+    "schemaContract": "edict.provider-manifest/v1",
+    "providerAbi": "edict:target-provider@1.0.0",
+    "providerCoordinate": "echo.edict-provider@1"
+  },
+  "invocationInputs": [
+    {
+      "role": "authority-facts.echo-dpo",
+      "kind": "authorityFacts",
+      "domain": "edict.authority-facts/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "authority-facts.echo-lawpack",
+      "kind": "authorityFacts",
+      "domain": "edict.authority-facts/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "core.echo-provider",
+      "kind": "core",
+      "domain": "edict.core.module/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "lawpack.echo-dpo",
+      "kind": "lawpack",
+      "domain": "edict.lawpack/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "lowerability.echo-dpo",
+      "kind": "lowerabilityFacts",
+      "domain": "edict.lowering-requirements/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "target-ir.echo-dpo",
+      "kind": "targetIr",
+      "domain": "edict.target-ir.artifact/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "target-profile.echo-dpo",
+      "kind": "targetProfile",
+      "domain": "edict.target-profile/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    }
+  ],
+  "invocationOutputs": [
+    {
+      "role": "generated.echo-dpo",
+      "kind": "generatedArtifact",
+      "domain": "echo.generated-artifact/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "review.echo-dpo",
+      "kind": "reviewPayload",
+      "domain": "echo.review-payload/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "target-ir.echo-dpo",
+      "kind": "targetIr",
+      "domain": "edict.target-ir.artifact/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    },
+    {
+      "role": "verifier-report.echo-dpo",
+      "kind": "verifierReport",
+      "domain": "echo.verifier-report/v1",
+      "schemaRole": "schema.echo-provider-artifacts"
+    }
+  ],
+  "schemaBindings": [
+    {
+      "domain": "echo.generated-artifact/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "generated-artifact"
+    },
+    {
+      "domain": "echo.review-payload/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "review-payload"
+    },
+    {
+      "domain": "echo.verifier-report/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "verifier-report"
+    },
+    {
+      "domain": "edict.authority-facts/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "authority-facts"
+    },
+    {
+      "domain": "edict.core.module/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "core-module"
+    },
+    {
+      "domain": "edict.lawpack/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "lawpack-manifest"
+    },
+    {
+      "domain": "edict.lowering-requirements/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "lowering-requirements"
+    },
+    {
+      "domain": "edict.target-ir.artifact/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "target-ir-artifact"
+    },
+    {
+      "domain": "edict.target-profile/v1",
+      "schemaRole": "schema.echo-provider-artifacts",
+      "format": "selfContainedCddlV1",
+      "rootRule": "target-profile-manifest"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add the strict, versioned `echo.edict-provider-semantics/v1` source model owned by `echo-wesley-gen`
- validate and normalize the minimal Echo provider vocabulary: bounded types, effects, failures, obstructions, operation profiles, budgets, native capabilities/direct adapters, artifact roles, invocation closure, and schema bindings
- check in the first reviewed semantic-source document and deterministic projection contract for the selected effectful Echo slice
- reconcile relocated SDL authority so historical GraphQL files cannot silently become a second semantic source

## Contract boundaries

- the checked JSON is authored semantic source, not a generated lawpack, target profile, authority-facts document, provider manifest, or executable component
- every runtime effect has exactly one implementation path, every lawpack adapter selector is unique, and all referenced types/failures/obstructions/profiles/budgets/capabilities/schemas close transitively
- authority-facts artifacts bind `contractOwner` to `flyingrobots/edict#157`; its canonical `edict.authority-facts/v1` CBOR/CDDL consumer contract landed in Edict PR #159
- target-profile resources remain explicit trusted external inputs; canonical publication is downstream under `flyingrobots/edict#158`
- generation provenance remains Wesley-owned under `flyingrobots/wesley#728`
- the provider manifest is a later #655 package root and cannot inventory itself as a #652 generated member

## RED / GREEN

RED:

- `CARGO_TARGET_DIR=/Users/james/git/echo/target cargo +1.90.0 test -p echo-wesley-gen --test provider_semantic_source`
- focused witnesses failed before implementation for missing strict source parsing/projection, duplicate lawpack adapter selection, missing/ambiguous effect implementations, and authority-facts contract ownership

GREEN:

- `CARGO_TARGET_DIR=/Users/james/git/echo/target cargo +1.90.0 test -p echo-wesley-gen --test provider_semantic_source` (18 passed)
- `CARGO_TARGET_DIR=/Users/james/git/echo/target cargo +1.90.0 clippy -p echo-wesley-gen --lib --tests -- -D warnings -D missing-docs`
- `CARGO_TARGET_DIR=/Users/james/git/echo/target cargo +1.90.0 xtask pr-preflight` (changed-scope verification, tests, Prettier, dead refs, and Markdown lint passed)

The pre-commit and pre-push repository hooks also passed their selected Echo-Wesley checks.

## Review

Independent implementation and contract reviews found and drove closure of:

- duplicate lawpack target-adapter selectors
- native/adapter ambiguity and missing effect implementations
- authority-facts ownership and Edict ABI dependency
- exact package-root versus generated-member responsibilities
- external canonical resource authority boundaries

A final post-fix review reported no remaining findings.

## Dependency impact

No dependencies were added or changed. This slice does not introduce a sibling-path dependency and publishes no artifact.

## Docs impact

Updated the Echo-Wesley README, application-hosting architecture, changelog, source-contract reference, schema inventory, and the detailed provider semantic-source design. The documents describe current branch behavior and keep #652/#655 boundaries explicit.

Closes #651
Closes #461
