### PR TITLE
Expose duplicate state evidence from the generic runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ### Added
 
+- The generic Edict-operation runner's duplicate witness now exposes canonical
+  before/after application-state roots and typed target-value digests. The
+  graph-only roots commit reachable application state without conflating WAL,
+  Tick history, Receipts, or commit metadata; report emission fails closed if
+  either the root or target value changes during an obstructed duplicate.
 - `cargo xtask run-edict-operation` now consumes an exact external
   compiler-produced executable-operation package, its structurally separate
   accepted verification report, the manifest-to-adapter-to-target-configuration

--- a/README.md
+++ b/README.md
@@ -274,8 +274,11 @@ mutation. A standalone application-owned Edict create-if-absent operation now
 crosses this route as an exact compiler-produced package and independently
 accepted verification report through `cargo xtask run-edict-operation`. That
 witness proves its package-declared typed obstruction and one Action in one
-Tick; it does not claim external multi-Action Tick composition, a product-ready
-application runner, a Jedit operation, or a Graft operation.
+Tick. Its duplicate report exposes equal before/after application-state roots
+and typed target-value digests; the roots commit the reachable graph state, not
+WAL, history, Receipt, or commit metadata. It does not claim external
+multi-Action Tick composition, a product-ready application runner, a Jedit
+operation, or a Graft operation.
 
 ## Contracts And Boundaries
 

--- a/docs/topics/GeneratedRules.md
+++ b/docs/topics/GeneratedRules.md
@@ -200,6 +200,14 @@ package meaning, and verification report all influence the canonical
 invocation; no application matcher, executor, footprint callback, or
 handwritten package participates.
 
+The duplicate witness reports the graph-only application-state root and typed
+target-value digest immediately before and after the obstructed Action. The
+state root commits the entire reachable graph, including attachment values,
+while excluding WAL frames, Tick history, Receipts, and commit metadata. The
+target digest separately binds the declared attachment type and exact value
+bytes. Echo refuses to emit a passing report if either before/after pair
+differs.
+
 This is singleton scheduler integration, not a claim that the external
 application can compose multiple Actions into one Tick. The kernel's synthetic
 multi-Action tests remain separate generic runtime evidence. Product-facing

--- a/docs/topics/WAL.md
+++ b/docs/topics/WAL.md
@@ -327,8 +327,12 @@ the installed package and pending Action before scheduler selection,
 scheduler-owned evaluation of that recovered work, decided-Tick durability, a
 second complete fresh-host recovery, a typed duplicate-create obstruction
 without mutation, and recovery refusal when the registered initial state
-changes. It uses the strict filesystem adapter and no native application
-callback.
+changes. Duplicate no-mutation evidence consists of equal graph-only
+application-state roots and equal typed target-value digests captured before
+and after the obstructed Action. WAL frames, Tick history, Receipts, and commit
+metadata are excluded from the application-state root because the obstruction
+legitimately extends causal history. It uses the strict filesystem adapter and
+no native application callback.
 
 The Action/Tick witnesses to read first are:
 

