### PR TITLE
Add trusted installed-contract admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Added
 
+- `TrustedRuntimeHost` can now admit a witnessed installed-contract submission
+  without accepting caller-manufactured ticket authority. Echo derives a
+  domain-separated admission digest from its witnessed submission record and
+  verified installed-package identity, stages the operation through the same
+  package-evidence boundary, and binds the resulting receipt to that evidence.
+  The explicit ticketed staging API remains available for actual Optic
+  admissions; application-facing handles still cannot admit, stage, or tick.
 - `echo-wesley-gen` now purely assembles and digest-admits the first complete
   Echo Edict provider distribution from the verified 22-file generated corpus
   and explicit lowerer/verifier bytes. The derived provider manifest carries ten

--- a/crates/warp-core/src/coordinator.rs
+++ b/crates/warp-core/src/coordinator.rs
@@ -2370,13 +2370,13 @@ impl WorldlineRuntime {
         ticket: &OpticAdmissionTicket,
         envelope: IngressEnvelope,
     ) -> Result<TicketedRuntimeIngressDisposition, RuntimeError> {
-        self.ingest_ticketed_invocation_inner(submission_id, ticket, envelope, None)
+        self.ingest_ticketed_invocation_inner(submission_id, ticket.ticket_digest, envelope, None)
     }
 
     fn ingest_ticketed_invocation_inner(
         &mut self,
         submission_id: Hash,
-        ticket: &OpticAdmissionTicket,
+        admission_digest: Hash,
         envelope: IngressEnvelope,
         contract: Option<crate::ContractEvidenceIdentity>,
     ) -> Result<TicketedRuntimeIngressDisposition, RuntimeError> {
@@ -2393,7 +2393,7 @@ impl WorldlineRuntime {
 
         let ticketed_ingress_id = derive_ticketed_runtime_ingress_id(
             submission_id,
-            ticket.ticket_digest,
+            admission_digest,
             ingress_id,
             head_key,
         );
@@ -2421,7 +2421,7 @@ impl WorldlineRuntime {
         let record = TicketedRuntimeIngressRecord {
             ticketed_ingress_id,
             submission_id,
-            ticket_digest: ticket.ticket_digest,
+            ticket_digest: admission_digest,
             ingress_id,
             head_key,
             contract,
@@ -2462,7 +2462,40 @@ impl WorldlineRuntime {
             .installed_contract_mutation_evidence(op_id)
             .ok_or(RuntimeError::UnsupportedInstalledContractMutation { op_id })?;
 
-        self.ingest_ticketed_invocation_inner(submission_id, ticket, envelope, Some(contract))
+        self.ingest_ticketed_invocation_inner(
+            submission_id,
+            ticket.ticket_digest,
+            envelope,
+            Some(contract),
+        )
+    }
+
+    /// Stages a witnessed installed-contract mutation using an admission digest
+    /// derived by the trusted runtime host.
+    ///
+    /// This crate-private seam prevents application adapters from manufacturing
+    /// Echo admission authority while preserving the installed-package evidence
+    /// checks performed by the normal generated-contract path.
+    #[cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
+    pub(crate) fn ingest_host_admitted_installed_contract_invocation(
+        &mut self,
+        _authority: &TicketedRuntimeIngressAuthority,
+        engine: &Engine,
+        submission_id: Hash,
+        admission_digest: Hash,
+        envelope: IngressEnvelope,
+    ) -> Result<TicketedRuntimeIngressDisposition, RuntimeError> {
+        let op_id = installed_contract_mutation_op_id(&envelope)?;
+        let contract = engine
+            .installed_contract_mutation_evidence(op_id)
+            .ok_or(RuntimeError::UnsupportedInstalledContractMutation { op_id })?;
+
+        self.ingest_ticketed_invocation_inner(
+            submission_id,
+            admission_digest,
+            envelope,
+            Some(contract),
+        )
     }
 
     /// Resolves an ingress envelope to a specific writer head and stores it in that inbox.

--- a/crates/warp-core/src/trusted_runtime_host.rs
+++ b/crates/warp-core/src/trusted_runtime_host.rs
@@ -57,6 +57,9 @@ use crate::{Hash, HistoryError};
 #[cfg(any(test, feature = "host_test"))]
 use crate::causal_wal::FilesystemWalFaultPlan;
 
+const INSTALLED_CONTRACT_HOST_ADMISSION_DIGEST_DOMAIN: &[u8] =
+    b"echo:trusted-host-installed-contract-admission:v1\0";
+
 /// Error returned by the reference trusted host loop.
 #[derive(Debug, Error)]
 pub enum TrustedRuntimeHostError {
@@ -967,6 +970,51 @@ impl TrustedRuntimeHost {
             ticket,
             envelope,
         )
+    }
+
+    /// Admits and stages one witnessed generated-contract submission under
+    /// trusted-host policy.
+    ///
+    /// Echo derives the admission digest from its witnessed submission record
+    /// and verified installed-package evidence. Application code neither
+    /// supplies nor observes an authority-bearing admission ticket. This method
+    /// does not tick or execute the installed operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a runtime error if the submission is unknown, malformed, not
+    /// backed by an installed mutation package, or rejected by runtime ingress.
+    pub fn admit_installed_contract_submission(
+        &mut self,
+        submission_id: Hash,
+    ) -> Result<TicketedRuntimeIngressDisposition, RuntimeError> {
+        let submission = self
+            .runtime
+            .witnessed_submission(&submission_id)
+            .cloned()
+            .ok_or(RuntimeError::UnknownIntentSubmission(submission_id))?;
+        let envelope = self
+            .runtime
+            .witnessed_submission_envelope(&submission_id)
+            .cloned()
+            .ok_or(RuntimeError::UnknownIntentSubmission(submission_id))?;
+        let IngressPayload::LocalIntent { intent_bytes, .. } = envelope.payload();
+        let (op_id, _vars) = decode_canonical_eint(intent_bytes)
+            .ok_or(RuntimeError::MalformedInstalledContractIntent)?;
+        let contract = self
+            .engine
+            .installed_contract_mutation_evidence(op_id)
+            .ok_or(RuntimeError::UnsupportedInstalledContractMutation { op_id })?;
+        let admission_digest = installed_contract_host_admission_digest(&submission, &contract);
+
+        self.runtime
+            .ingest_host_admitted_installed_contract_invocation(
+                &TicketedRuntimeIngressAuthority::assume_runtime_owner(),
+                &self.engine,
+                submission_id,
+                admission_digest,
+                envelope,
+            )
     }
 
     /// Runs one scheduler-owned pass.
@@ -3012,6 +3060,21 @@ fn submission_transaction_digest(
     hasher.update(&handle.submission_generation.as_u64().to_le_bytes());
     hasher.update(&record.canonical_envelope_digest);
     hasher.update(&record.acceptance_evidence_digest);
+    hasher.finalize().into()
+}
+
+fn installed_contract_host_admission_digest(
+    submission: &IntentSubmissionRecord,
+    contract: &crate::ContractEvidenceIdentity,
+) -> Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(INSTALLED_CONTRACT_HOST_ADMISSION_DIGEST_DOMAIN);
+    hasher.update(&submission.submission_id);
+    hasher.update(&submission.ingress_id);
+    hasher.update(submission.head_key.worldline_id.as_bytes());
+    hasher.update(submission.head_key.head_id.as_bytes());
+    hasher.update(contract.package_id.as_bytes());
+    hasher.update(&contract.op_id.to_le_bytes());
     hasher.finalize().into()
 }
 

--- a/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
+++ b/crates/warp-core/tests/trusted_runtime_host_loop_tests.rs
@@ -527,6 +527,49 @@ fn reference_host_loop_keeps_tick_authority_out_of_app_surface() {
 }
 
 #[test]
+fn trusted_host_admits_installed_contract_submission_without_caller_ticket_authority() {
+    let (runtime, worldline_id) = runtime();
+    let mut host =
+        TrustedRuntimeHost::new(runtime, empty_engine()).expect("trusted host should initialize");
+    host.register_contract_package(package())
+        .expect("host should install package");
+
+    let submission = {
+        let mut app = host.app();
+        app.submit_intent(eint_envelope(worldline_id))
+            .expect("app should submit witnessed intent")
+    };
+
+    let staged = host
+        .admit_installed_contract_submission(submission.submission_id)
+        .expect("trusted host should derive admission evidence and stage installed work");
+    let admission_digest = match staged {
+        warp_core::TicketedRuntimeIngressDisposition::Staged { record, .. }
+        | warp_core::TicketedRuntimeIngressDisposition::Duplicate { record } => {
+            record.ticket_digest
+        }
+    };
+    assert_ne!(admission_digest, [0; 32]);
+
+    host.run_until_idle(4)
+        .expect("trusted host should tick until idle");
+    let outcome = {
+        let app = host.app();
+        app.observe_intent_outcome(&submission.submission_id)
+    };
+    let IntentOutcome::Applied { receipt, .. } = outcome else {
+        panic!("expected applied outcome");
+    };
+    assert_eq!(receipt.ticket_digest, admission_digest);
+    let contract = receipt
+        .contract
+        .expect("installed mutation receipt should carry package evidence");
+    assert_eq!(contract.op_id, MUTATION_OP_ID);
+    assert_eq!(contract.op_kind, ContractOperationKind::Mutation);
+    assert_eq!(contract.package_name, "reference-counter");
+}
+
+#[test]
 fn runtime_wal_ack_submit_commits_acceptance_before_returning_handle() {
     let (runtime, worldline_id) = runtime();
     let mut host =

--- a/docs/case-studies/JimAndEcho.md
+++ b/docs/case-studies/JimAndEcho.md
@@ -351,8 +351,8 @@ sequenceDiagram
     end
 
     Note over H,S: Host, not Jim UI, controls staging and tick cadence.
-    H->>H: Resolve installed operation support and Echo admission ticket
-    H->>R: Stage witnessed submission under trusted ticket
+    H->>H: Verify installed operation support and derive admission evidence
+    H->>R: Admit and stage witnessed installed operation
     H->>S: tick_once()
     S->>R: Pin candidates and deterministic order
     S->>C: Execute ReplaceRange against basis H41

--- a/docs/quickstart-local-contract-host.md
+++ b/docs/quickstart-local-contract-host.md
@@ -39,7 +39,7 @@ The witness covers the current v0.1.0 local contract path:
 1. Register a generated-style package through the package boundary.
 2. Submit canonical EINT bytes through an app-facing handle.
 3. Keep the submission pending until trusted runtime-owned staging.
-4. Stage ticketed runtime ingress through the trusted host.
+4. Admit and stage installed-contract ingress through the trusted host.
 5. Run scheduler-owned ticks until idle.
 6. Observe applied and rejected intent outcomes.
 7. Query a bounded `QueryView` reading through a read-only observer.
@@ -60,7 +60,7 @@ let reading = app.observe(query_request)?;
 The app surface does not expose:
 
 - package registration;
-- ticketed runtime ingress staging;
+- installed-contract admission or runtime ingress staging;
 - `super_tick`;
 - scheduler pass or run-until-idle control;
 - scheduler fault recovery authority.
@@ -71,11 +71,15 @@ The trusted runtime owner uses the host surface:
 
 ```rust
 host.register_contract_package(package)?;
-host.stage_installed_contract_submission(submission.submission_id, &ticket)?;
+host.admit_installed_contract_submission(submission.submission_id)?;
 host.run_until_idle(4)?;
 ```
 
-That host role owns scheduler control. Wall-clock cadence is host policy; fixed
+That host role derives admission evidence from Echo's witnessed submission and
+the verified installed package. Applications do not construct admission tickets
+or admission digests for this path. The explicit caller-ticket API remains for
+Optic admissions, where a separately witnessed ticket is the relevant evidence.
+The host also owns scheduler control. Wall-clock cadence is host policy; fixed
 logical ticks are Echo semantic history.
 
 ## Compatibility Boundary

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -844,7 +844,7 @@ fn build_test_slice_commands(slice: TestSlice) -> Vec<Command> {
                 "-p",
                 "warp-core",
                 "--features",
-                "native_rule_bootstrap trusted_runtime",
+                "native_rule_bootstrap trusted_runtime host_test",
                 "--test",
                 "trusted_runtime_host_loop_tests",
             ]),
@@ -6552,7 +6552,7 @@ mod tests {
                 "-p",
                 "warp-core",
                 "--features",
-                "native_rule_bootstrap trusted_runtime",
+                "native_rule_bootstrap trusted_runtime host_test",
                 "--test",
                 "trusted_runtime_host_loop_tests",
             ]


### PR DESCRIPTION
## Summary

- add an Echo-owned trusted-host admission path for witnessed generated-contract submissions
- derive domain-separated admission evidence from witnessed submission and verified package identity
- keep caller-authored Optic tickets out of application contract hosts
- repair the canonical contract-path test slice feature set and update current docs

## Verification

- `cargo xtask test-slice contract-path-release`
- `cargo clippy -p warp-core --features native_rule_bootstrap,trusted_runtime,host_test --lib -- -D warnings`
- `cargo clippy -p warp-core --features native_rule_bootstrap,trusted_runtime,host_test --test trusted_runtime_host_loop_tests -- -D warnings`

## Documentation

Updated the local contract-host quickstart, Jim/Echo case study, and changelog to reflect the Echo-owned admission boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trusted hosts can now admit witnessed installed-contract submissions without caller-provided ticket authority.
  - Resulting receipts are bound to verified installed-package evidence.
  - Explicit ticket-based staging remains available for Optic admissions.

- **Documentation**
  - Updated the local contract-host quickstart and Jim-and-Echo case study to describe the new admission flow.

- **Tests**
  - Added coverage confirming installed-contract submissions are admitted and applied successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->