### PR TITLE
fix(warp-core): reject unrecoverable provider evidence before install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1342,6 +1342,14 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
 
 ### Fixed
 
+- Provider-native installation now applies the same pure structural validation
+  used to reconstruct retained invocation evidence before mutating any Echo
+  engine index. Empty operation or Target IR coordinates, empty Target IR
+  digest domains, and Target IR digests that are not exact lowercase
+  `sha256:<64-hex>` values fail with stable typed installation errors, so Echo
+  cannot originate receipt or WAL evidence that fresh-host recovery would
+  reject. Existing valid tag-2 provider evidence and byte-stable tag-1 legacy
+  evidence retain their encoding and recovery behavior.
 - Direct GraphQL SDL lowering in `echo-wesley-gen` now binds the exact pinned
   `wesley-core` version into generated Rust artifact-hash provenance, with a
   regression test that refuses dependency/provenance version drift.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1350,6 +1350,9 @@ Applied, Rejected, Obstructed}` with receipt evidence and typed contract
   cannot originate receipt or WAL evidence that fresh-host recovery would
   reject. Existing valid tag-2 provider evidence and byte-stable tag-1 legacy
   evidence retain their encoding and recovery behavior.
+- Full local verification now enables the declared
+  `native_rule_bootstrap,trusted_runtime` feature set when testing or linting
+  `provider_contract_admission_tests`, matching the canonical pre-push route.
 - Direct GraphQL SDL lowering in `echo-wesley-gen` now binds the exact pinned
   `wesley-core` version into generated Rust artifact-hash provenance, with a
   regression test that refuses dependency/provenance version drift.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ package bytes and consume the resulting opaque proof through Echo's sealed
 runtime-owner installation port. `TrustedRuntimeHost` then installs a distinct
 provider record and the package, root, mutation-operation, and scheduler-rule
 indexes atomically, without invoking the handler or fabricating legacy
-Wesley/GraphQL metadata.
+Wesley/GraphQL metadata. Before any index changes, the installation crossing
+applies the same structural checks used by retained-evidence recovery to the
+package reference, operation coordinate, and Target IR identity.
 
 After a generated client submits canonical EINT v1 bytes, the trusted host can
 admit a witnessed submission for an installed provider mutation. Echo requires

--- a/crates/warp-core/README.md
+++ b/crates/warp-core/README.md
@@ -94,8 +94,11 @@ receipt, or grant application authority.
 Later crossings are now implemented without weakening that boundary. A sealed
 runtime-owner port consumes independently corroborated package evidence and
 atomically installs a distinct provider record plus package, root, mutation,
-and scheduler-rule indexes. A trusted host can then admit a witnessed canonical
-EINT v1 submission with `admit_provider_contract_submission_v1(...)`. Admission
+and scheduler-rule indexes. Before any index changes, installation applies the
+same pure package-reference and operation/Target-IR structural validators used
+by retained-evidence recovery; malformed identities return stable typed
+installation failures. A trusted host can then admit a witnessed canonical EINT
+v1 submission with `admit_provider_contract_submission_v1(...)`. Admission
 requires the exact EINT outer intent kind and an installed provider operation;
 it stages work through the shared scheduler rather than invoking callbacks
 directly. `InstalledInvocationEvidence::ProviderV1` binds the installed package

--- a/crates/warp-core/src/provider_contract.rs
+++ b/crates/warp-core/src/provider_contract.rs
@@ -1101,15 +1101,81 @@ impl InstalledProviderContractPackageRecordV1 {
         let operation = self.registry.operations().iter().find(|operation| {
             operation.operation_id() == operation_id && operation.kind() == OpKind::Mutation
         })?;
-        Some(ProviderContractEvidenceIdentityV1 {
-            package_id: self.package_id,
-            package_reference: self.package_reference.clone(),
+        ProviderContractEvidenceIdentityV1::try_from_retained_parts(
+            self.package_id,
+            self.package_reference.clone(),
             operation_id,
-            operation_coordinate: operation.coordinate().to_owned(),
-            target_ir: operation.target_ir().clone(),
-            mutation_rule_id: *self.mutation_rule.rule_id(),
-        })
+            operation.coordinate().to_owned(),
+            operation.target_ir().clone(),
+            *self.mutation_rule.rule_id(),
+        )
+        .ok()
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProviderPackageReferenceValidationError {
+    EmptyCoordinate,
+    MalformedDigest,
+}
+
+impl ProviderPackageReferenceValidationError {
+    const fn recovery_subject(self) -> &'static str {
+        match self {
+            Self::EmptyCoordinate => "provider package reference coordinate",
+            Self::MalformedDigest => "provider package reference digest",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProviderOperationEvidenceValidationError {
+    EmptyOperationCoordinate,
+    EmptyTargetIrCoordinate,
+    EmptyTargetIrDigestDomain,
+    MalformedTargetIrDigest,
+}
+
+impl ProviderOperationEvidenceValidationError {
+    const fn recovery_subject(self) -> &'static str {
+        match self {
+            Self::EmptyOperationCoordinate => "provider operation coordinate",
+            Self::EmptyTargetIrCoordinate => "provider Target IR coordinate",
+            Self::EmptyTargetIrDigestDomain => "provider Target IR digest domain",
+            Self::MalformedTargetIrDigest => "provider Target IR digest",
+        }
+    }
+}
+
+fn validate_provider_package_reference_v1(
+    package_reference: &ProviderPackageReferenceV1,
+) -> Result<&str, ProviderPackageReferenceValidationError> {
+    if package_reference.coordinate().is_empty() {
+        return Err(ProviderPackageReferenceValidationError::EmptyCoordinate);
+    }
+    strict_prefixed_sha256(package_reference.digest())
+        .ok_or(ProviderPackageReferenceValidationError::MalformedDigest)
+}
+
+fn validate_provider_operation_evidence_v1(
+    operation_coordinate: &str,
+    target_ir_coordinate: &str,
+    target_ir_digest_domain: &str,
+    target_ir_digest: &str,
+) -> Result<(), ProviderOperationEvidenceValidationError> {
+    if operation_coordinate.is_empty() {
+        return Err(ProviderOperationEvidenceValidationError::EmptyOperationCoordinate);
+    }
+    if target_ir_coordinate.is_empty() {
+        return Err(ProviderOperationEvidenceValidationError::EmptyTargetIrCoordinate);
+    }
+    if target_ir_digest_domain.is_empty() {
+        return Err(ProviderOperationEvidenceValidationError::EmptyTargetIrDigestDomain);
+    }
+    if strict_prefixed_sha256(target_ir_digest).is_none() {
+        return Err(ProviderOperationEvidenceValidationError::MalformedTargetIrDigest);
+    }
+    Ok(())
 }
 
 /// Provider-native installed-operation evidence attached to invocation receipts.
@@ -1137,27 +1203,18 @@ impl ProviderContractEvidenceIdentityV1 {
         target_ir: InstalledProviderDigestIdentityV1,
         mutation_rule_id: crate::Hash,
     ) -> Result<Self, &'static str> {
-        if package_reference.coordinate().is_empty() {
-            return Err("provider package reference coordinate");
-        }
-        if strict_prefixed_sha256(package_reference.digest()).is_none() {
-            return Err("provider package reference digest");
-        }
+        validate_provider_package_reference_v1(&package_reference)
+            .map_err(ProviderPackageReferenceValidationError::recovery_subject)?;
         if is_reserved_operation_id(operation_id) {
             return Err("provider operation id");
         }
-        if operation_coordinate.is_empty() {
-            return Err("provider operation coordinate");
-        }
-        if target_ir.coordinate().is_empty() {
-            return Err("provider Target IR coordinate");
-        }
-        if target_ir.digest_domain().is_empty() {
-            return Err("provider Target IR digest domain");
-        }
-        if strict_prefixed_sha256(target_ir.digest()).is_none() {
-            return Err("provider Target IR digest");
-        }
+        validate_provider_operation_evidence_v1(
+            &operation_coordinate,
+            target_ir.coordinate(),
+            target_ir.digest_domain(),
+            target_ir.digest(),
+        )
+        .map_err(ProviderOperationEvidenceValidationError::recovery_subject)?;
         Ok(Self {
             package_id,
             package_reference,
@@ -1214,6 +1271,14 @@ pub enum ProviderContractInstallationErrorKind {
     MalformedPackageReferenceDigest,
     /// The referenced package root differs from the admitted occurrence hash.
     PackageArtifactDigestMismatch,
+    /// The admitted provider operation has an empty semantic coordinate.
+    EmptyOperationCoordinate,
+    /// The admitted provider operation has an empty Target IR coordinate.
+    EmptyTargetIrCoordinate,
+    /// The admitted provider operation has an empty Target IR digest domain.
+    EmptyTargetIrDigestDomain,
+    /// The admitted provider operation Target IR digest is not strict lowercase SHA-256.
+    MalformedTargetIrDigest,
     /// The admitted proposal does not contain exactly one supported operation.
     UnsupportedOperationCount,
     /// The admitted provider operation is not a mutation.
@@ -1329,9 +1394,10 @@ pub trait ProviderContractPackageInstallerV1: SealedProviderContractPackageInsta
     ///
     /// # Errors
     ///
-    /// Returns a structured installation failure when the package-root claim
-    /// is malformed or disagrees with admission, or when the package conflicts
-    /// with existing Echo-owned registry state.
+    /// Returns a structured installation failure when the package-root or
+    /// retained invocation-evidence structure is malformed, the package root
+    /// disagrees with admission, or the package conflicts with existing
+    /// Echo-owned registry state.
     fn install_admitted_provider_contract_package_v1_trusted(
         &mut self,
         package_reference: ProviderPackageReferenceV1,
@@ -1348,28 +1414,33 @@ pub(crate) struct PreparedInstalledProviderContractPackageV1 {
 
 /// Prepare one admitted provider proposal for atomic Engine installation.
 ///
-/// This pure crossing validates the explicit package-root claim, owns the full
-/// admitted provider proposition, and derives a deterministic installed id. It
-/// does not authenticate bytes, invoke provider callbacks, or mutate Engine
-/// state.
+/// This pure crossing validates the explicit package-root claim and every
+/// operation field later retained as provider invocation evidence, owns the
+/// full admitted provider proposition, and derives a deterministic installed
+/// id. It does not authenticate bytes, invoke provider callbacks, or mutate
+/// Engine state.
 #[cfg(all(feature = "native_rule_bootstrap", feature = "trusted_runtime"))]
 pub(crate) fn prepare_installed_provider_contract_package_v1(
     package_reference: ProviderPackageReferenceV1,
     admitted: AdmittedProviderContractPackageV1<'_>,
 ) -> Result<PreparedInstalledProviderContractPackageV1, ProviderContractInstallationError> {
-    if package_reference.coordinate.is_empty() {
-        return Err(ProviderContractInstallationError::without_reference(
-            ProviderContractInstallationErrorKind::EmptyPackageReferenceCoordinate,
-            "provider.package.reference.coordinate",
-        ));
-    }
-    let Some(reference_raw_sha256) = strict_prefixed_sha256(&package_reference.digest) else {
-        return Err(ProviderContractInstallationError::new(
-            ProviderContractInstallationErrorKind::MalformedPackageReferenceDigest,
-            "provider.package.reference.digest",
-            package_reference.digest,
-        ));
-    };
+    let reference_raw_sha256 = validate_provider_package_reference_v1(&package_reference).map_err(
+        |error| match error {
+            ProviderPackageReferenceValidationError::EmptyCoordinate => {
+                ProviderContractInstallationError::without_reference(
+                    ProviderContractInstallationErrorKind::EmptyPackageReferenceCoordinate,
+                    "provider.package.reference.coordinate",
+                )
+            }
+            ProviderPackageReferenceValidationError::MalformedDigest => {
+                ProviderContractInstallationError::new(
+                    ProviderContractInstallationErrorKind::MalformedPackageReferenceDigest,
+                    "provider.package.reference.digest",
+                    package_reference.digest(),
+                )
+            }
+        },
+    )?;
 
     let ProviderContractPackageProposalV1 {
         occurrence,
@@ -1398,6 +1469,39 @@ pub(crate) fn prepare_installed_provider_contract_package_v1(
             provider_op_kind_label(operation.kind),
         ));
     }
+    validate_provider_operation_evidence_v1(
+        operation.coordinate,
+        operation.target_ir.coordinate,
+        operation.target_ir.digest_domain,
+        operation.target_ir.digest,
+    )
+    .map_err(|error| match error {
+        ProviderOperationEvidenceValidationError::EmptyOperationCoordinate => {
+            ProviderContractInstallationError::without_reference(
+                ProviderContractInstallationErrorKind::EmptyOperationCoordinate,
+                "provider.operation.coordinate",
+            )
+        }
+        ProviderOperationEvidenceValidationError::EmptyTargetIrCoordinate => {
+            ProviderContractInstallationError::without_reference(
+                ProviderContractInstallationErrorKind::EmptyTargetIrCoordinate,
+                "provider.operation.target-ir.coordinate",
+            )
+        }
+        ProviderOperationEvidenceValidationError::EmptyTargetIrDigestDomain => {
+            ProviderContractInstallationError::without_reference(
+                ProviderContractInstallationErrorKind::EmptyTargetIrDigestDomain,
+                "provider.operation.target-ir.digest-domain",
+            )
+        }
+        ProviderOperationEvidenceValidationError::MalformedTargetIrDigest => {
+            ProviderContractInstallationError::new(
+                ProviderContractInstallationErrorKind::MalformedTargetIrDigest,
+                "provider.operation.target-ir.digest",
+                operation.target_ir.digest,
+            )
+        }
+    })?;
     if mutation_handler.op_id != operation.operation_id {
         return Err(ProviderContractInstallationError::new(
             ProviderContractInstallationErrorKind::MutationHandlerOperationMismatch,

--- a/crates/warp-core/tests/provider_contract_admission_tests.rs
+++ b/crates/warp-core/tests/provider_contract_admission_tests.rs
@@ -18,7 +18,8 @@ mod checked_generated_helper;
 
 use checked_generated_helper::echo_dpo as generated;
 use echo_registry_api::{
-    ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, RegistryInfo, RegistryProvider,
+    ContractArtifactVerificationPolicy, ObjectDef, OpDef, OpKind, ProviderOperationV1,
+    RegistryInfo, RegistryProvider,
 };
 use warp_core::{
     causal_wal::{WalRecordKind, WalRuntimeStateDeltaRecord},
@@ -345,6 +346,44 @@ fn admission_policy() -> ProviderContractAdmissionPolicyV1<'static> {
         expected_occurrence: occurrence(PACKAGE_ARTIFACT_SHA256),
         expected_registry: descriptor(RELEASE_DIGEST).provider_registry(),
     }
+}
+
+fn proposal_and_policy_for_operation(
+    operation: &ProviderOperationV1<'static>,
+) -> (
+    ProviderContractAdmissionPolicyV1<'static>,
+    ProviderContractPackageProposalV1<'static>,
+) {
+    let operation = *operation;
+    let operations: &'static [ProviderOperationV1<'static>] = Box::leak(Box::new([operation]));
+    let mut registry = descriptor(RELEASE_DIGEST).provider_registry();
+    registry.operations = operations;
+
+    let mut implementation_identity = descriptor(RELEASE_DIGEST).mutation_implementation_identity();
+    implementation_identity.operation = operation;
+    let rule_name = Box::leak(
+        format!(
+            "cmd/contract/{}/{}/{}",
+            registry.provider_schema.raw_sha256_hex, operation.operation_id, operation.coordinate
+        )
+        .into_boxed_str(),
+    );
+    let proposal = propose_provider_contract_package_v1(
+        occurrence(PACKAGE_ARTIFACT_SHA256),
+        registry,
+        GeneratedProviderMutationDispatchV1::new(
+            operation.operation_id,
+            rule_name,
+            counting_matcher,
+        ),
+        ProviderMutationHooksV1::for_host::<CountingHost>(implementation_identity),
+    )
+    .expect("a self-consistent malformed evidence fixture reaches Echo admission");
+    let policy = ProviderContractAdmissionPolicyV1 {
+        expected_occurrence: occurrence(PACKAGE_ARTIFACT_SHA256),
+        expected_registry: registry,
+    };
+    (policy, proposal)
 }
 
 fn empty_host() -> TrustedRuntimeHost {
@@ -790,6 +829,143 @@ fn trusted_installation_lower_boundary_rejects_unproven_package_root_disagreemen
         assert!(host
             .engine()
             .installed_provider_contract_mutation_package_id(generated::OPERATION_ID)
+            .is_none());
+        assert_no_callback();
+    }
+}
+
+#[test]
+fn installation_rejects_provider_evidence_that_recovery_would_reject() {
+    let _callback_guard = callback_test_guard();
+    let valid_operation = descriptor(RELEASE_DIGEST).provider_registry().operations[0];
+    let cases = [
+        (
+            "empty operation coordinate",
+            {
+                let mut operation = valid_operation;
+                operation.coordinate = "";
+                operation
+            },
+            ProviderContractInstallationErrorKind::EmptyOperationCoordinate,
+            "provider.operation.coordinate",
+        ),
+        (
+            "empty Target IR coordinate",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.coordinate = "";
+                operation
+            },
+            ProviderContractInstallationErrorKind::EmptyTargetIrCoordinate,
+            "provider.operation.target-ir.coordinate",
+        ),
+        (
+            "empty Target IR digest domain",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.digest_domain = "";
+                operation
+            },
+            ProviderContractInstallationErrorKind::EmptyTargetIrDigestDomain,
+            "provider.operation.target-ir.digest-domain",
+        ),
+        (
+            "empty Target IR digest",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.digest = "";
+                operation
+            },
+            ProviderContractInstallationErrorKind::MalformedTargetIrDigest,
+            "provider.operation.target-ir.digest",
+        ),
+        (
+            "Target IR digest without an algorithm prefix",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.digest =
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+                operation
+            },
+            ProviderContractInstallationErrorKind::MalformedTargetIrDigest,
+            "provider.operation.target-ir.digest",
+        ),
+        (
+            "uppercase Target IR digest hexadecimal",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.digest =
+                    "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+                operation
+            },
+            ProviderContractInstallationErrorKind::MalformedTargetIrDigest,
+            "provider.operation.target-ir.digest",
+        ),
+        (
+            "63-character Target IR SHA-256 payload",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.digest =
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+                operation
+            },
+            ProviderContractInstallationErrorKind::MalformedTargetIrDigest,
+            "provider.operation.target-ir.digest",
+        ),
+        (
+            "65-character Target IR SHA-256 payload",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.digest =
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+                operation
+            },
+            ProviderContractInstallationErrorKind::MalformedTargetIrDigest,
+            "provider.operation.target-ir.digest",
+        ),
+        (
+            "non-hexadecimal Target IR SHA-256 payload",
+            {
+                let mut operation = valid_operation;
+                operation.target_ir.digest =
+                    "sha256:gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg";
+                operation
+            },
+            ProviderContractInstallationErrorKind::MalformedTargetIrDigest,
+            "provider.operation.target-ir.digest",
+        ),
+    ];
+
+    for (case, operation, expected_kind, expected_subject) in cases {
+        reset_callback_counts();
+        let (policy, proposal) = proposal_and_policy_for_operation(&operation);
+        let mut host = empty_host();
+        let admitted = host
+            .admit_provider_contract_package_v1(&policy, proposal)
+            .expect("exact policy equality admits the malformed structural fixture");
+        let reference = package_reference();
+        let error = host
+            .install_admitted_provider_contract_package_v1_trusted(reference.clone(), admitted)
+            .expect_err(case);
+
+        assert_eq!(error.kind(), expected_kind, "{case}");
+        assert_eq!(error.subject(), expected_subject, "{case}");
+        let expected_reference = (expected_kind
+            == ProviderContractInstallationErrorKind::MalformedTargetIrDigest)
+            .then_some(operation.target_ir.digest);
+        assert_eq!(error.reference(), expected_reference, "{case}");
+
+        assert!(host
+            .engine()
+            .installed_provider_contract_package_by_reference(&reference)
+            .is_none());
+        assert!(host
+            .engine()
+            .installed_provider_contract_mutation_package_id(operation.operation_id)
+            .is_none());
+        assert!(host
+            .engine()
+            .installed_provider_contract_mutation_evidence_v1(operation.operation_id)
             .is_none());
         assert_no_callback();
     }

--- a/docs/architecture/application-contract-hosting.md
+++ b/docs/architecture/application-contract-hosting.md
@@ -365,8 +365,11 @@ runtime-owner installer port. The `TrustedRuntimeHost` lower primitive does not
 authenticate package bytes and is not exposed to application code. It creates a
 distinct owned provider record retaining the exact occurrence and reference,
 complete provider registry, and mutation-rule identity, then atomically installs
-provider package, root, operation, and shared scheduler-rule indexes. It invokes
-no callbacks and fabricates no legacy Wesley/GraphQL metadata or evidence.
+provider package, root, operation, and shared scheduler-rule indexes. Before
+those index changes, the lower primitive runs the same pure structural
+validation used to reconstruct retained provider invocation evidence over the
+package reference, operation coordinate, and Target IR identity. It invokes no
+callbacks and fabricates no legacy Wesley/GraphQL metadata or evidence.
 Those separation laws continue after installation. A trusted host may admit a
 previously witnessed provider submission only when its outer intent kind is the
 exact canonical EINT v1 domain and its encoded operation id names the installed

--- a/docs/topics/GeneratedRules.md
+++ b/docs/topics/GeneratedRules.md
@@ -59,8 +59,10 @@ only, not registry semantics or callback behavior. A proof-owning
 `echo-wesley-gen` adapter now consumes that token through `warp-core`'s sealed
 runtime-owner installer port. `TrustedRuntimeHost` creates a distinct owned
 provider record and atomically updates provider package, root, operation, and
-shared scheduler-rule indexes. It invokes no callback and invents no
-Wesley/GraphQL metadata or legacy installed-contract evidence.
+shared scheduler-rule indexes. Before those updates, Echo subjects the package
+reference, operation coordinate, and Target IR evidence fields to the same pure
+structural validation used by WAL recovery. It invokes no callback and invents
+no Wesley/GraphQL metadata or legacy installed-contract evidence.
 Generated code cannot install itself. The application handle exposes no
 installation surface.
 

--- a/docs/topics/WAL.md
+++ b/docs/topics/WAL.md
@@ -69,11 +69,12 @@ installed-invocation identity attached to the outcome. That identity is a
 tagged proposition: the existing legacy Wesley/GraphQL evidence keeps its
 byte-stable tag-1 encoding, while tag 2 retains provider package id and exact
 reference, operation id and coordinate, Target IR identity, and scheduler rule
-id. Provider installation applies the same pure structural checks to every
-field it can later originate as invocation evidence before changing any Engine
-index. Provider decoding independently rejects empty coordinates, reserved
-operation ids, and malformed package or Target IR digests rather than
-laundering structurally invalid fields through a valid WAL frame checksum.
+id. Provider installation applies the same pure package-reference and
+operation/Target-IR structural checks used by retained decoding before changing
+any Engine index. Provider proposal construction rejects Echo-reserved
+operation ids before installation; retained decoding independently rejects
+those ids, empty coordinates, and malformed package or Target IR digests rather
+than laundering structurally invalid fields through a valid WAL frame checksum.
 Provider evidence does not fabricate a legacy retained-contract coordinate.
 
 Filesystem WAL reopen loads that evidence into a fresh provenance service,

--- a/docs/topics/WAL.md
+++ b/docs/topics/WAL.md
@@ -69,10 +69,12 @@ installed-invocation identity attached to the outcome. That identity is a
 tagged proposition: the existing legacy Wesley/GraphQL evidence keeps its
 byte-stable tag-1 encoding, while tag 2 retains provider package id and exact
 reference, operation id and coordinate, Target IR identity, and scheduler rule
-id. Provider decoding rejects empty coordinates, reserved operation ids, and
-malformed package or Target IR digests rather than laundering structurally
-invalid fields through a valid WAL frame checksum. Provider evidence does not
-fabricate a legacy retained-contract coordinate.
+id. Provider installation applies the same pure structural checks to every
+field it can later originate as invocation evidence before changing any Engine
+index. Provider decoding independently rejects empty coordinates, reserved
+operation ids, and malformed package or Target IR digests rather than
+laundering structurally invalid fields through a valid WAL frame checksum.
+Provider evidence does not fabricate a legacy retained-contract coordinate.
 
 Filesystem WAL reopen loads that evidence into a fresh provenance service,
 replays the worldline from its deterministic registered boundary, restores

--- a/docs/topics/security/ThreatModel.md
+++ b/docs/topics/security/ThreatModel.md
@@ -296,11 +296,14 @@ and duplicate identities fail before engine mutation. The Edict provider path
 separately admits the complete proposal claim under host policy, corroborates
 the exact package root, installs a distinct provider record atomically, and
 binds runtime evidence to the exact package, operation, Target IR, and scheduler
-rule. Installation applies the retained-evidence decoder's structural law before
-any Engine index changes, preventing Echo from writing provider receipt or WAL
-evidence that recovery would refuse. A same-scope system acknowledgement cannot
-stand in for execution of that provider rule. Generated semantic-source
-validation covers a broader set of internal consistency constraints.
+rule. Installation applies the same pure package-reference and
+operation/Target-IR structural validators used by the retained-evidence decoder
+before any Engine index changes, preventing Echo from writing provider receipt
+or WAL evidence that recovery would refuse. Echo-reserved operation ids are
+rejected earlier during proposal construction and remain independently rejected
+by retained decoding. A same-scope system acknowledgement cannot stand in for
+execution of that provider rule. Generated semantic-source validation covers a
+broader set of internal consistency constraints.
 
 **Residual risk.** Digest verification is not publisher authentication or CI
 attestation. The production trust ramp from local development through verified

--- a/docs/topics/security/ThreatModel.md
+++ b/docs/topics/security/ThreatModel.md
@@ -296,9 +296,11 @@ and duplicate identities fail before engine mutation. The Edict provider path
 separately admits the complete proposal claim under host policy, corroborates
 the exact package root, installs a distinct provider record atomically, and
 binds runtime evidence to the exact package, operation, Target IR, and scheduler
-rule. A same-scope system acknowledgement cannot stand in for execution of that
-provider rule. Generated semantic-source validation covers a broader set of
-internal consistency constraints.
+rule. Installation applies the retained-evidence decoder's structural law before
+any Engine index changes, preventing Echo from writing provider receipt or WAL
+evidence that recovery would refuse. A same-scope system acknowledgement cannot
+stand in for execution of that provider rule. Generated semantic-source
+validation covers a broader set of internal consistency constraints.
 
 **Residual risk.** Digest verification is not publisher authentication or CI
 attestation. The production trust ramp from local development through verified

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -1416,6 +1416,9 @@ warp_core_feature_args_for_test() {
     inbox|installed_contract_intent_pipeline_tests)
       printf '%s\n' "--features" "native_rule_bootstrap,host_test"
       ;;
+    external_consumer_contract_fixture_tests|provider_contract_admission_tests)
+      printf '%s\n' "--features" "native_rule_bootstrap,trusted_runtime"
+      ;;
     causal_fact_publication_tests|optic_invocation_admission_tests)
       printf '%s\n' "--features" "host_test"
       ;;

--- a/tests/hooks/test_verify_local.sh
+++ b/tests/hooks/test_verify_local.sh
@@ -1717,6 +1717,22 @@ else
 fi
 
 VERIFY_LOCAL_FULL_TESTS=1
+fake_warp_core_provider_contract_output="$(run_fake_verify full crates/warp-core/tests/provider_contract_admission_tests.rs)"
+unset VERIFY_LOCAL_FULL_TESTS
+if printf '%s\n' "$fake_warp_core_provider_contract_output" | grep -q -- 'test -p warp-core --features native_rule_bootstrap,trusted_runtime --test provider_contract_admission_tests'; then
+  pass "full verification keeps required provider admission test features"
+else
+  fail "full verification should keep required provider admission test features"
+  printf '%s\n' "$fake_warp_core_provider_contract_output"
+fi
+if printf '%s\n' "$fake_warp_core_provider_contract_output" | grep -q -- 'clippy -p warp-core --features native_rule_bootstrap,trusted_runtime --test provider_contract_admission_tests'; then
+  pass "full verification keeps required provider admission clippy features"
+else
+  fail "full verification should keep required provider admission clippy features"
+  printf '%s\n' "$fake_warp_core_provider_contract_output"
+fi
+
+VERIFY_LOCAL_FULL_TESTS=1
 fake_warp_core_optic_artifact_output="$(run_fake_verify full crates/warp-core/src/optic_artifact.rs)"
 unset VERIFY_LOCAL_FULL_TESTS
 if printf '%s\n' "$fake_warp_core_optic_artifact_output" | grep -q -- '--test optic_artifact_registry_tests'; then


### PR DESCRIPTION
## Summary

- Apply shared pure structural validators at provider installation and retained-evidence reconstruction.
- Reject empty operation or Target IR coordinates, empty Target IR digest domains, and every non-canonical Target IR SHA-256 rendering before any Engine index changes.
- Construct live provider invocation evidence through the same fallible retained-parts boundary used by WAL recovery.
- Repair full local verification so the provider admission integration target retains its required feature set.

This addresses the unresolved provider installation/WAL recoverability finding from #678.

## Executable claim

Every provider evidence identity accepted for installation and capable of entering a receipt or WAL record is lawful under the same structural validation required during recovery.

The new witness admits self-consistent malformed registries under exact policy equality, then proves installation fails with stable typed errors before package, operation, or writable-evidence indexes exist and without invoking provider callbacks.

## Evidence

- cargo +1.90.0 test -p warp-core --features native_rule_bootstrap,trusted_runtime --test provider_contract_admission_tests
- cargo +1.90.0 xtask test-slice contract-path-release
- cargo +1.90.0 test -p warp-core --features native_rule_bootstrap,trusted_runtime --test provenance_retention_codec_tests legacy_contract_state_delta_encoding_remains_byte_stable -- --exact
- cargo +1.90.0 clippy -p warp-core --lib --features native_rule_bootstrap,trusted_runtime -- -D warnings -D missing_docs
- cargo +1.90.0 clippy -p warp-core --features native_rule_bootstrap,trusted_runtime --test provider_contract_admission_tests -- -D warnings
- scripts/verify-edict-provider-host-v1.sh
- bash tests/hooks/test_verify_local.sh
- VERIFY_FORCE=1 VERIFY_LOCAL_FULL_TESTS=1 VERIFY_LOCAL_RUSTDOC=1 cargo +1.90.0 xtask pr-preflight
- canonical pre-commit and pre-push hooks

## Compatibility and authority

- Legacy installed-contract tag-1 WAL bytes remain unchanged.
- Valid provider tag-2 install, invocation, persistence, recovery, idempotency, and no-callback recovery remain green.
- No WAL decoder weakening, Jedit semantics, Gate C work, provider reads, inverses, or authorization changes are included.
- Generated artifacts remain evidence only; Echo remains the installation and runtime authority.

## Documentation

Updated the existing architecture, Generated Rules, WAL, threat-model, crate/root entrances, API documentation, and changelog. The documentation-accuracy audit found no stale current-state claims in the relevant guide, docs map, invariants, specifications, or ADR 0015.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider package installation now rejects malformed coordinates and digests before updating engine indexes.
  * Invalid provider evidence produces stable, structured installation errors.
  * Existing valid tag-1 and tag-2 evidence behavior remains unchanged.

* **Documentation**
  * Clarified installation-time validation, recovery behavior, and security safeguards across user and architecture documentation.

* **Tests**
  * Added coverage for malformed provider evidence and confirmed no artifacts or callbacks are created after rejection.
  * Updated full verification to run provider admission tests with the required feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->