--- a/xtask/src/run_edict_operation.rs
+++ b/xtask/src/run_edict_operation.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use warp_core::{
     echo_operation_action_envelope_v1, echo_operation_anchored_node_creation_application_basis_v1,
+    echo_operation_atom_value_digest_v1,
     echo_operation_create_if_absent_target_profile_identity_v1, echo_operation_package_id_v1,
     make_head_id, make_node_id, make_type_id, make_warp_id, AtomPayload, AttachmentValue,
     EchoOperationActionOutcomeV1, EchoOperationAdmissionPolicyV1,
@@ -133,6 +134,10 @@ pub struct RecoveryReport {
 #[serde(rename_all = "camelCase")]
 pub struct DuplicateReport {
     pub obstruction: String,
+    pub application_state_root_before: String,
+    pub application_state_root_after: String,
+    pub target_value_digest_before: String,
+    pub target_value_digest_after: String,
 }
 
 struct PackageMetadata {
@@ -474,6 +479,7 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
             duplicate_obstruction,
             state_before_duplicate,
             current_state(&recovered)?.state_root(),
+            package.required_attachment_type,
             &value_before_duplicate,
             &node_value(
                 &recovered,
@@ -556,6 +562,7 @@ fn duplicate_report(
     obstruction: String,
     application_state_root_before: [u8; 32],
     application_state_root_after: [u8; 32],
+    target_value_type: TypeId,
     target_value_before: &[u8],
     target_value_after: &[u8],
 ) -> Result<DuplicateReport> {
@@ -564,7 +571,19 @@ fn duplicate_report(
     {
         bail!("obstructed duplicate Action changed committed state");
     }
-    Ok(DuplicateReport { obstruction })
+    Ok(DuplicateReport {
+        obstruction,
+        application_state_root_before: hex::encode(application_state_root_before),
+        application_state_root_after: hex::encode(application_state_root_after),
+        target_value_digest_before: hex::encode(echo_operation_atom_value_digest_v1(
+            target_value_type,
+            target_value_before,
+        )),
+        target_value_digest_after: hex::encode(echo_operation_atom_value_digest_v1(
+            target_value_type,
+            target_value_after,
+        )),
+    })
 }
 
 fn artifact_identity(digest_hex: String) -> ArtifactIdentity {
@@ -1220,15 +1239,18 @@ fn domain_hash(domain: &[u8], bytes: &[u8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::duplicate_report;
+    use warp_core::make_type_id;
 
     #[test]
     fn duplicate_mutation_cannot_produce_a_passing_witness() {
         let root = [0x11; 32];
+        let target_value_type = make_type_id("test.target-value/v1");
 
         let root_mutation = duplicate_report(
             "test.obstruction".to_owned(),
             root,
             [0x22; 32],
+            target_value_type,
             b"value",
             b"value",
         );
@@ -1241,6 +1263,7 @@ mod tests {
             "test.obstruction".to_owned(),
             root,
             root,
+            target_value_type,
             b"value",
             b"changed",
         );

--- a/xtask/src/run_edict_operation.rs
+++ b/xtask/src/run_edict_operation.rs
@@ -378,8 +378,7 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
     let state_recovered;
     let outcome_recovered;
     let receipt_recovered;
-    let hidden_mutation;
-    let duplicate_obstruction;
+    let duplicate;
 
     {
         let mut recovered = build_host(&input.basis, &input.key, false)?;
@@ -460,7 +459,7 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
         if duplicate_steps.len() != 1 || duplicate_steps[0].admitted_count != 1 {
             bail!("duplicate proof produced an unexpected scheduler selection");
         }
-        duplicate_obstruction = match recovered
+        let duplicate_obstruction = match recovered
             .host
             .echo_operation_action_outcome_v1(&duplicate_submission_id)
         {
@@ -471,12 +470,17 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
             }
             outcome => bail!("duplicate Action produced unexpected outcome: {outcome:?}"),
         };
-        hidden_mutation = current_state(&recovered)?.state_root() != state_before_duplicate
-            || node_value(
+        duplicate = duplicate_report(
+            duplicate_obstruction,
+            state_before_duplicate,
+            current_state(&recovered)?.state_root(),
+            &value_before_duplicate,
+            &node_value(
                 &recovered,
                 package.required_node_type,
                 package.required_attachment_type,
-            )? != value_before_duplicate;
+            )?,
+        )?;
     }
     if !action_recovered
         || !tick_recovered
@@ -486,10 +490,6 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
     {
         bail!("fresh host did not recover the complete Action/Tick/state/outcome/Receipt witness");
     }
-    if hidden_mutation {
-        bail!("obstructed duplicate Action changed committed state");
-    }
-
     let mutated_initial_state_refusal = {
         let mut mutated = build_host(&input.basis, &input.key, true)?;
         match mutated
@@ -548,10 +548,23 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
             receipt_recovered,
             mutated_initial_state_refusal,
         },
-        duplicate: DuplicateReport {
-            obstruction: duplicate_obstruction,
-        },
+        duplicate,
     })
+}
+
+fn duplicate_report(
+    obstruction: String,
+    application_state_root_before: [u8; 32],
+    application_state_root_after: [u8; 32],
+    target_value_before: &[u8],
+    target_value_after: &[u8],
+) -> Result<DuplicateReport> {
+    if application_state_root_before != application_state_root_after
+        || target_value_before != target_value_after
+    {
+        bail!("obstructed duplicate Action changed committed state");
+    }
+    Ok(DuplicateReport { obstruction })
 }
 
 fn artifact_identity(digest_hex: String) -> ArtifactIdentity {
@@ -1202,4 +1215,38 @@ fn domain_hash(domain: &[u8], bytes: &[u8]) -> [u8; 32] {
     hasher.update(&(bytes.len() as u64).to_le_bytes());
     hasher.update(bytes);
     hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::duplicate_report;
+
+    #[test]
+    fn duplicate_mutation_cannot_produce_a_passing_witness() {
+        let root = [0x11; 32];
+
+        let root_mutation = duplicate_report(
+            "test.obstruction".to_owned(),
+            root,
+            [0x22; 32],
+            b"value",
+            b"value",
+        );
+        assert!(
+            root_mutation.is_err(),
+            "a changed application-state root must fail closed"
+        );
+
+        let value_mutation = duplicate_report(
+            "test.obstruction".to_owned(),
+            root,
+            root,
+            b"value",
+            b"changed",
+        );
+        assert!(
+            value_mutation.is_err(),
+            "a changed target value must fail closed"
+        );
+    }
 }

--- a/xtask/tests/run_edict_operation.rs
+++ b/xtask/tests/run_edict_operation.rs
@@ -216,6 +216,33 @@ fn compiler_emitted_operation_runs_durably_without_native_callbacks() {
         report["duplicate"]["obstruction"],
         "causal.cell@1.AlreadyExists"
     );
+    for field in [
+        "applicationStateRootBefore",
+        "applicationStateRootAfter",
+        "targetValueDigestBefore",
+        "targetValueDigestAfter",
+    ] {
+        let digest = report["duplicate"][field]
+            .as_str()
+            .unwrap_or_else(|| panic!("duplicate witness is missing {field}"));
+        assert_eq!(digest.len(), 64, "{field} must be one 32-byte digest");
+        assert!(
+            digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+            "{field} must be canonical lowercase hexadecimal"
+        );
+    }
+    assert_eq!(
+        report["duplicate"]["applicationStateRootBefore"],
+        report["duplicate"]["applicationStateRootAfter"],
+        "the duplicate obstruction must leave authoritative application state unchanged"
+    );
+    assert_eq!(
+        report["duplicate"]["targetValueDigestBefore"],
+        report["duplicate"]["targetValueDigestAfter"],
+        "the duplicate obstruction must leave the target value unchanged"
+    );
     assert_eq!(
         report["recovery"]["mutatedInitialStateRefusal"],
         "echo-operation-execution-mismatch/action-basis"


### PR DESCRIPTION
Expose graph-only application-state roots and typed target-value digests before and after an obstructed duplicate. Report construction fails closed on either mutation.

Validation: `cargo xtask pr-preflight --base origin/main`; `cargo clippy -p xtask --all-targets -- -D warnings`; 131 xtask unit tests and 7 runner integration tests pass.

Documentation impact: the public runner contract and canonical Generated Rules/WAL topics now distinguish application state from causal-history evidence.

Closes #699.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified duplicate-operation witness behavior, including application-state roots and typed target-value digests.
  * Documented exclusions for WAL, tick history, receipts, and commit metadata.
  * Updated explanatory wording in the README.

* **Bug Fixes**
  * Duplicate-operation reports now fail safely when application state or target values change unexpectedly.
  * Witness data is provided as canonical 32-byte hexadecimal values.

* **Tests**
  * Added validation ensuring duplicate witnesses remain consistent and correctly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->