### PR TITLE
Harden trusted runtime WAL recovery integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,11 @@
   receipt indexes, causal parents, and app-facing outcome. Legacy digest-only
   runtime deltas remain explicit recovery obstructions. WAL activation also
   rejects live process-only authority that recovered durable history cannot
-  reproduce. Recovery rejects scheduler transactions that duplicate tick
-  receipt or receipt-correlation records. WAL transaction construction rejects
-  retained submission, correlation, or replayable state-delta material that
-  does not bind the other evidence in the same atomic claim.
+  reproduce. Recovery rejects duplicate singular acceptance, retained-envelope,
+  tick-receipt, receipt-correlation, or state-delta frames instead of selecting
+  one claim. WAL transaction construction rejects retained submission,
+  correlation, or replayable state-delta material that does not bind the other
+  evidence in the same atomic claim.
 - Trusted runtime submission intake now atomically retains a versioned canonical
   ingress envelope with each WAL-backed acceptance. Filesystem WAL reopen
   restores the witnessed submission ledger without ticking or dispatching,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@
   codecs reject malformed magic and empty-but-present, duplicated, or reordered
   parent sets as corruption and report structurally valid legacy digest-only
   parent evidence as an explicit ambiguity rather than aliasing it to an
-  arbitrary event.
+  arbitrary event. Read-only runtime-WAL recovery also rejects any correlation
+  parent set that disagrees with the independently retained ingress envelope.
   Retained tick-receipt reconstruction also rejects non-canonical blocker
   ordering, forward or non-applied blocker references, and blocker attribution
   incompatible with the candidate disposition before the receipt re-enters

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -2105,7 +2105,7 @@ impl WorldlineRuntime {
                 persisted.tick_receipt_digest,
             ));
         }
