### PR TITLE
Expose exact typed result recovery evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ### Added
 
+- The generic Edict-operation runner now exposes complete fresh-host and
+  WAL-recovered application-result records beside the applied result. Report
+  construction fails closed unless all three schema-neutral projection
+  identities, output types, canonical bytes, and result identities are exactly
+  equal.
 - Executable-operation packages can now bind an exact compiler-owned
   `edict.result-projection.artifact/v1`. Projected invocations retain the exact
   canonical application input, scheduler-owned private evaluation emits the

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ external compiler-produced ExecutableOperationPackageV1 bytes
 -> one composite Tick consequence with typed per-Action outcomes
 -> decided Tick WAL retention before state, frontier, and Receipt publication
 -> callback-free pending-Action, result, and decided-Tick recovery
+-> independently comparable applied, fresh-host, and WAL result evidence
 ```
 
 The first two paths are callback-shaped compatibility infrastructure. The

--- a/docs/topics/GeneratedRules.md
+++ b/docs/topics/GeneratedRules.md
@@ -8,9 +8,10 @@ Rust rule registration is not a supported product authoring surface. The first
 Edict provider-v1 compatibility closure now reaches provider-native scheduling,
 receipts, and WAL recovery. Its semantic implementation remains host-bound.
 Echo now also has the first generic, hook-free executable-operation runtime
-slice. No Edict compiler or Jedit consumer emits its package yet. Wesley
-packaging and the generated bounded-read corridor remain incomplete and must
-not borrow evidence from either mutation path.
+slice. The standalone Hello Echo application emits its package through Edict;
+no Jedit consumer emits one yet. Wesley packaging and the generated
+bounded-read corridor remain incomplete and must not borrow evidence from
+either mutation path.
 
 ## Current Implementation
 
@@ -210,8 +211,10 @@ type coordinate, exact canonical result bytes, and domain-separated result
 identity. The committed Receipt, recovered Action outcome, and recovered WAL
 outcome must agree on all four propositions. Corrupting or coherently rebinding
 the projection artifact fails independent Echo admission; substituting retained
-result bytes fails recovery validation. The runner never decodes
-application-specific fields in production.
+result bytes fails recovery validation. The machine report exposes the applied
+result plus independently comparable fresh-host and WAL-recovered result
+records, and fails closed unless all three generic records are exactly equal.
+The runner never decodes application-specific fields in production.
 
 The duplicate witness reports the graph-only application-state root and typed
 target-value digest immediately before and after the obstructed Action. The

--- a/xtask/src/run_edict_operation.rs
+++ b/xtask/src/run_edict_operation.rs
@@ -139,6 +139,8 @@ pub struct RecoveryReport {
     pub outcome_recovered: bool,
     pub receipt_recovered: bool,
     pub application_result_recovered: bool,
+    pub fresh_host_application_result: ApplicationResultReport,
+    pub wal_application_result: ApplicationResultReport,
     pub mutated_initial_state_refusal: &'static str,
 }
 
@@ -409,7 +411,7 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
     let state_recovered;
     let outcome_recovered;
     let receipt_recovered;
-    let application_result_recovered;
+    let recovered_application_results;
     let duplicate;
 
     {
@@ -472,8 +474,11 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
                 .receipt_correlations
                 .iter()
                 .any(|record| record.submission_id == first_submission_id);
-        application_result_recovered = recovered_result.as_ref() == Some(&application_result)
-            && wal_result.as_ref() == Some(&application_result);
+        recovered_application_results = comparable_recovered_application_results(
+            &application_result,
+            recovered_result,
+            wal_result,
+        )?;
 
         recovered
             .host
@@ -541,7 +546,6 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
         || !state_recovered
         || !outcome_recovered
         || !receipt_recovered
-        || !application_result_recovered
     {
         bail!("fresh host did not recover the complete Action/Tick/state/outcome/Receipt witness");
     }
@@ -602,7 +606,9 @@ pub fn run(config: RunEdictOperationConfig) -> Result<RunEdictOperationReport> {
             state_recovered,
             outcome_recovered,
             receipt_recovered,
-            application_result_recovered,
+            application_result_recovered: true,
+            fresh_host_application_result: recovered_application_results.fresh_host,
+            wal_application_result: recovered_application_results.wal,
             mutated_initial_state_refusal,
         },
         duplicate,
@@ -651,6 +657,25 @@ fn application_result_report(result: &EchoOperationApplicationResultV1) -> Appli
         canonical_bytes_hex: hex::encode(result.canonical_bytes()),
         result_identity: hex::encode(result.identity()),
     }
+}
+
+struct ComparableRecoveredApplicationResults {
+    fresh_host: ApplicationResultReport,
+    wal: ApplicationResultReport,
+}
+
+fn comparable_recovered_application_results(
+    expected: &ApplicationResultReport,
+    fresh_host: Option<ApplicationResultReport>,
+    wal: Option<ApplicationResultReport>,
+) -> Result<ComparableRecoveredApplicationResults> {
+    let (Some(fresh_host), Some(wal)) = (fresh_host, wal) else {
+        bail!("fresh host or WAL is missing the recovered application result");
+    };
+    if fresh_host != *expected || wal != *expected {
+        bail!("fresh host or WAL recovered substituted application result evidence");
+    }
+    Ok(ComparableRecoveredApplicationResults { fresh_host, wal })
 }
 
 fn read_bounded(path: &Path, maximum: u64, label: &str) -> Result<Vec<u8>> {
@@ -1365,8 +1390,44 @@ fn domain_hash(domain: &[u8], bytes: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-    use super::duplicate_report;
+    use super::{
+        comparable_recovered_application_results, duplicate_report, ApplicationResultReport,
+    };
     use warp_core::make_type_id;
+
+    #[test]
+    fn substituted_recovered_application_result_cannot_produce_a_passing_witness() {
+        let expected = ApplicationResultReport {
+            projection_identity: "11".repeat(32),
+            output_type: "test.output/v1".to_owned(),
+            canonical_bytes_hex: "a0".to_owned(),
+            result_identity: "22".repeat(32),
+        };
+
+        let mut changed_fresh_host = expected.clone();
+        changed_fresh_host.canonical_bytes_hex = "f6".to_owned();
+        assert!(
+            comparable_recovered_application_results(
+                &expected,
+                Some(changed_fresh_host),
+                Some(expected.clone()),
+            )
+            .is_err(),
+            "substituted fresh-host result bytes must fail closed"
+        );
+
+        let mut changed_wal = expected.clone();
+        changed_wal.output_type = "test.other-output/v1".to_owned();
+        assert!(
+            comparable_recovered_application_results(
+                &expected,
+                Some(expected.clone()),
+                Some(changed_wal),
+            )
+            .is_err(),
+            "a substituted WAL result schema must fail closed"
+        );
+    }
 
     #[test]
     fn duplicate_mutation_cannot_produce_a_passing_witness() {

--- a/xtask/tests/run_edict_operation.rs
+++ b/xtask/tests/run_edict_operation.rs
@@ -230,6 +230,14 @@ fn compiler_emitted_operation_runs_durably_without_native_callbacks() {
     assert_eq!(report["recovery"]["receiptRecovered"], true);
     assert_eq!(report["recovery"]["applicationResultRecovered"], true);
     assert_eq!(
+        report["recovery"]["freshHostApplicationResult"], report["applicationResult"],
+        "fresh-host recovery must expose the exact applied application result"
+    );
+    assert_eq!(
+        report["recovery"]["walApplicationResult"], report["applicationResult"],
+        "WAL recovery must expose the exact applied application result"
+    );
+    assert_eq!(
         report["duplicate"]["obstruction"],
         "causal.cell@1.AlreadyExists"
     );
@@ -596,6 +604,14 @@ fn fixed_seed_keys_preserve_the_generic_durable_witness_under_bounded_stress() {
             "examples.hello_echo@1.GreetingCreated"
         );
         assert_eq!(report["recovery"]["applicationResultRecovered"], true);
+        assert_eq!(
+            report["recovery"]["freshHostApplicationResult"], report["applicationResult"],
+            "fixed-seed fresh-host recovery must preserve the exact application result"
+        );
+        assert_eq!(
+            report["recovery"]["walApplicationResult"], report["applicationResult"],
+            "fixed-seed WAL recovery must preserve the exact application result"
+        );
         let result = decode_canonical_cbor_v1(
             &hex::decode(
                 report["applicationResult"]["canonicalBytesHex"]


### PR DESCRIPTION
Exposes complete schema-neutral application-result records from applied execution, fresh-host recovery, and recovered WAL state through one fail-closed equality gate. Adds negative substitution coverage and the external three-way comparison contract.

Validation: xtask 132/132; generic runner 9/9; affected Clippy, formatting, documentation, and pre-push checks green.

Closes #702.