-        if persisted.causal_parent_receipts != canonical_causal_parent_receipts(envelope) {
+        if persisted.causal_parent_receipts != envelope.canonical_causal_parent_receipt_refs() {
             return Err(RuntimeError::ReceiptCorrelationReplayMismatch(
                 persisted.causal_receipt_ref.identity_digest(),
             ));
@@ -2700,7 +2700,7 @@ impl WorldlineRuntime {
                 worldline_tick_after: context.worldline_tick_after,
                 tick_receipt_digest: context.tick_receipt_digest,
                 commit_hash: context.commit_hash,
-                causal_parent_receipts: canonical_causal_parent_receipts(envelope),
+                causal_parent_receipts: envelope.canonical_causal_parent_receipt_refs(),
             };
             let current_basis = receipt_correlation_current_basis(&record);
             if self
@@ -2790,18 +2790,6 @@ impl WorldlineRuntime {
                 .ok_or(RuntimeError::UnknownHead(*key)),
         }
     }
-}
-
-fn canonical_causal_parent_receipts(envelope: &IngressEnvelope) -> Vec<CausalTickReceiptRef> {
-    let mut receipt_refs = envelope
-        .causal_parents()
-        .iter()
-        .copied()
-        .map(crate::IngressCausalParent::receipt_ref)
-        .collect::<Vec<_>>();
-    receipt_refs.sort_unstable();
-    receipt_refs.dedup();
-    receipt_refs
 }
 
 fn receipt_correlation_current_basis(

--- a/crates/warp-core/src/head_inbox.rs
+++ b/crates/warp-core/src/head_inbox.rs
@@ -243,6 +243,20 @@ impl IngressEnvelope {
         &self.causal_parents
     }
 
+    /// Returns the canonical receipt set cited by every typed causal relation.
+    #[must_use]
+    pub(crate) fn canonical_causal_parent_receipt_refs(&self) -> Vec<CausalTickReceiptRef> {
+        let mut receipt_refs = self
+            .causal_parents
+            .iter()
+            .copied()
+            .map(IngressCausalParent::receipt_ref)
+            .collect::<Vec<_>>();
+        receipt_refs.sort_unstable();
+        receipt_refs.dedup();
+        receipt_refs
+    }
+
     /// Encodes this envelope as bounded, versioned retained material.
     ///
     /// These bytes preserve the canonical claim needed for restart replay. The

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -121,6 +121,16 @@ pub enum TrustedRuntimeWalError {
         /// Accepted submission whose canonical envelope was unavailable.
         submission_id: Hash,
     },
+    /// Receipt correlation parents disagreed with the retained ingress envelope.
+    #[error(
+        "trusted runtime WAL causal parents mismatched submission {submission_id:?} receipt {receipt_ref_digest:?}"
+    )]
+    ReceiptCorrelationCausalParentsMismatch {
+        /// Submission whose retained causal-parent claims disagreed.
+        submission_id: Hash,
+        /// Identity digest of the receipt carrying the conflicting correlation.
+        receipt_ref_digest: Hash,
+    },
     /// A replayable runtime state delta could not be encoded or decoded.
     #[error("trusted runtime WAL retained state-delta codec error: {0}")]
     RuntimeStateDeltaCodec(#[from] RetainedProvenanceError),
@@ -1164,6 +1174,7 @@ impl TrustedRuntimeWal {
         let provenance_entries = runtime_state.provenance_entries;
         let receipt_correlations = runtime_state.receipt_correlations;
         let missing_runtime_state_deltas = runtime_state.missing_runtime_state_deltas;
+        validate_recovered_causal_parent_evidence(&witnessed_submissions, &receipt_correlations)?;
         Ok(TrustedRuntimeWalRecovery {
             certificate: runtime_wal_recovery_certificate(
                 &report,
@@ -1993,6 +2004,31 @@ fn recover_runtime_state_delta_material(
     })
 }
 
+fn validate_recovered_causal_parent_evidence(
+    witnessed_submissions: &WitnessedSubmissionPersistenceSnapshot,
+    receipt_correlations: &[ReceiptCorrelationPersistenceRecord],
+) -> Result<(), TrustedRuntimeWalError> {
+    let envelopes_by_submission = witnessed_submissions
+        .records()
+        .iter()
+        .map(|record| (record.submission.submission_id, &record.envelope))
+        .collect::<BTreeMap<_, _>>();
+    for correlation in receipt_correlations {
+        let Some(envelope) = envelopes_by_submission.get(&correlation.submission_id) else {
+            continue;
+        };
+        if correlation.causal_parent_receipts != envelope.canonical_causal_parent_receipt_refs() {
+            return Err(
+                TrustedRuntimeWalError::ReceiptCorrelationCausalParentsMismatch {
+                    submission_id: correlation.submission_id,
+                    receipt_ref_digest: correlation.causal_receipt_ref.identity_digest(),
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
 fn tick_records_from_transaction(
     transaction: &crate::causal_wal::WalRecoveredTransaction,
 ) -> Result<
@@ -2460,8 +2496,8 @@ fn wal_tick_decision_from_observation(
 mod tests {
     use super::*;
     use crate::{
-        CausalTickReceiptRef, GlobalTick, IngressSubmissionGeneration, WorldlineId, WorldlineTick,
-        WriterHeadKey,
+        CausalTickReceiptRef, GlobalTick, IngressSubmissionGeneration, IngressTarget, WorldlineId,
+        WorldlineTick, WriterHeadKey,
     };
 
     fn test_head_key() -> WriterHeadKey {
@@ -2766,6 +2802,54 @@ mod tests {
                 )))
             ));
         }
+    }
+
+    #[test]
+    fn recovered_correlation_rejects_parents_not_bound_by_envelope() {
+        let head_key = test_head_key();
+        let envelope_parent = CausalTickReceiptRef {
+            worldline_id: head_key.worldline_id,
+            worldline_tick_after: WorldlineTick::from_raw(2),
+            commit_global_tick: GlobalTick::from_raw(2),
+            commit_hash: [31; 32],
+            submission_id: [32; 32],
+            ticket_digest: [33; 32],
+            receipt_content_digest: [34; 32],
+        };
+        let envelope = IngressEnvelope::local_intent_with_causal_parents(
+            IngressTarget::ExactHead { key: head_key },
+            crate::make_intent_kind("runtime-wal-parent-validation"),
+            b"parent-validation".to_vec(),
+            vec![IngressCausalParent::TickReceipt {
+                receipt_ref: envelope_parent,
+            }],
+        );
+        let witnessed = WitnessedSubmissionPersistenceSnapshot::new(vec![
+            WitnessedSubmissionPersistenceRecord {
+                submission: IntentSubmissionRecord {
+                    submission_id: [2; 32],
+                    ingress_id: envelope.ingress_id(),
+                    head_key,
+                    submission_generation: IngressSubmissionGeneration::from_raw(1),
+                },
+                envelope,
+            },
+        ]);
+        let mut correlation = ReceiptCorrelationPersistenceRecord::from(&test_correlation([7; 32]));
+        correlation.causal_parent_receipts = vec![CausalTickReceiptRef {
+            ticket_digest: [35; 32],
+            ..envelope_parent
+        }];
+
+        assert_eq!(
+            validate_recovered_causal_parent_evidence(&witnessed, &[correlation.clone()]),
+            Err(
+                TrustedRuntimeWalError::ReceiptCorrelationCausalParentsMismatch {
+                    submission_id: correlation.submission_id,
+                    receipt_ref_digest: correlation.causal_receipt_ref.identity_digest(),
+                }
+            )
+        );
     }
 }
 

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -1764,11 +1764,8 @@ impl TrustedRuntimeWalCursor {
 fn submission_acceptance_record_from_transaction(
     transaction: &crate::causal_wal::WalRecoveredTransaction,
 ) -> Result<SubmissionAcceptanceRecord, TrustedRuntimeWalError> {
-    let frame = transaction
-        .frames
-        .iter()
-        .find(|frame| frame.header.record_kind == WalRecordKind::SubmissionAcceptedRecorded)
-        .ok_or_else(missing_trusted_runtime_record)?;
+    let frame =
+        required_unique_transaction_frame(transaction, WalRecordKind::SubmissionAcceptedRecorded)?;
     SubmissionAcceptanceRecord::from_payload_bytes(&frame.payload.canonical_bytes)
         .map_err(decode_trusted_runtime_wal_payload)
 }
@@ -1779,10 +1776,9 @@ fn recover_witnessed_submission_material(
 ) -> Result<(WitnessedSubmissionPersistenceSnapshot, Vec<Hash>), TrustedRuntimeWalError> {
     let mut material_by_submission = BTreeMap::new();
     for transaction in &report.transactions {
-        for frame in &transaction.frames {
-            if frame.header.record_kind != WalRecordKind::SubmissionEnvelopeRetained {
-                continue;
-            }
+        if let Some(frame) =
+            unique_transaction_frame(transaction, WalRecordKind::SubmissionEnvelopeRetained)?
+        {
             let material =
                 WalSubmissionEnvelopeRecord::from_payload_bytes(&frame.payload.canonical_bytes)
                     .map_err(decode_trusted_runtime_wal_payload)?;
@@ -1891,18 +1887,10 @@ fn recover_runtime_state_delta_material(
                 WalDecodeError::InvalidEmbeddedFrame,
             ));
         }
-        let mut state_delta_frames = transaction
-            .frames
-            .iter()
-            .filter(|frame| frame.header.record_kind == WalRecordKind::RuntimeStateDeltaRecorded);
-        let state_delta_frame = state_delta_frames
-            .next()
-            .ok_or_else(missing_trusted_runtime_record)?;
-        if state_delta_frames.next().is_some() {
-            return Err(decode_trusted_runtime_wal_payload(
-                WalDecodeError::InvalidEmbeddedFrame,
-            ));
-        }
+        let state_delta_frame = required_unique_transaction_frame(
+            transaction,
+            WalRecordKind::RuntimeStateDeltaRecorded,
+        )?;
         if state_delta_frame.payload.canonical_bytes.len() == core::mem::size_of::<Hash>() {
             missing.push(receipt.receipt_ref.identity_digest());
             continue;
@@ -2047,11 +2035,8 @@ fn tick_records_from_transaction(
             WalDecodeError::InvalidEmbeddedFrame,
         ));
     }
-    let state_delta_frame = transaction
-        .frames
-        .iter()
-        .find(|frame| frame.header.record_kind == WalRecordKind::RuntimeStateDeltaRecorded)
-        .ok_or_else(missing_trusted_runtime_record)?;
+    let state_delta_frame =
+        required_unique_transaction_frame(transaction, WalRecordKind::RuntimeStateDeltaRecorded)?;
     let (state_delta_digest, provenance_entry) = if state_delta_frame.payload.canonical_bytes.len()
         == core::mem::size_of::<Hash>()
     {
@@ -2082,7 +2067,8 @@ fn tick_records_from_transaction(
 fn tick_receipt_from_transaction(
     transaction: &crate::causal_wal::WalRecoveredTransaction,
 ) -> Result<TickReceiptRecord, TrustedRuntimeWalError> {
-    let receipt_frame = unique_tick_record(transaction, WalRecordKind::TickReceiptRecorded)?;
+    let receipt_frame =
+        required_unique_transaction_frame(transaction, WalRecordKind::TickReceiptRecorded)?;
     TickReceiptRecord::from_payload_bytes(&receipt_frame.payload.canonical_bytes)
         .map_err(decode_trusted_runtime_wal_payload)
 }
@@ -2091,20 +2077,27 @@ fn tick_correlation_from_transaction(
     transaction: &crate::causal_wal::WalRecoveredTransaction,
 ) -> Result<WalReceiptCorrelationRecord, TrustedRuntimeWalError> {
     let correlation_frame =
-        unique_tick_record(transaction, WalRecordKind::ReceiptCorrelationRecorded)?;
+        required_unique_transaction_frame(transaction, WalRecordKind::ReceiptCorrelationRecorded)?;
     WalReceiptCorrelationRecord::from_payload_bytes(&correlation_frame.payload.canonical_bytes)
         .map_err(decode_trusted_runtime_wal_payload)
 }
 
-fn unique_tick_record(
+fn required_unique_transaction_frame(
     transaction: &crate::causal_wal::WalRecoveredTransaction,
     record_kind: WalRecordKind,
 ) -> Result<&crate::causal_wal::WalFrame, TrustedRuntimeWalError> {
+    unique_transaction_frame(transaction, record_kind)?.ok_or_else(missing_trusted_runtime_record)
+}
+
+fn unique_transaction_frame(
+    transaction: &crate::causal_wal::WalRecoveredTransaction,
+    record_kind: WalRecordKind,
+) -> Result<Option<&crate::causal_wal::WalFrame>, TrustedRuntimeWalError> {
     let mut matching = transaction
         .frames
         .iter()
         .filter(|frame| frame.header.record_kind == record_kind);
-    let record = matching.next().ok_or_else(missing_trusted_runtime_record)?;
+    let record = matching.next();
     if matching.next().is_some() {
         return Err(decode_trusted_runtime_wal_payload(
             WalDecodeError::InvalidEmbeddedFrame,
@@ -2724,7 +2717,105 @@ mod tests {
     }
 
     #[test]
-    fn runtime_wal_tick_record_selection_rejects_duplicate_receipt_evidence() {
+    fn runtime_wal_submission_record_selection_rejects_duplicate_singular_evidence() {
+        let wal = TrustedRuntimeWal::new_in_memory().expect("test WAL should initialize");
+        let head_key = test_head_key();
+        let envelope = IngressEnvelope::local_intent(
+            IngressTarget::ExactHead { key: head_key },
+            crate::make_intent_kind("runtime-wal-duplicate-submission-record"),
+            b"duplicate-submission-record".to_vec(),
+        );
+        let handle = IntentSubmissionHandle {
+            ingress_id: envelope.ingress_id(),
+            head_key,
+            submission_id: [21; 32],
+            submission_generation: IngressSubmissionGeneration::from_raw(1),
+            duplicate: false,
+        };
+        let acceptance = SubmissionAcceptanceRecord {
+            submission_id: handle.submission_id,
+            canonical_envelope_digest: handle.ingress_id,
+            idempotency_key_digest: None,
+            acceptance_evidence_digest: acceptance_evidence_digest(handle),
+        };
+        let retained_envelope = submission_envelope_record(&envelope, handle);
+
+        for (index, duplicate_kind) in [
+            WalRecordKind::SubmissionAcceptedRecorded,
+            WalRecordKind::SubmissionEnvelopeRetained,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut transaction_id = [22; 32];
+            transaction_id[0] = u8::try_from(index).expect("fixture index must fit in u8");
+            let mut builder = wal.builder(
+                WalTransactionKind::SubmissionIntake,
+                WalAppendAuthority::SubmissionIntake,
+                WalTransactionId::from_hash(transaction_id),
+            );
+            builder
+                .push_record(
+                    WalRecordKind::SubmissionAcceptedRecorded,
+                    acceptance.to_payload_bytes(),
+                )
+                .expect("fixture acceptance must append");
+            if duplicate_kind == WalRecordKind::SubmissionAcceptedRecorded {
+                builder
+                    .push_record(
+                        WalRecordKind::SubmissionAcceptedRecorded,
+                        acceptance.to_payload_bytes(),
+                    )
+                    .expect("duplicate acceptance must append");
+            }
+            builder
+                .push_record(
+                    WalRecordKind::SubmissionEnvelopeRetained,
+                    retained_envelope.to_payload_bytes(),
+                )
+                .expect("fixture retained envelope must append");
+            if duplicate_kind == WalRecordKind::SubmissionEnvelopeRetained {
+                builder
+                    .push_record(
+                        WalRecordKind::SubmissionEnvelopeRetained,
+                        retained_envelope.to_payload_bytes(),
+                    )
+                    .expect("duplicate retained envelope must append");
+            }
+            let transaction = builder
+                .commit(Vec::new())
+                .expect("duplicate-kind transaction must commit structurally");
+            transaction
+                .validate()
+                .expect("duplicate-kind transaction must remain structurally valid");
+            let recovered = crate::causal_wal::WalRecoveredTransaction {
+                commit: transaction.commit,
+                frames: transaction.frames,
+            };
+
+            let result = if duplicate_kind == WalRecordKind::SubmissionAcceptedRecorded {
+                submission_acceptance_record_from_transaction(&recovered).map(|_| ())
+            } else {
+                let report = RecoveryScanReport {
+                    transactions: vec![recovered],
+                    tail_posture: crate::causal_wal::RecoveryTailPosture::Clean,
+                };
+                let submissions =
+                    recover_submission_index(&report).expect("canonical acceptance should recover");
+                recover_witnessed_submission_material(&report, &submissions).map(|_| ())
+            };
+
+            assert!(matches!(
+                result,
+                Err(TrustedRuntimeWalError::Recovery(WalRecoveryError::Index(
+                    WalRecoveryIndexError::Decode(WalDecodeError::InvalidEmbeddedFrame)
+                )))
+            ));
+        }
+    }
+
+    #[test]
+    fn runtime_wal_tick_record_selection_rejects_duplicate_singular_evidence() {
         let wal = TrustedRuntimeWal::new_in_memory().expect("test WAL should initialize");
         let receipt = TickReceiptRecord {
             receipt_ref: CausalTickReceiptRef {
@@ -2748,6 +2839,7 @@ mod tests {
         for (index, duplicate_kind) in [
             WalRecordKind::TickReceiptRecorded,
             WalRecordKind::ReceiptCorrelationRecorded,
+            WalRecordKind::RuntimeStateDeltaRecorded,
         ]
         .into_iter()
         .enumerate()
@@ -2784,6 +2876,11 @@ mod tests {
             builder
                 .push_record(WalRecordKind::RuntimeStateDeltaRecorded, [36; 32].to_vec())
                 .expect("fixture state delta must append");
+            if duplicate_kind == WalRecordKind::RuntimeStateDeltaRecorded {
+                builder
+                    .push_record(WalRecordKind::RuntimeStateDeltaRecorded, [36; 32].to_vec())
+                    .expect("duplicate state delta must append");
+            }
             let transaction = builder
                 .commit(Vec::new())
                 .expect("duplicate-kind transaction must commit structurally");

--- a/docs/topics/WAL.md
+++ b/docs/topics/WAL.md
@@ -48,7 +48,9 @@ parent lookup and reverse child lookup during read-only recovery. A contract can
 therefore define inverse semantics while Echo preserves the provenance chain
 across process loss. Recovery rejects explicitly empty, duplicated, or
 out-of-order parent receipt coordinates instead of normalizing committed
-non-canonical bytes.
+non-canonical bytes. Before exposing a recovered correlation, it also requires
+that correlation's parent set to match the independently retained ingress
+envelope.
 
 Sixth, trusted submission intake commits the canonical retained ingress envelope
 in the same transaction as acceptance evidence. Reopening a filesystem WAL can

--- a/docs/topics/WAL.md
+++ b/docs/topics/WAL.md
@@ -17,7 +17,7 @@ Echo may only claim what its WAL can recover.
 
 ## What We Found
 
-The current runtime WAL evidence says four concrete things.
+The current runtime WAL evidence says seven concrete things.
 
 First, accepted-submission evidence is not just an in-memory editor event. The
 WAL-backed ACK path, `submit_intent_with_runtime_wal_ack(...)`, returns only

--- a/docs/topics/WAL.md
+++ b/docs/topics/WAL.md
@@ -60,6 +60,8 @@ lack envelope material remain inspectable, but recovery reports them as
 obstructed and the trusted host refuses to claim a complete replay.
 Transaction construction rejects any retained envelope whose submission or
 canonical-envelope identity disagrees with its acceptance record.
+Recovery requires exactly one acceptance frame and at most one retained
+envelope frame in each intake transaction.
 
 Seventh, a scheduler-tick transaction for ticketed runtime ingress retains the
 canonical local-commit provenance entry, its exact typed `TickReceipt`, and any
@@ -73,6 +75,9 @@ digest-only state-delta record is inspectable but obstructs writable startup.
 Transaction construction also requires the receipt and correlation to name the
 same causal event and the retained state delta to bind that receipt's content
 commitment before the transaction can commit.
+Each scheduler transaction must also contain exactly one receipt, correlation,
+and runtime state-delta frame; recovery rejects duplicate claims rather than
+selecting whichever frame appears first.
 WAL activation is non-lossy: if the live host contains submissions, staged
 ingress, receipt correlations, provenance, pending inbox work, cycle progress,
 or worldline state that recovered WAL evidence cannot reproduce, activation


### PR DESCRIPTION
## Summary

- cross-check recovered receipt-correlation parent sets against independently retained ingress envelopes before exposing read-only recovery
- enforce exact per-transaction cardinality for singular submission and scheduler WAL authority frames
- retain exact duplicates across separate transactions under the existing append-only/idempotency policy
- correct the WAL topic's enumerated evidence count

## Why

This is a post-merge integrity follow-up to #659. The final audit found that correlation-parent validation occurred during runtime restoration but not at the public `TrustedRuntimeWal::recover_read_only` boundary. It also found that the duplicate-frame correction covered tick receipts and correlations but left submission acceptance, retained-envelope, and state-delta cardinality inconsistent.

The result is one validation boundary for recovered causal-parent evidence and one exact-cardinality helper for every singular authority frame.

## Validation

- `cargo +1.90.0 xtask pr-preflight --base origin/main`
- `cargo test -p warp-core --lib --features native_rule_bootstrap,trusted_runtime trusted_runtime_host::tests:: -- --nocapture`
- `cargo test -p warp-core --test external_consumer_contract_fixture_tests --features native_rule_bootstrap,trusted_runtime inverse_intent_resolves_one_admitted_transition_after_restart -- --exact --nocapture`
- `cargo test -p warp-core --test trusted_runtime_host_loop_tests --features native_rule_bootstrap,trusted_runtime,host_test`
- `cargo clippy -p warp-core --lib --features native_rule_bootstrap,trusted_runtime,host_test -- -D warnings -D missing_docs`
